### PR TITLE
Fix #406 show the day-of-week with each match time

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/views/MatchView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/MatchView.java
@@ -1,5 +1,6 @@
 package com.thebluealliance.androidclient.views;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.text.format.DateFormat;
@@ -16,6 +17,7 @@ import com.thebluealliance.androidclient.helpers.MatchHelper;
 import com.thebluealliance.androidclient.listeners.MatchClickListener;
 import com.thebluealliance.androidclient.listeners.TeamAtEventClickListener;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
@@ -231,9 +233,14 @@ public class MatchView extends FrameLayout {
                 // Match has no time
                 localTimeString = getContext().getString(R.string.no_time_available);
             } else {
+                // Format the day-of-week & time in the current locale with the user's 12/24-hour
+                // preference. The day part distinguishes today's matches from tomorrow's matches
+                // and from yesterday's matches with delayed results.
                 Date date = new Date(time * 1000L);
                 java.text.DateFormat format = DateFormat.getTimeFormat(getContext());
-                localTimeString = format.format(date);
+                @SuppressLint("SimpleDateFormat")
+                java.text.DateFormat dowFormat = new SimpleDateFormat("E ");
+                localTimeString = dowFormat.format(date) + format.format(date);
             }
 
             this.time.setText(localTimeString);


### PR DESCRIPTION
This distinguishes today's matches from tomorrow's matches and from
yesterday's matches with delayed results (e.g. right now on Carson and
Tesla).

I tried out two approaches. This simple, low-risk approach just prepends
the day-of-week to the formatted time. Would any locales rather append the
day-of-week?

The other approach uses the user's 12/24 hour preference to select the date
format pattern "E HH:mm" or "E hh:mm a" from a string resource, calls
DateFormat.getBestDateTimePattern() on API level >= 18 to allow
locale-specific adjustments and field reorderings, then uses that to format
the Date. Localizing those resources might fight with
getBestDateTimePattern(), so maybe the code should use one of those two.
The app isn't really internationalized yet so the added complexity doesn't
pay off. I stashed this approach and went back to the simple approach.

A match list might look less busy if entries omitted the day-of-week when
following a list entry with the same day-of-week, but then their day/time
strings wouldn't line up vertically. Also it's not obvious how to pass that
info across adjacent entries, and it's not a time for avoiding risk.