### PR TITLE
Fixed navigation issues

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/HomeActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/HomeActivity.java
@@ -74,7 +74,7 @@ public class HomeActivity extends RefreshableHostActivity implements ActionBar.O
         }
 
         districtsDropdownItems = new String[Constants.MAX_COMP_YEAR - Constants.FIRST_DISTRICT_YEAR + 1];
-        for (int i=0; i < districtsDropdownItems.length; i++){
+        for (int i = 0; i < districtsDropdownItems.length; i++) {
             districtsDropdownItems[i] = Integer.toString(Constants.MAX_COMP_YEAR - i);
         }
 
@@ -164,7 +164,7 @@ public class HomeActivity extends RefreshableHostActivity implements ActionBar.O
 
     private void resetActionBar() {
         ActionBar bar = getActionBar();
-        if(bar != null) {
+        if (bar != null) {
             bar.setNavigationMode(ActionBar.NAVIGATION_MODE_STANDARD);
             bar.setDisplayShowCustomEnabled(false);
             bar.setDisplayShowTitleEnabled(true);
@@ -198,7 +198,7 @@ public class HomeActivity extends RefreshableHostActivity implements ActionBar.O
 
     private void setupActionBarForEvents() {
         ActionBar bar = getActionBar();
-        if(bar != null) {
+        if (bar != null) {
             bar.setDisplayShowTitleEnabled(false);
 
             ArrayAdapter<String> actionBarAdapter = new ArrayAdapter<>(bar.getThemedContext(), R.layout.actionbar_spinner_events, R.id.year, eventsDropdownItems);
@@ -209,18 +209,18 @@ public class HomeActivity extends RefreshableHostActivity implements ActionBar.O
         }
     }
 
-    private void setupActionBarForDistricts(){
+    private void setupActionBarForDistricts() {
         ActionBar bar = getActionBar();
-        if(bar != null) {
+        if (bar != null) {
             bar.setDisplayShowTitleEnabled(false);
 
             ArrayAdapter<String> actionBarAdapter = new ArrayAdapter<>(bar.getThemedContext(), R.layout.actionbar_spinner_districts, R.id.year, districtsDropdownItems);
             actionBarAdapter.setDropDownViewResource(R.layout.actionbar_spinner_dropdown);
             bar.setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);
             bar.setListNavigationCallbacks(actionBarAdapter, this);
-            if(mCurrentSelectedYearPosition >= 0 && mCurrentSelectedYearPosition < districtsDropdownItems.length) {
+            if (mCurrentSelectedYearPosition >= 0 && mCurrentSelectedYearPosition < districtsDropdownItems.length) {
                 bar.setSelectedNavigationItem(mCurrentSelectedYearPosition);
-            }else{
+            } else {
                 bar.setSelectedNavigationItem(0);
             }
         }
@@ -240,9 +240,9 @@ public class HomeActivity extends RefreshableHostActivity implements ActionBar.O
         int selectedYear = Constants.MAX_COMP_YEAR - position;
         Log.d(Constants.LOG_TAG, "year selected: " + selectedYear);
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction().setCustomAnimations(R.anim.fade_in_support, R.anim.fade_out_support);
-        if(mCurrentSelectedNavigationItemId == R.id.nav_item_events) {
+        if (mCurrentSelectedNavigationItemId == R.id.nav_item_events) {
             transaction = transaction.replace(R.id.container, EventsByWeekFragment.newInstance(selectedYear), MAIN_FRAGMENT_TAG);
-        }else if(mCurrentSelectedNavigationItemId == R.id.nav_item_districts){
+        } else if (mCurrentSelectedNavigationItemId == R.id.nav_item_districts) {
             transaction = transaction.replace(R.id.container, DistrictListFragment.newInstance(selectedYear), MAIN_FRAGMENT_TAG);
         }
         transaction.commit();
@@ -269,5 +269,21 @@ public class HomeActivity extends RefreshableHostActivity implements ActionBar.O
     @Override
     public void hideWarningMessage() {
         warningMessage.setVisibility(View.GONE);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        Log.d(Constants.LOG_TAG, "New intent received!");
+        int requestedMode = intent.getExtras().getInt(REQUESTED_MODE, R.id.nav_item_events);
+        if (requestedMode == mCurrentSelectedNavigationItemId) {
+            // We are already in the appropriate mode
+            return;
+        } else {
+            switchToModeForId(requestedMode);
+            // Ensure that the Action Bar is properly configured for the current mode
+            invalidateOptionsMenu();
+        }
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewDistrictActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewDistrictActivity.java
@@ -4,17 +4,13 @@ import android.app.ActionBar;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v4.app.NavUtils;
-import android.support.v4.app.TaskStackBuilder;
 import android.support.v4.view.ViewPager;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
 import com.astuetz.PagerSlidingTabStrip;
-import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.NfcUris;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
@@ -43,7 +39,7 @@ public class ViewDistrictActivity extends RefreshableHostActivity implements Vie
         return intent;
     }
 
-    public static Intent newInstance(Context c, String districtKey){
+    public static Intent newInstance(Context c, String districtKey) {
         int year = Integer.parseInt(districtKey.substring(0, 4));
         String abbrev = districtKey.substring(4);
         Intent intent = new Intent(c, ViewDistrictActivity.class);
@@ -102,7 +98,7 @@ public class ViewDistrictActivity extends RefreshableHostActivity implements Vie
 
     private void setupActionBar() {
         ActionBar bar = getActionBar();
-        if(bar != null) {
+        if (bar != null) {
             bar.setDisplayHomeAsUpEnabled(true);
             setActionBarTitle(String.format(getString(R.string.district_title_format), year, DistrictHelper.districtTypeFromKey(districtKey).getName()));
         }
@@ -131,13 +127,10 @@ public class ViewDistrictActivity extends RefreshableHostActivity implements Vie
                     closeDrawer();
                     return true;
                 }
-                Intent upIntent = NavUtils.getParentActivityIntent(this);
-                if (NavUtils.shouldUpRecreateTask(this, upIntent)) {
-                    TaskStackBuilder.create(this).addNextIntent(HomeActivity.newInstance(this, R.id.nav_item_events)).startActivities();
-                } else {
-                    Log.d(Constants.LOG_TAG, "Navigating up...");
-                    NavUtils.navigateUpTo(this, upIntent);
-                }
+
+                // If this tasks exists in the back stack, it will be brought to the front and all other activities
+                // will be destroyed. HomeActivity will be delivered this intent via onNewIntent().
+                startActivity(HomeActivity.newInstance(this, R.id.nav_item_districts).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
                 return true;
         }
         return super.onOptionsItemSelected(item);
@@ -161,7 +154,7 @@ public class ViewDistrictActivity extends RefreshableHostActivity implements Vie
 
     @Override
     public void onPageSelected(int position) {
-        if(mOptionsMenu != null) {
+        if (mOptionsMenu != null) {
             MenuItem pointsHelp = mOptionsMenu.findItem(R.id.points_help);
             if (position == 1) {
                 pointsHelp.setVisible(true);

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewEventActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewEventActivity.java
@@ -3,24 +3,18 @@ package com.thebluealliance.androidclient.activities;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v4.app.NavUtils;
-import android.support.v4.app.TaskStackBuilder;
 import android.support.v4.view.ViewPager;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
 import com.astuetz.PagerSlidingTabStrip;
-import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.NfcUris;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.adapters.ViewEventFragmentPagerAdapter;
 import com.thebluealliance.androidclient.datafeed.ConnectionDetector;
-
-import java.util.Arrays;
 
 /**
  * File created by phil on 4/20/14.
@@ -80,7 +74,7 @@ public class ViewEventActivity extends RefreshableHostActivity implements ViewPa
         isDistrict = true;
     }
 
-    public void updateDistrict(boolean isDistrict){
+    public void updateDistrict(boolean isDistrict) {
         this.isDistrict = isDistrict;
     }
 
@@ -116,13 +110,9 @@ public class ViewEventActivity extends RefreshableHostActivity implements ViewPa
                     closeDrawer();
                     return true;
                 }
-                Intent upIntent = NavUtils.getParentActivityIntent(this);
-                if (NavUtils.shouldUpRecreateTask(this, upIntent)) {
-                    TaskStackBuilder.create(this).addNextIntent(HomeActivity.newInstance(this, R.id.nav_item_events)).startActivities();
-                } else {
-                    Log.d(Constants.LOG_TAG, "Navigating up...");
-                    NavUtils.navigateUpTo(this, upIntent);
-                }
+                // If this tasks exists in the back stack, it will be brought to the front and all other activities
+                // will be destroyed. HomeActivity will be delivered this intent via onNewIntent().
+                startActivity(HomeActivity.newInstance(this, R.id.nav_item_events).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
                 return true;
             case R.id.stats_help:
                 Utilities.showHelpDialog(this, R.raw.stats_help, getString(R.string.stats_help_title));
@@ -166,10 +156,10 @@ public class ViewEventActivity extends RefreshableHostActivity implements ViewPa
 
     @Override
     public void onPageSelected(int position) {
-        if(mOptionsMenu != null) {
-            if(position == 5 && !isDistrict){
+        if (mOptionsMenu != null) {
+            if (position == 5 && !isDistrict) {
                 showInfoMessage(getString(R.string.warning_not_real_district));
-            }else{
+            } else {
                 hideInfoMessage();
             }
         }

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
@@ -4,7 +4,6 @@ import android.app.ActionBar;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v4.app.TaskStackBuilder;
 import android.support.v4.view.ViewPager;
 import android.util.Log;
 import android.view.Menu;
@@ -143,7 +142,7 @@ public class ViewTeamActivity extends RefreshableHostActivity implements ActionB
 
     private void setupActionBar() {
         ActionBar bar = getActionBar();
-        if(bar != null) {
+        if (bar != null) {
             bar.setDisplayHomeAsUpEnabled(true);
             if (yearsParticipated != null) {
                 ArrayAdapter<String> actionBarAdapter = new ArrayAdapter<>(bar.getThemedContext(), R.layout.actionbar_spinner_team, R.id.year, yearsParticipated);
@@ -183,8 +182,9 @@ public class ViewTeamActivity extends RefreshableHostActivity implements ActionB
                 return true;
             }
 
-            // We recreate the back stack every time so we can assure that "up" goes to the teams view
-            TaskStackBuilder.create(this).addNextIntent(HomeActivity.newInstance(this, R.id.nav_item_teams)).startActivities();
+            // If this tasks exists in the back stack, it will be brought to the front and all other activities
+            // will be destroyed. HomeActivity will be delivered this intent via onNewIntent().
+            startActivity(HomeActivity.newInstance(this, R.id.nav_item_teams).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
             return true;
         }
         return super.onOptionsItemSelected(item);


### PR DESCRIPTION
This fixes some issues with up navigation. In the old code, HomeActivity was always recreated when it was navigated up to, resulting in the loss of any state it had (tab position, scroll position, etc.). Intents are now delivered to the instance of HomeActivity that exists in the back stack so that it only resets its state and changes the mode if it needs to.
