### PR TITLE
Fixed UnsupportedOperationException when viewing  past events

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/deserializers/EventDeserializer.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/deserializers/EventDeserializer.java
@@ -67,7 +67,7 @@ public class EventDeserializer implements JsonDeserializer<Event> {
         if(object.has("alliances")){
             event.setAlliances(object.get("alliances").getAsJsonArray());
         }
-        if(object.has("event_district")){
+        if(object.has("event_district") && !object.get("event_district").isJsonNull()){
             event.setDistrictEnum(object.get("event_district").getAsInt());
         }else{
             event.setDistrictEnum(0);


### PR DESCRIPTION
Added another null check to fix the other exception that came up in #122.
