### PR TITLE
Notification activity updates

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -182,6 +182,7 @@
             android:name="com.thebluealliance.androidclient.activities.NotificationDashboardActivity"
             android:label="@string/title_activity_notification_dashboard"
             android:theme="@style/AppThemeNoActionBarTranslucentStatus"
+            android:launchMode="singleTop"
             android:parentActivityName="com.thebluealliance.androidclient.activities.HomeActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/BaseActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/BaseActivity.java
@@ -15,7 +15,6 @@ import android.view.MenuItem;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.accounts.AccountHelper;
 import com.thebluealliance.androidclient.accounts.PlusHelper;
@@ -24,6 +23,7 @@ import com.thebluealliance.androidclient.background.UpdateMyTBA;
 import com.thebluealliance.androidclient.datafeed.RequestParams;
 import com.thebluealliance.androidclient.gcm.GCMHelper;
 import com.thebluealliance.androidclient.helpers.ModelHelper;
+import com.thebluealliance.androidclient.listeners.NotificationDismissedListener;
 
 /**
  * Provides the features that should be in every activity in the app: a navigation drawer,
@@ -37,8 +37,6 @@ public abstract class BaseActivity extends NavigationDrawerActivity
     String modelKey = "";
     ModelHelper.MODELS modelType;
 
-    GoogleAccountCredential credential;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -48,6 +46,13 @@ public abstract class BaseActivity extends NavigationDrawerActivity
         if (mNfcAdapter != null) {
             // Register callback
             mNfcAdapter.setNdefPushMessageCallback(this, this);
+        }
+
+        // If this Activity was launched by tapping a system notification, dismiss the "active"
+        // stored notifications as having been "read."
+        Intent intent = getIntent();
+        if (intent != null && intent.hasCategory(Intent.CATEGORY_ALTERNATIVE)) {
+            sendBroadcast(NotificationDismissedListener.newIntent(this));
         }
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/BaseActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/BaseActivity.java
@@ -37,6 +37,16 @@ public abstract class BaseActivity extends NavigationDrawerActivity
     String modelKey = "";
     ModelHelper.MODELS modelType;
 
+    /**
+     * If this Activity was triggered by tapping a system notification, dismiss the "active" stored
+     * notifications as having been "read."
+     */
+    private void handleIntent(Intent intent) {
+        if (intent != null && intent.hasCategory(Intent.CATEGORY_ALTERNATIVE)) {
+            sendBroadcast(NotificationDismissedListener.newIntent(this));
+        }
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -48,12 +58,13 @@ public abstract class BaseActivity extends NavigationDrawerActivity
             mNfcAdapter.setNdefPushMessageCallback(this, this);
         }
 
