### PR TITLE
Fix #157 "Can't switch to any event year after..."

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/HomeActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/HomeActivity.java
@@ -201,6 +201,7 @@ public class HomeActivity extends RefreshableHostActivity implements ActionBar.O
         Log.d(Constants.LOG_TAG, "year selected: " + Integer.parseInt(dropdownItems[position]));
         getSupportFragmentManager().beginTransaction().setCustomAnimations(R.anim.fade_in_support, R.anim.fade_out_support).replace(R.id.container, EventsByWeekFragment.newInstance(Integer.parseInt(dropdownItems[position])), MAIN_FRAGMENT_TAG).commit();
         mCurrentSelectedYearPosition = position;
+        getActionBar().setSelectedNavigationItem(mCurrentSelectedYearPosition);
         return true;
     }
 


### PR DESCRIPTION
Fix #157 by updating the action bar's selected nav item when the user
selects an item.

But I'm puzzled as to why ViewTeamActivity#onNavigationItemSelected()
doesn't have the same bug. Does one of its listeners recreate the menu?
