### PR TITLE
v0.2.2 Bug Fixes

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/Constants.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/Constants.java
@@ -32,7 +32,7 @@ public class Constants {
 
     //the week of the year that each event starts competition on, starting with 1992
     public static final int[] FIRST_COMP_WEEK =
-            {6, 8, 8, 8, 12, 9, 9, 8, 10, 8, 9, 9, 9, 9, 9, 8, 8, 8, 9, 9, 8, 8, 8};
+            {6, 8, 8, 8, 12, 9, 9, 8, 10, 8, 9, 9, 9, 9, 8, 8, 8, 8, 9, 9, 8, 8, 8};
 
     //the competition week of CMP that year, starting with 1992
     public static final int[] CMP_WEEK =

--- a/android/src/main/java/com/thebluealliance/androidclient/background/match/PopulateMatchInfo.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/background/match/PopulateMatchInfo.java
@@ -163,14 +163,12 @@ public class PopulateMatchInfo extends AsyncTask<String, Void, APIResponse.CODE>
             }
             // Blue score
             TextView blue_score = ((TextView) mActivity.findViewById(R.id.blue_score));
-            if (blueAlliance.get("score").getAsInt() < 0) {
+            JsonElement blueScore = blueAlliance.get("score");
+            if (blueScore.getAsInt() < 0) {
                 blue_score.setText("?");
             } else {
-               blue_score.setText(blueAlliance.get("score").getAsString());
+               blue_score.setText(blueScore.getAsString());
             }
-
-            JsonElement blueScore = blueAlliance.get("score");
-            blue_score.setText(blueScore.getAsString());
 
             Resources resources = mActivity.getResources();
             if (blueScore.getAsInt() > redScore.getAsInt()) {


### PR DESCRIPTION
Late night "I thought we fixed this already...?" bug hunt & stress test.
## Bug fixes
- Edited constants to fix a 'Week 0' appearing in 2006.
- Removed an extra blue_score.setText in PopulateMatchInfo that accidentally
  caused null/unknown blue scores to revert back to '-1' instead of '?'
## Known issues

Events by Week has some performance issues, which I've outlined in a separate issue. 