-        // If this Activity was launched by tapping a system notification, dismiss the "active"
-        // stored notifications as having been "read."
-        Intent intent = getIntent();
-        if (intent != null && intent.hasCategory(Intent.CATEGORY_ALTERNATIVE)) {
-            sendBroadcast(NotificationDismissedListener.newIntent(this));
-        }
+        handleIntent(getIntent());
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        handleIntent(intent);
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/background/PopulateNotificationDashboard.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/background/PopulateNotificationDashboard.java
@@ -48,7 +48,6 @@ public class PopulateNotificationDashboard extends AsyncTask<Void, Void, Void> {
     protected Void doInBackground(Void... params) {
         Log.d(Constants.LOG_TAG, "Starting to fetch notifications");
         Database.Notifications table = Database.getInstance(activity).getNotificationsTable();
-        table.dismissAll();
         ArrayList<StoredNotification> notifications = table.get();
         items = new ArrayList<>();
         for(StoredNotification notification: notifications){

--- a/android/src/main/java/com/thebluealliance/androidclient/eventbus/NotificationsUpdatedEvent.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/eventbus/NotificationsUpdatedEvent.java
@@ -1,0 +1,7 @@
+package com.thebluealliance.androidclient.eventbus;
+
+/**
+ * Created by Jerry on 4/8/2015.
+ */
+public class NotificationsUpdatedEvent {
+}

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/NotificationDashboardFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/NotificationDashboardFragment.java
@@ -85,12 +85,12 @@ public class NotificationDashboardFragment extends Fragment implements RefreshLi
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        startRefresh();
     }
 
     @Override
     public void onResume() {
         super.onResume();
+        startRefresh();
         EventBus.getDefault().register(this);
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/NotificationDashboardFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/NotificationDashboardFragment.java
@@ -18,10 +18,13 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.activities.RefreshableHostActivity;
 import com.thebluealliance.androidclient.adapters.ListViewAdapter;
 import com.thebluealliance.androidclient.background.PopulateNotificationDashboard;
+import com.thebluealliance.androidclient.eventbus.NotificationsUpdatedEvent;
 import com.thebluealliance.androidclient.helpers.MyTBAHelper;
 import com.thebluealliance.androidclient.interfaces.RefreshListener;
 import com.thebluealliance.androidclient.listitems.LabelValueListItem;
 import com.thebluealliance.androidclient.listitems.ListItem;
+
+import de.greenrobot.event.EventBus;
 
 /**
  * Created by phil on 2/3/15.
@@ -73,17 +76,27 @@ public class NotificationDashboardFragment extends Fragment implements RefreshLi
         return view;
     }
 
-    @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    private void startRefresh() {
         if (parent instanceof RefreshableHostActivity) {
             ((RefreshableHostActivity) parent).startRefresh(this);
         }
     }
 
     @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        startRefresh();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        EventBus.getDefault().register(this);
+    }
+
+    @Override
     public void onPause() {
-        super.onPause();
+        EventBus.getDefault().unregister(this);
         if (task != null) {
             task.cancel(false);
         }
@@ -91,6 +104,7 @@ public class NotificationDashboardFragment extends Fragment implements RefreshLi
             mAdapter = (ListViewAdapter) mListView.getAdapter();
             mListState = mListView.onSaveInstanceState();
         }
+        super.onPause();
     }
 
     @Override
@@ -119,5 +133,9 @@ public class NotificationDashboardFragment extends Fragment implements RefreshLi
     
     public void updateTask(PopulateNotificationDashboard task){
         this.task = task;
+    }
+
+    public void onEventMainThread(NotificationsUpdatedEvent event) {
+        startRefresh();
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
@@ -121,20 +121,13 @@ public class GCMMessageHandler extends IntentService {
             boolean enabled = prefs.getBoolean("enable_notifications", true);
             if (enabled) {
                 Notification built;
-                int id;
 
                 built = notification.buildNotification(c);
                 if (built == null) return;
-                id = notification.getNotificationId();
-
-                if (notification.shouldShow()) {
-                    setNotificationParams(built, c, messageType, prefs);
-                    notificationManager.notify(id, built);
-                }
 
                 /* Update the data coming from this notification in the local db */
                 notification.updateDataLocally(c);
-                
+
                 /* Store this notification for future access */
                 StoredNotification stored = notification.getStoredNotification();
                 if (stored != null) {
@@ -143,11 +136,14 @@ public class GCMMessageHandler extends IntentService {
                     table.prune();
                 }
 
-                if(SummaryNotification.isNotificationActive(c) && notification.shouldShow()) {
-                    SummaryNotification summary = new SummaryNotification();
-                    built = summary.buildNotification(c);
+                if (notification.shouldShow()) {
+                    if (SummaryNotification.isNotificationActive(c)) {
+                        notification = new SummaryNotification();
+                        built = notification.buildNotification(c);
+                    }
+
                     setNotificationParams(built, c, messageType, prefs);
-                    id = summary.getNotificationId();
+                    int id = notification.getNotificationId();
                     notificationManager.notify(id, built);
                 }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
@@ -17,6 +17,7 @@ import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.background.UpdateMyTBA;
 import com.thebluealliance.androidclient.datafeed.Database;
 import com.thebluealliance.androidclient.datafeed.RequestParams;
+import com.thebluealliance.androidclient.eventbus.NotificationsUpdatedEvent;
 import com.thebluealliance.androidclient.gcm.notifications.AllianceSelectionNotification;
 import com.thebluealliance.androidclient.gcm.notifications.AwardsPostedNotification;
 import com.thebluealliance.androidclient.gcm.notifications.BaseNotification;
@@ -29,6 +30,8 @@ import com.thebluealliance.androidclient.gcm.notifications.ScoreNotification;
 import com.thebluealliance.androidclient.gcm.notifications.SummaryNotification;
 import com.thebluealliance.androidclient.gcm.notifications.UpcomingMatchNotification;
 import com.thebluealliance.androidclient.models.StoredNotification;
+
+import de.greenrobot.event.EventBus;
 
 /**
  * Created by Nathan on 7/24/2014.
@@ -147,6 +150,8 @@ public class GCMMessageHandler extends IntentService {
                     id = summary.getNotificationId();
                     notificationManager.notify(id, built);
                 }
+
+                EventBus.getDefault().post(new NotificationsUpdatedEvent());
             }
         } catch (Exception e) {
             // We probably tried to post a null notification or something like that. Oops...

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/AllianceSelectionNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/AllianceSelectionNotification.java
@@ -1,11 +1,9 @@
 package com.thebluealliance.androidclient.gcm.notifications;
 
 import android.app.Notification;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
-import android.graphics.BitmapFactory;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
@@ -15,10 +13,8 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.activities.ViewEventActivity;
 import com.thebluealliance.androidclient.adapters.ViewEventFragmentPagerAdapter;
 import com.thebluealliance.androidclient.datafeed.JSONManager;
-import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
 import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.helpers.MyTBAHelper;
-import com.thebluealliance.androidclient.listeners.NotificationDismissedListener;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.Event;
 import com.thebluealliance.androidclient.models.StoredNotification;
@@ -70,8 +66,6 @@ public class AllianceSelectionNotification extends BaseNotification{
         String contentText = String.format(r.getString(R.string.notification_alliances_updated), eventName);
 
         Intent instance = ViewEventActivity.newInstance(context, eventKey, ViewEventFragmentPagerAdapter.TAB_ALLIANCES);
-        PendingIntent intent = PendingIntent.getActivity(context, getNotificationId(), instance, 0);
-        PendingIntent onDismiss = PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationDismissedListener.class), 0);
 
         stored = new StoredNotification();
         stored.setType(getNotificationType());
@@ -81,16 +75,11 @@ public class AllianceSelectionNotification extends BaseNotification{
         stored.setBody(contentText);
         stored.setIntent(MyTBAHelper.serializeIntent(instance));
         stored.setTime(Calendar.getInstance().getTime());
-        
-        NotificationCompat.Builder builder = getBaseBuilder(context)
+
+        NotificationCompat.Builder builder = getBaseBuilder(context, instance)
                 .setContentTitle(title)
                 .setContentText(contentText)
-                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_info_outline_white_24dp))
-                .setContentIntent(intent)
-                .setDeleteIntent(onDismiss)
-                .setGroup(GCMMessageHandler.GROUP_KEY)
-                .setAutoCancel(true)
-                .extend(new NotificationCompat.WearableExtender().setBackground(BitmapFactory.decodeResource(context.getResources(), R.drawable.tba_blue_background)));
+                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_info_outline_white_24dp));
 
         NotificationCompat.BigTextStyle style = new NotificationCompat.BigTextStyle().bigText(contentText);
         builder.setStyle(style);

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/AwardsPostedNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/AwardsPostedNotification.java
@@ -1,11 +1,9 @@
 package com.thebluealliance.androidclient.gcm.notifications;
 
 import android.app.Notification;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
-import android.graphics.BitmapFactory;
 import android.support.v4.app.NotificationCompat;
 
 import com.google.gson.JsonArray;
@@ -16,10 +14,8 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.activities.ViewEventActivity;
 import com.thebluealliance.androidclient.adapters.ViewEventFragmentPagerAdapter;
 import com.thebluealliance.androidclient.datafeed.JSONManager;
-import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
 import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.helpers.MyTBAHelper;
-import com.thebluealliance.androidclient.listeners.NotificationDismissedListener;
 import com.thebluealliance.androidclient.models.Award;
 import com.thebluealliance.androidclient.models.StoredNotification;
 
@@ -68,8 +64,6 @@ public class AwardsPostedNotification extends BaseNotification {
         String contentText = String.format(r.getString(R.string.notification_awards_updated), eventName);
 
         Intent instance = ViewEventActivity.newInstance(context, eventKey, ViewEventFragmentPagerAdapter.TAB_AWARDS);
-        PendingIntent intent = PendingIntent.getActivity(context, getNotificationId(), instance, 0);
-        PendingIntent onDismiss = PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationDismissedListener.class), 0);
 
         stored = new StoredNotification();
         stored.setType(getNotificationType());
@@ -80,15 +74,10 @@ public class AwardsPostedNotification extends BaseNotification {
         stored.setIntent(MyTBAHelper.serializeIntent(instance));
         stored.setTime(Calendar.getInstance().getTime());
         
-        NotificationCompat.Builder builder = getBaseBuilder(context)
+        NotificationCompat.Builder builder = getBaseBuilder(context, instance)
                 .setContentTitle(title)
                 .setContentText(contentText)
-                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_assessment_white_24dp))
-                .setContentIntent(intent)
-                .setDeleteIntent(onDismiss)
-                .setGroup(GCMMessageHandler.GROUP_KEY)
-                .setAutoCancel(true)
-                .extend(new NotificationCompat.WearableExtender().setBackground(BitmapFactory.decodeResource(context.getResources(), R.drawable.tba_blue_background)));
+                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_assessment_white_24dp));
 
         NotificationCompat.BigTextStyle style = new NotificationCompat.BigTextStyle().bigText(contentText);
         builder.setStyle(style);

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/BaseNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/BaseNotification.java
@@ -71,6 +71,15 @@ public abstract class BaseNotification {
     }
 
     /**
+     * Adds a Category to activityIntent to mark it as "triggered by tapping a system notification",
+     * then builds a PendingIntent with it.
+     */
+    protected PendingIntent makeNotificationIntent(Context context, Intent activityIntent) {
+        activityIntent.addCategory(Intent.CATEGORY_ALTERNATIVE);
+        return PendingIntent.getActivity(context, getNotificationId(), activityIntent, 0);
+    }
+
+    /**
      * Creates a builder with the important defaults set.
      */
     public NotificationCompat.Builder getBaseBuilder(Context context) {
@@ -87,10 +96,14 @@ public abstract class BaseNotification {
 
     /**
      * Creates a builder with the important defaults and an Activity content intent.
+     *
+     * <p/>SIDE EFFECTS: Adds a Category to activityIntent so the launched Activity can tell it was
+     * triggered by a notification. (Note: Just adding an Extra won't work because Android will
+     * retrieve the existing intent, ignoring the new Extra.)
      */
     public NotificationCompat.Builder getBaseBuilder(Context context, Intent activityIntent) {
         NotificationCompat.Builder builder = getBaseBuilder(context);
-        PendingIntent onTap = PendingIntent.getActivity(context, getNotificationId(), activityIntent, 0);
+        PendingIntent onTap = makeNotificationIntent(context, activityIntent);
 
         builder.setContentIntent(onTap);
         return builder;

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/BaseNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/BaseNotification.java
@@ -1,7 +1,9 @@
 package com.thebluealliance.androidclient.gcm.notifications;
 
 import android.app.Notification;
+import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
@@ -17,6 +19,7 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.datafeed.JSONManager;
 import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
+import com.thebluealliance.androidclient.listeners.NotificationDismissedListener;
 import com.thebluealliance.androidclient.models.StoredNotification;
 
 /**
@@ -68,17 +71,29 @@ public abstract class BaseNotification {
     }
 
     /**
-     * Creates a builder with the important defaults set; namely, the app icon and the accent color
-     *
-     * @return
+     * Creates a builder with the important defaults set.
      */
-    public static NotificationCompat.Builder getBaseBuilder(Context context) {
+    public NotificationCompat.Builder getBaseBuilder(Context context) {
+        PendingIntent onDismiss = PendingIntent.getBroadcast(context, 0, NotificationDismissedListener.newIntent(context), 0);
+
         return new NotificationCompat.Builder(context)
                 .setSmallIcon(R.drawable.ic_notification)
                 .setGroup(GCMMessageHandler.GROUP_KEY)
                 .setColor(context.getResources().getColor(R.color.accent_dark))
+                .setDeleteIntent(onDismiss)
+                .setAutoCancel(true)
                 .extend(new NotificationCompat.WearableExtender().setBackground(BitmapFactory.decodeResource(context.getResources(), R.drawable.tba_blue_background)));
+    }
 
+    /**
+     * Creates a builder with the important defaults and an Activity content intent.
+     */
+    public NotificationCompat.Builder getBaseBuilder(Context context, Intent activityIntent) {
+        NotificationCompat.Builder builder = getBaseBuilder(context);
+        PendingIntent onTap = PendingIntent.getActivity(context, getNotificationId(), activityIntent, 0);
+
+        builder.setContentIntent(onTap);
+        return builder;
     }
 
     protected static Bitmap getLargeIconFormattedForPlatform(Context context, @DrawableRes int drawable) {

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/CompLevelStartingNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/CompLevelStartingNotification.java
@@ -1,11 +1,9 @@
 package com.thebluealliance.androidclient.gcm.notifications;
 
 import android.app.Notification;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
-import android.graphics.BitmapFactory;
 import android.support.v4.app.NotificationCompat;
 
 import com.google.gson.JsonElement;
@@ -15,10 +13,8 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.activities.ViewEventActivity;
 import com.thebluealliance.androidclient.adapters.ViewEventFragmentPagerAdapter;
 import com.thebluealliance.androidclient.datafeed.JSONManager;
-import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
 import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.helpers.MyTBAHelper;
-import com.thebluealliance.androidclient.listeners.NotificationDismissedListener;
 import com.thebluealliance.androidclient.models.StoredNotification;
 
 import java.text.DateFormat;
@@ -87,8 +83,6 @@ public class CompLevelStartingNotification extends BaseNotification {
         }
 
         Intent instance = ViewEventActivity.newInstance(context, eventKey, ViewEventFragmentPagerAdapter.TAB_MATCHES);
-        PendingIntent intent = PendingIntent.getActivity(context, 0, instance, 0);
-        PendingIntent onDismiss = PendingIntent.getBroadcast(context, getNotificationId(), new Intent(context, NotificationDismissedListener.class), 0);
 
         stored = new StoredNotification();
         stored.setType(getNotificationType());
@@ -99,15 +93,10 @@ public class CompLevelStartingNotification extends BaseNotification {
         stored.setIntent(MyTBAHelper.serializeIntent(instance));
         stored.setTime(Calendar.getInstance().getTime());
         
-        NotificationCompat.Builder builder = getBaseBuilder(context)
+        NotificationCompat.Builder builder = getBaseBuilder(context, instance)
                 .setContentTitle(title)
                 .setContentText(contentText)
-                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_access_time_white_24dp))
-                .setContentIntent(intent)
-                .setDeleteIntent(onDismiss)
-                .setGroup(GCMMessageHandler.GROUP_KEY)
-                .setAutoCancel(true)
-                .extend(new NotificationCompat.WearableExtender().setBackground(BitmapFactory.decodeResource(context.getResources(), R.drawable.tba_blue_background)));
+                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_access_time_white_24dp));
 
         NotificationCompat.BigTextStyle style = new NotificationCompat.BigTextStyle().bigText(contentText);
         builder.setStyle(style);

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/DistrictPointsUpdatedNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/DistrictPointsUpdatedNotification.java
@@ -1,11 +1,9 @@
 package com.thebluealliance.androidclient.gcm.notifications;
 
 import android.app.Notification;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
-import android.graphics.BitmapFactory;
 import android.support.v4.app.NotificationCompat;
 
 import com.google.gson.JsonObject;
@@ -13,10 +11,8 @@ import com.google.gson.JsonParseException;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.activities.ViewDistrictActivity;
 import com.thebluealliance.androidclient.datafeed.JSONManager;
-import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
 import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.helpers.MyTBAHelper;
-import com.thebluealliance.androidclient.listeners.NotificationDismissedListener;
 import com.thebluealliance.androidclient.models.StoredNotification;
 
 import java.util.Calendar;
@@ -48,8 +44,6 @@ public class DistrictPointsUpdatedNotification extends BaseNotification {
         String contentText = String.format(r.getString(R.string.notification_district_points_updated), districtName);
 
         Intent instance = ViewDistrictActivity.newInstance(context, districtKey);
-        PendingIntent intent = PendingIntent.getActivity(context, getNotificationId(), instance, 0);
-        PendingIntent onDismiss = PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationDismissedListener.class), 0);
 
         stored = new StoredNotification();
         stored.setType(getNotificationType());
@@ -60,15 +54,10 @@ public class DistrictPointsUpdatedNotification extends BaseNotification {
         stored.setIntent(MyTBAHelper.serializeIntent(instance));
         stored.setTime(Calendar.getInstance().getTime());
         
-        NotificationCompat.Builder builder = getBaseBuilder(context)
+        NotificationCompat.Builder builder = getBaseBuilder(context, instance)
                 .setContentTitle(title)
                 .setContentText(contentText)
-                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_info_outline_white_24dp))
-                .setContentIntent(intent)
-                .setDeleteIntent(onDismiss)
-                .setGroup(GCMMessageHandler.GROUP_KEY)
-                .setAutoCancel(true)
-                .extend(new NotificationCompat.WearableExtender().setBackground(BitmapFactory.decodeResource(context.getResources(), R.drawable.tba_blue_background)));
+                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_info_outline_white_24dp));
 
         NotificationCompat.BigTextStyle style = new NotificationCompat.BigTextStyle().bigText(contentText);
         builder.setStyle(style);

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/GenericNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/GenericNotification.java
@@ -14,7 +14,6 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.activities.NotificationDashboardActivity;
 import com.thebluealliance.androidclient.datafeed.JSONManager;
-import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
 
 import java.util.Date;
 
@@ -71,7 +70,6 @@ public class GenericNotification extends BaseNotification {
                 .setContentTitle(title)
                 .setContentText(message)
                 .setContentIntent(intent)
-                .setGroup(GCMMessageHandler.GROUP_KEY)
                 .setAutoCancel(true)
                 .setStyle(new NotificationCompat.BigTextStyle().bigText(message))
                 .extend(new NotificationCompat.WearableExtender().setBackground(BitmapFactory.decodeResource(context.getResources(), R.drawable.tba_blue_background)))

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/ScheduleUpdatedNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/ScheduleUpdatedNotification.java
@@ -1,11 +1,9 @@
 package com.thebluealliance.androidclient.gcm.notifications;
 
 import android.app.Notification;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
-import android.graphics.BitmapFactory;
 import android.support.v4.app.NotificationCompat;
 import android.text.format.DateFormat;
 
@@ -16,10 +14,8 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.activities.ViewEventActivity;
 import com.thebluealliance.androidclient.adapters.ViewEventFragmentPagerAdapter;
 import com.thebluealliance.androidclient.datafeed.JSONManager;
-import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
 import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.helpers.MyTBAHelper;
-import com.thebluealliance.androidclient.listeners.NotificationDismissedListener;
 import com.thebluealliance.androidclient.models.StoredNotification;
 
 import java.util.Calendar;
@@ -74,8 +70,6 @@ public class ScheduleUpdatedNotification extends BaseNotification {
         }
 
         Intent instance = ViewEventActivity.newInstance(context, eventKey, ViewEventFragmentPagerAdapter.TAB_MATCHES);
-        PendingIntent intent = PendingIntent.getActivity(context, getNotificationId(), instance, 0);
-        PendingIntent onDismiss = PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationDismissedListener.class), 0);
 
         stored = new StoredNotification();
         stored.setType(getNotificationType());
@@ -86,16 +80,11 @@ public class ScheduleUpdatedNotification extends BaseNotification {
         stored.setIntent(MyTBAHelper.serializeIntent(instance));
         stored.setTime(Calendar.getInstance().getTime());
         
-        NotificationCompat.Builder builder = getBaseBuilder(context)
+        NotificationCompat.Builder builder = getBaseBuilder(context, instance)
                 .setContentTitle(title)
                 .setContentText(contentText)
                 .setSmallIcon(R.drawable.ic_notification)
-                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_access_time_white_24dp))
-                .setContentIntent(intent)
-                .setDeleteIntent(onDismiss)
-                .setGroup(GCMMessageHandler.GROUP_KEY)
-                .setAutoCancel(true)
-                .extend(new NotificationCompat.WearableExtender().setBackground(BitmapFactory.decodeResource(context.getResources(), R.drawable.tba_blue_background)));
+                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_access_time_white_24dp));
 
         NotificationCompat.BigTextStyle style = new NotificationCompat.BigTextStyle().bigText(contentText);
         builder.setStyle(style);

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/ScoreNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/ScoreNotification.java
@@ -1,11 +1,9 @@
 package com.thebluealliance.androidclient.gcm.notifications;
 
 import android.app.Notification;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
