### PR TITLE
Extra check for evaluatePerformanceForTeam

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/helpers/MatchHelper.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/helpers/MatchHelper.java
@@ -350,7 +350,10 @@ public class MatchHelper {
                 // Won quarterfinals
             } else if ((countPlayed > 1 && countWon == 0) || (countPlayed > 2 && countWon == 1)) {
                 return EventPerformance.ELIMINATED_IN_QUARTERS;
-            } else {
+            } else if (!e.isHappeningNow() && semiMatches.isEmpty()){
+                return EventPerformance.ELIMINATED_IN_QUARTERS;
+            }
+            else {
                 return EventPerformance.PLAYING_IN_QUARTERS;
             }
         }
@@ -374,6 +377,8 @@ public class MatchHelper {
             if (countPlayed > 1 && countWon > 1) {
                 // Won semifinals
             } else if ((countPlayed > 1 && countWon == 0) || (countPlayed > 2 && countWon == 1)) {
+                return EventPerformance.ELIMINATED_IN_SEMIS;
+            } else if (!e.isHappeningNow() && finalMatches.isEmpty()){
                 return EventPerformance.ELIMINATED_IN_SEMIS;
             } else {
                 return EventPerformance.PLAYING_IN_SEMIS;
@@ -401,7 +406,10 @@ public class MatchHelper {
                 return EventPerformance.WON_EVENT;
             } else if ((countPlayed > 1 && countWon == 0) || (countPlayed > 2 && countWon == 1)) {
                 return EventPerformance.ELIMINATED_IN_FINALS;
-            } else {
+            } else if (!e.isHappeningNow()){
+                return EventPerformance.ELIMINATED_IN_FINALS;
+            }
+            else {
                 return EventPerformance.PLAYING_IN_FINALS;
             }
         } else {


### PR DESCRIPTION
Fixes #125 by adding an extra check: If the event is already over and the team has only 1 match in an elim group and doesn't have any matches in the next group category, then we assume they were eliminated in that elim group. 

EDIT: Travis is failing because gradle plugins need to be updated and blah blah blah.
