### PR TITLE
Fixed vertical team numbers in landscape

### DIFF
--- a/android/src/main/res/layout/list_item_stats.xml
+++ b/android/src/main/res/layout/list_item_stats.xml
@@ -12,7 +12,6 @@
         android:layout_width="90dp"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
-        android:paddingRight="@dimen/activity_horizontal_margin"
         android:text="254"
         android:textSize="30sp" />
 


### PR DESCRIPTION
Found that the vertical team numbers issue was also in 'Stats' tab in individual events.