-import android.graphics.BitmapFactory;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
@@ -17,11 +15,9 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.activities.ViewMatchActivity;
 import com.thebluealliance.androidclient.datafeed.JSONManager;
-import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
 import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.helpers.MatchHelper;
 import com.thebluealliance.androidclient.helpers.MyTBAHelper;
-import com.thebluealliance.androidclient.listeners.NotificationDismissedListener;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.Match;
 import com.thebluealliance.androidclient.models.StoredNotification;
@@ -184,8 +180,6 @@ public class ScoreNotification extends BaseNotification {
 
         // We can finally build the notification!
         Intent instance = ViewMatchActivity.newInstance(context, matchKey);
-        PendingIntent intent = PendingIntent.getActivity(context, getNotificationId(), instance, 0);
-        PendingIntent onDismiss = PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationDismissedListener.class), 0);
 
         stored = new StoredNotification();
         stored.setType(getNotificationType());
@@ -196,15 +190,10 @@ public class ScoreNotification extends BaseNotification {
         stored.setIntent(MyTBAHelper.serializeIntent(instance));
         stored.setTime(Calendar.getInstance().getTime());
         
-        NotificationCompat.Builder builder = getBaseBuilder(context)
+        NotificationCompat.Builder builder = getBaseBuilder(context, instance)
                 .setContentTitle(notificationTitle)
                 .setContentText(notificationString)
-                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_info_outline_white_24dp))
-                .setContentIntent(intent)
-                .setDeleteIntent(onDismiss)
-                .setGroup(GCMMessageHandler.GROUP_KEY)
-                .setAutoCancel(true)
-                .extend(new NotificationCompat.WearableExtender().setBackground(BitmapFactory.decodeResource(context.getResources(), R.drawable.tba_blue_background)));
+                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_info_outline_white_24dp));
 
         NotificationCompat.BigTextStyle style = new NotificationCompat.BigTextStyle().bigText(notificationString);
         builder.setStyle(style);

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/SummaryNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/SummaryNotification.java
@@ -37,10 +37,11 @@ public class SummaryNotification extends BaseNotification {
         String notificationTitle = context.getString(R.string.notification_summary, active.size());
         style.setBigContentTitle(notificationTitle);
         style.setSummaryText(context.getString(R.string.app_name));
-        
-        PendingIntent intent = PendingIntent.getActivity(context, getNotificationId(), NotificationDashboardActivity.newInstance(context), 0);
+
+        Intent instance = NotificationDashboardActivity.newInstance(context);
+        PendingIntent intent = makeNotificationIntent(context, instance);
         PendingIntent onDismiss = PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationDismissedListener.class), 0);
