### PR TITLE
Elimination group transition bug fix

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/helpers/MatchHelper.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/helpers/MatchHelper.java
@@ -431,6 +431,11 @@ public class MatchHelper {
                 return EventStatus.PLAYING_IN_QUARTERS;
             }
         }
+        else {
+            // We've already checked for not picked/no alliance data/etc above, so if the current group is empty,
+            // then the team is likely playing the first match of quarters/semis/finals.
+            return EventStatus.PLAYING_IN_QUARTERS;
+        }
 
         if (!semiMatches.isEmpty()) {
             int countPlayed = 0, countWon = 0;
@@ -457,6 +462,8 @@ public class MatchHelper {
             } else {
                 return EventStatus.PLAYING_IN_SEMIS;
             }
+        } else {
+            return EventStatus.PLAYING_IN_SEMIS;
         }
 
         if (!finalMatches.isEmpty()) {


### PR DESCRIPTION
Fix bug where a team in transition to quarters/semis/finals from a previous group (e.g. they just advanced to semis by winning their second/third match, but don't know their opponents for semis yet) would have their summary display "Playing in finals". 

Since we do the alliance checking at the beginning, if a match group is empty and the previous group has been checked without hitting the eliminated status, then I think it's safe to say they are/will be playing in the next group.
