### PR TITLE
Fix #392 Notification Testing Script Temporarily Disabled

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ android {
             debug {
                 versionNameSuffix "/"+gitBranch+"/" + gitSha
                 applicationIdSuffix ".development"
+                manifestPlaceholders = [gcmPermissionRequired: ""] // "" => let GCMBroadcastReceiver accept Intents from 'adb shell am broadcast'
             }
 
             // run 'gradlew assembleDebugBlue' to do a debug signed build without using debug resources
@@ -38,10 +39,12 @@ android {
                 signingConfig signingConfigs.debug
                 versionNameSuffix "/"+gitBranch+"/" + gitSha
                 applicationIdSuffix ".development"
+                manifestPlaceholders = [gcmPermissionRequired: "com.google.android.c2dm.permission.SEND"]
             }
 
             release {
                 versionNameSuffix "/"+gitBranch
+                manifestPlaceholders = [gcmPermissionRequired: "com.google.android.c2dm.permission.SEND"]
                 signingConfig signingConfigs.release
                 minifyEnabled true
                 zipAlignEnabled true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ android {
                 signingConfig signingConfigs.debug
                 versionNameSuffix "/"+gitBranch+"/" + gitSha
                 applicationIdSuffix ".development"
-                manifestPlaceholders = [gcmPermissionRequired: "com.google.android.c2dm.permission.SEND"]
+                manifestPlaceholders = [gcmPermissionRequired: ""]
             }
 
             release {

--- a/android/src/debug/res/values/strings.xml
+++ b/android/src/debug/res/values/strings.xml
@@ -4,7 +4,4 @@
     <string name="package_name">com.thebluealliance.androidclient.development</string>
     <string name="account_type">com.thebluealliance.androidclient.development.account.TBAACCOUNT</string>
 
-    <!-- An empty string in debug builds lets 'adb shell am broadcast' send intents to GCMBroadcastReceiver. -->
-    <string name="gcm_sender_permission"></string>
-
 </resources>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -200,7 +200,7 @@
         </receiver>
         <receiver
             android:name="com.thebluealliance.androidclient.gcm.GCMBroadcastReceiver"
-            android:permission="com.google.android.c2dm.permission.SEND">
+            android:permission="${gcmPermissionRequired}">
             <intent-filter>
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -198,6 +198,10 @@
                 <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
             </intent-filter>
         </receiver>
+
+        <!-- The receiver's android:permission filters Intents by sender permission.
+             ${gcmPermissionRequired} is defined in android/build.gradle so debug builds accept
+             Intents from 'adb shell am broadcast'. See test_notification.py . -->
         <receiver
             android:name="com.thebluealliance.androidclient.gcm.GCMBroadcastReceiver"
             android:permission="${gcmPermissionRequired}">
@@ -207,6 +211,7 @@
                 <category android:name="com.thebluealliance.androidclient" />
             </intent-filter>
         </receiver>
+
         <receiver 
             android:name="com.thebluealliance.androidclient.listeners.NotificationDismissedListener"
             android:exported="false" />

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -21,7 +21,6 @@
     <string name="year_selector_title_events">%1$s Events</string>
     <string name="year_selector_title_districts">%1$s Districts</string>
     <string name="select_year">Select Year</string>
-    <string name="gcm_sender_permission">com.google.android.c2dm.permission.SEND</string>
 
     <!-- Main Activity -->
     <string-array name="event_list_year_selector">


### PR DESCRIPTION
Play Store doesn't like debug/release string resources for enabling GCM
testing in debug builds, so do it instead via Manifest Merger placeholders.

Changing this setting in build.gradle does work although I can't build a
release config to verify there.