-        
+
         Notification summary = new NotificationCompat.Builder(context)
                 .setContentTitle(notificationTitle)
                 .setSmallIcon(R.drawable.ic_notification)

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/UpcomingMatchNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/UpcomingMatchNotification.java
@@ -1,11 +1,9 @@
 package com.thebluealliance.androidclient.gcm.notifications;
 
 import android.app.Notification;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
-import android.graphics.BitmapFactory;
 import android.support.v4.app.NotificationCompat;
 
 import com.google.gson.JsonArray;
@@ -17,11 +15,9 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.activities.ViewMatchActivity;
 import com.thebluealliance.androidclient.datafeed.JSONManager;
-import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
 import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.helpers.MatchHelper;
 import com.thebluealliance.androidclient.helpers.MyTBAHelper;
-import com.thebluealliance.androidclient.listeners.NotificationDismissedListener;
 import com.thebluealliance.androidclient.models.StoredNotification;
 
 import java.util.ArrayList;
@@ -121,8 +117,6 @@ public class UpcomingMatchNotification extends BaseNotification {
         }
 
         Intent instance = ViewMatchActivity.newInstance(context, matchKey);
-        PendingIntent intent = PendingIntent.getActivity(context, 0, instance, 0);
-        PendingIntent onDismiss = PendingIntent.getBroadcast(context, getNotificationId(), new Intent(context, NotificationDismissedListener.class), 0);
 
         stored = new StoredNotification();
         stored.setType(getNotificationType());
