### PR TITLE
Don't show progress spinners on refreshes after the first load

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ContributorsActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ContributorsActivity.java
@@ -50,14 +50,7 @@ public class ContributorsActivity extends RefreshableHostActivity implements Ref
     @Override
     protected void onResume() {
         super.onResume();
-
-        if (ConnectionDetector.isConnectedToInternet(this)) {
-            new PopulateContributors(this).execute();
-        } else {
-            findViewById(android.R.id.list).setVisibility(View.GONE);
-            findViewById(R.id.no_data).setVisibility(View.VISIBLE);
-            findViewById(R.id.progress).setVisibility(View.GONE);
-        }
+        startRefresh(this);
     }
 
     private void setupActionBar() {
@@ -87,7 +80,13 @@ public class ContributorsActivity extends RefreshableHostActivity implements Ref
 
     @Override
     public void onRefreshStart() {
-        new PopulateContributors(this).execute();
+        if (ConnectionDetector.isConnectedToInternet(this)) {
+            new PopulateContributors(this).execute();
+        } else {
+            findViewById(android.R.id.list).setVisibility(View.GONE);
+            findViewById(R.id.no_data).setVisibility(View.VISIBLE);
+            findViewById(R.id.progress).setVisibility(View.GONE);
+        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/TeamAtEventActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/TeamAtEventActivity.java
@@ -78,9 +78,6 @@ public class TeamAtEventActivity extends RefreshableHostActivity implements Refr
     public void onRefreshStart() {
         task = new PopulateTeamAtEvent(this, true);
         task.execute(teamKey, eventKey);
-        // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-        findViewById(R.id.team_at_event_progress).setVisibility(View.VISIBLE);
-        findViewById(R.id.content_view).setVisibility(View.GONE);
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/EventListFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/EventListFragment.java
@@ -133,12 +133,6 @@ public class EventListFragment extends Fragment implements RefreshListener {
     public void onRefreshStart() {
         mTask = new PopulateEventList(this, mYear, mHeader, mTeamKey, true);
         mTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-        View view = getView();
-        if (view != null) {
-            // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.list).setVisibility(View.GONE);
-        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/TeamListFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/TeamListFragment.java
@@ -130,12 +130,6 @@ public class TeamListFragment extends Fragment implements RefreshListener, Loade
     public void onRefreshStart() {
         mTask = new PopulateTeamList(this);
         mTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mTeamNumberStart, mTeamNumberEnd);
-        View view = getView();
-        if (view != null) {
-            // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.list).setVisibility(View.GONE);
-        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventAwardsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventAwardsFragment.java
@@ -103,12 +103,6 @@ public class EventAwardsFragment extends Fragment implements RefreshListener {
     public void onRefreshStart() {
         mTask = new PopulateEventAwards(this, true);
         mTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mEventKey);
-        View view = getView();
-        if (view != null) {
-            // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.list).setVisibility(View.GONE);
-        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventInfoFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventInfoFragment.java
@@ -78,12 +78,6 @@ public class EventInfoFragment extends Fragment implements RefreshListener, View
     public void onRefreshStart() {
         task = new PopulateEventInfo(this, true);
         task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, eventKey);
-        View view = getView();
-        if (view != null) {
-            // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.event_info_container).setVisibility(View.GONE);
-        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventRankingsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventRankingsFragment.java
@@ -120,12 +120,6 @@ public class EventRankingsFragment extends Fragment implements RefreshListener {
     public void onRefreshStart() {
         mTask = new PopulateEventRankings(this, true);
         mTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, eventKey);
-        View view = getView();
-        if (view != null) {
-            // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.list).setVisibility(View.GONE);
-        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventResultsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventResultsFragment.java
@@ -116,12 +116,6 @@ public class EventResultsFragment extends Fragment implements RefreshListener {
     public void onRefreshStart() {
         mTask = new PopulateEventResults(this, true);
         mTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, eventKey, teamKey);
-        View view = getView();
-        if (view != null) {
-            // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.match_results).setVisibility(View.GONE);
-        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventStatsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventStatsFragment.java
@@ -131,12 +131,6 @@ public class EventStatsFragment extends Fragment implements RefreshListener {
     public void onRefreshStart() {
         mTask = new PopulateEventStats(this, true);
         mTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mEventKey);
-        View view = getView();
-        if (view != null) {
-            // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.list).setVisibility(View.GONE);
-        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventTeamsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventTeamsFragment.java
@@ -103,8 +103,6 @@ public class EventTeamsFragment extends Fragment implements RefreshListener {
         View view = getView();
         if (view != null) {
             // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.list).setVisibility(View.GONE);
         }
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/team/TeamEventsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/team/TeamEventsFragment.java
@@ -119,12 +119,6 @@ public class TeamEventsFragment extends Fragment implements RefreshListener, OnY
     public void onRefreshStart() {
         mTask = new PopulateEventList(this, mYear, "", mTeamKey, true);
         mTask.execute();
-        View view = getView();
-        if (view != null) {
-            // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.list).setVisibility(View.GONE);
-        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/team/TeamInfoFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/team/TeamInfoFragment.java
@@ -95,12 +95,6 @@ public class TeamInfoFragment extends Fragment implements View.OnClickListener, 
     public void onRefreshStart() {
         task = new PopulateTeamInfo(this, true);
         task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mTeamKey);
-        View view = getView();
-        if (view != null) {
-            // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.team_info_container).setVisibility(View.GONE);
-        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/team/TeamMediaFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/team/TeamMediaFragment.java
@@ -77,12 +77,6 @@ public class TeamMediaFragment extends Fragment implements RefreshListener, OnYe
 
         task = new PopulateTeamMedia(this, true);
         task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, teamKey, year);
-        View view = getView();
-        if (view != null) {
-            // Indicate loading; the task will hide the progressbar and show the content when loading is complete
-            view.findViewById(R.id.progress).setVisibility(View.VISIBLE);
-            view.findViewById(R.id.team_media_list).setVisibility(View.GONE);
-        }
     }
 
     @Override


### PR DESCRIPTION
Combined with properly restoring state from #158, this should result in a much nicer refreshing experience.