@@ -133,15 +127,10 @@ public class UpcomingMatchNotification extends BaseNotification {
         stored.setIntent(MyTBAHelper.serializeIntent(instance));
         stored.setTime(Calendar.getInstance().getTime());
         
-        NotificationCompat.Builder builder = getBaseBuilder(context)
+        NotificationCompat.Builder builder = getBaseBuilder(context, instance)
                 .setContentTitle(notificationTitle)
                 .setContentText(contentText)
-                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_access_time_white_24dp))
-                .setContentIntent(intent)
-                .setDeleteIntent(onDismiss)
-                .setGroup(GCMMessageHandler.GROUP_KEY)
-                .setAutoCancel(true)
-                .extend(new NotificationCompat.WearableExtender().setBackground(BitmapFactory.decodeResource(context.getResources(), R.drawable.tba_blue_background)));
+                .setLargeIcon(getLargeIconFormattedForPlatform(context, R.drawable.ic_access_time_white_24dp));
 
         NotificationCompat.BigTextStyle style = new NotificationCompat.BigTextStyle().bigText(contentText);
         builder.setStyle(style);

--- a/android/src/main/java/com/thebluealliance/androidclient/listeners/NotificationDismissedListener.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/listeners/NotificationDismissedListener.java
@@ -12,6 +12,11 @@ import com.thebluealliance.androidclient.datafeed.Database;
  * Created by phil on 2/5/15.
  */
 public class NotificationDismissedListener extends BroadcastReceiver{
+
+    public static Intent newIntent(Context context) {
+        return new Intent(context, NotificationDismissedListener.class);
+    }
+
     @Override
     public void onReceive(Context context, Intent intent) {
         Log.d(Constants.LOG_TAG, "Notification Dismiss!");


### PR DESCRIPTION
Fix #382 auto-update Recent Notifications when a notification arrives (using EventBus).
Fix #384 Notifications Not Being Marked As Read.
Fix double-chime notifications.
Fix navigating Back to Recent Notifications should refresh in case notifications arrived while it was paused.
Tapping a summary notification will reuse the Recent Notifications if it's on top rather than add a confusing entry to the task stack.
Refactor replicatedcode into BaseNotification.getBaseBuilder() where it can uniformly mark the content intents as "from notifications" so the receiving activity can tell when to dismiss "read" notifications.

_Branched from notification-titles which was merged from master, so there may be some commits from master to revert. If that turns out to be problematic, I can back out the merge from master and merge in 2015-comp-freeze._

(This can be reviewed file-by-file or commit-by-commit.)

(Android's Intent/Activity/task-stack/notification interactions are tricky and buggy.)