### PR TITLE
Fixes #459; improves behavior of team year selection

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -187,8 +187,8 @@ dependencies {
 
     // Square Libraries
     compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.squareup.retrofit:retrofit:2.0.0-SNAPSHOT'
-    compile 'com.squareup.retrofit:adapter-rxjava:2.0.0-SNAPSHOT'
+    compile 'com.squareup.retrofit:retrofit:2.0.0-beta1'
+    compile 'com.squareup.retrofit:adapter-rxjava:2.0.0-beta1'
     compile 'com.squareup.okhttp:okhttp:2.4.0'
 
     compile 'com.google.dagger:dagger:2.0.1'
@@ -211,4 +211,3 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.0.31-beta'
 }
-

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
@@ -124,8 +124,7 @@ public class ViewTeamActivity extends FABNotificationSettingsActivity implements
 
         mPager = (ViewPager) findViewById(R.id.view_pager);
         mPager.setOffscreenPageLimit(3);
-        mPager.setPageMargin(Utilities.getPixelsFromDp(this,
-                16));
+        mPager.setPageMargin(Utilities.getPixelsFromDp(this, 16));
         // We will notify the fragments of the year later
         mAdapter = new ViewTeamFragmentPagerAdapter(getSupportFragmentManager(), mTeamKey, mYear);
         mPager.setAdapter(mAdapter);

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
@@ -37,10 +37,10 @@ import java.util.Calendar;
 import rx.schedulers.Schedulers;
 
 public class ViewTeamActivity extends FABNotificationSettingsActivity implements
-  ViewPager.OnPageChangeListener,
-  View.OnClickListener,
-  HasFragmentComponent,
-  YearsParticipatedUpdate {
+        ViewPager.OnPageChangeListener,
+        View.OnClickListener,
+        HasFragmentComponent,
+        YearsParticipatedUpdate {
 
     public static final String TEAM_KEY = "team_key",
             TEAM_YEAR = "team_year",
@@ -53,7 +53,7 @@ public class ViewTeamActivity extends FABNotificationSettingsActivity implements
     private int mCurrentSelectedYearPosition = -1,
             mSelectedTab = -1;
 
-    private String[] mYearsParticipated;
+    private int[] mYearsParticipated;
 
     // Should come in the format frc####
     private String mTeamKey;
@@ -119,13 +119,13 @@ public class ViewTeamActivity extends FABNotificationSettingsActivity implements
             } else {
                 mYear = Calendar.getInstance().get(Calendar.YEAR);
             }
-            mCurrentSelectedYearPosition = 0;
             mSelectedTab = 0;
         }
+
         mPager = (ViewPager) findViewById(R.id.view_pager);
         mPager.setOffscreenPageLimit(3);
         mPager.setPageMargin(Utilities.getPixelsFromDp(this,
-          16));
+                16));
         // We will notify the fragments of the year later
         mAdapter = new ViewTeamFragmentPagerAdapter(getSupportFragmentManager(), mTeamKey, mYear);
         mPager.setAdapter(mAdapter);
@@ -140,9 +140,9 @@ public class ViewTeamActivity extends FABNotificationSettingsActivity implements
         }
 
         getComponent().datafeed().fetchTeamYearsParticipated(mTeamKey, null)
-          .subscribeOn(Schedulers.io())
-          .observeOn(Schedulers.computation())
-          .subscribe(new YearsParticipatedDropdownSubscriber(this));
+                .subscribeOn(Schedulers.io())
+                .observeOn(Schedulers.computation())
+                .subscribe(new YearsParticipatedDropdownSubscriber(this));
 
         // We can call this even though the years participated haven't been loaded yet.
         // The years won't be shown yet; this just shows the team number in the toolbar.
@@ -177,43 +177,36 @@ public class ViewTeamActivity extends FABNotificationSettingsActivity implements
             bar.setDisplayShowTitleEnabled(false);
             String teamNumber = mTeamKey.replace("frc", "");
             mYearSelectorTitle.setText(String.format(getString(R.string.team_actionbar_title),
-                                                    teamNumber));
+                    teamNumber));
 
             // If we call this and the years participated haven't been loaded yet, don't try to use them
-            if (mYearsParticipated != null) {
+            if (mYearsParticipated != null && mYearsParticipated.length > 0) {
 
                 mYearSelectorSubtitleContainer.setVisibility(View.VISIBLE);
 
-                final Dialog dialog = makeDialogForYearSelection(R.string.select_year,
-                                                                 mYearsParticipated);
+                final Dialog dialog = makeDialogForYearSelection(R.string.select_year, mYearsParticipated);
 
-                mYearSelectorContainer.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        dialog.show();
-                    }
-                });
-
-                if (mCurrentSelectedYearPosition >= 0 && mCurrentSelectedYearPosition < mYearsParticipated.length) {
-                    onYearSelected(mCurrentSelectedYearPosition);
-                    updateTeamYearSelector(mCurrentSelectedYearPosition);
-                } else {
-                    onYearSelected(0);
-                    updateTeamYearSelector(0);
-                }
+                mYearSelectorContainer.setOnClickListener(v -> dialog.show());
+            } else {
+                // If there are no valid years, hide the subtitle and disable clicking
+                mYearSelectorSubtitleContainer.setVisibility(View.GONE);
+                mYearSelectorContainer.setOnClickListener(null);
             }
         }
     }
 
-    private Dialog makeDialogForYearSelection(@StringRes int titleResId, String[] dropdownItems) {
+    private Dialog makeDialogForYearSelection(@StringRes int titleResId, int[] dropdownItems) {
+        // Create an array of strings from the int years
+        String[] years = new String[dropdownItems.length];
+        for(int i = 0; i < years.length; i++) {
+            years[i] = String.valueOf(dropdownItems[i]);
+        }
+
         Resources res = getResources();
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle(res.getString(titleResId));
-        builder.setItems(dropdownItems, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                onYearSelected(which);
-            }
+        builder.setItems(years, (dialog, which) -> {
+            onYearSelected(which);
         });
 
         return builder.create();
@@ -223,12 +216,15 @@ public class ViewTeamActivity extends FABNotificationSettingsActivity implements
         if (selectedPosition < 0 || selectedPosition >= mYearsParticipated.length) {
             return;
         }
-        mYearSelectorSubtitle.setText(mYearsParticipated[selectedPosition]);
+        mYearSelectorSubtitle.setText(String.valueOf(mYearsParticipated[selectedPosition]));
     }
 
     @Override
     public void updateYearsParticipated(int[] years) {
+        mYearsParticipated = years;
         String[] dropdownItems = new String[years.length];
+
+        // If we received a desired year in the intent, find the index of that year if it exists
         int requestedYearIndex = 0;
         for (int i = 0; i < years.length; i++) {
             if (years[i] == mYear) {
@@ -236,7 +232,10 @@ public class ViewTeamActivity extends FABNotificationSettingsActivity implements
             }
             dropdownItems[i] = String.valueOf(years[i]);
         }
-        mYearsParticipated = dropdownItems;
+
+        // Refresh action bar; this will the year subtitle if there are no valid ones
+        setupActionBar();
+
         onYearSelected(requestedYearIndex);
     }
 
@@ -245,9 +244,15 @@ public class ViewTeamActivity extends FABNotificationSettingsActivity implements
         if (position == mCurrentSelectedYearPosition) {
             return;
         }
+
+        // Bounds checking!
+        if (position < 0 || position >= mYearsParticipated.length) {
+            return;
+        }
+
         mCurrentSelectedYearPosition = position;
         updateTeamYearSelector(position);
-        int newYear = Integer.valueOf(mYearsParticipated[mCurrentSelectedYearPosition]);
+        int newYear = mYearsParticipated[mCurrentSelectedYearPosition];
         if (newYear == mYear) {
             return;
         }
@@ -306,20 +311,16 @@ public class ViewTeamActivity extends FABNotificationSettingsActivity implements
 
     }
 
-    public int getCurrentSelectedYearPosition() {
-        return mCurrentSelectedYearPosition;
-    }
-
     public FragmentComponent getComponent() {
         if (mComponent == null) {
             TBAAndroid application = ((TBAAndroid) getApplication());
             mComponent = DaggerFragmentComponent.builder()
-              .applicationComponent(application.getComponent())
-              .datafeedModule(application.getDatafeedModule())
-              .binderModule(application.getBinderModule())
-              .databaseWriterModule(application.getDatabaseWriterModule())
-              .subscriberModule(new SubscriberModule(this))
-              .build();
+                    .applicationComponent(application.getComponent())
+                    .datafeedModule(application.getDatafeedModule())
+                    .binderModule(application.getBinderModule())
+                    .databaseWriterModule(application.getDatabaseWriterModule())
+                    .subscriberModule(new SubscriberModule(this))
+                    .build();
         }
         return mComponent;
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
@@ -198,7 +198,7 @@ public class ViewTeamActivity extends FABNotificationSettingsActivity implements
     private Dialog makeDialogForYearSelection(@StringRes int titleResId, int[] dropdownItems) {
         // Create an array of strings from the int years
         String[] years = new String[dropdownItems.length];
-        for(int i = 0; i < years.length; i++) {
+        for (int i = 0; i < years.length; i++) {
             years[i] = String.valueOf(dropdownItems[i]);
         }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/modules/DatafeedModule.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/modules/DatafeedModule.java
@@ -36,7 +36,7 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
-import retrofit.ObservableCallAdapterFactory;
+import retrofit.RxJavaCallAdapterFactory;
 import retrofit.Retrofit;
 
 @Module(includes = TBAAndroidModule.class)
@@ -105,8 +105,8 @@ public class DatafeedModule {
         return new Retrofit.Builder()
           .baseUrl(APIv2.TBA_URL)
           .client(okHttpClient)
-          .converterFactory(LenientGsonConverterFactory.create(gson))
-          .callAdapterFactory(ObservableCallAdapterFactory.create())
+          .addConverterFactory(LenientGsonConverterFactory.create(gson))
+          .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
           .build();
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriber.java
@@ -3,6 +3,8 @@ package com.thebluealliance.androidclient.subscribers;
 import com.google.gson.JsonArray;
 import com.thebluealliance.androidclient.interfaces.YearsParticipatedUpdate;
 
+import java.util.Arrays;
+
 import javax.inject.Inject;
 
 import rx.android.schedulers.AndroidSchedulers;
@@ -27,7 +29,19 @@ public class YearsParticipatedDropdownSubscriber implements Action1<JsonArray> {
             years[i] = apiYears.get(i).getAsInt();
         }
 
+        /*
+        First sort the array, then reverse its order.
+        This will put it in descending order (most recent year first).
+         */
+        Arrays.sort(years);
+        for (int i = 0; i < years.length / 2; i++) {
+            int temp = years[i];
+            int index = years.length - i - 1;
+            years[i] = years[index];
+            years[index] = temp;
+        }
+
         AndroidSchedulers.mainThread().createWorker()
-          .schedule(() -> mCallback.updateYearsParticipated(years));
+                .schedule(() -> mCallback.updateYearsParticipated(years));
     }
 }

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriberTest.java
@@ -36,7 +36,7 @@ public class YearsParticipatedDropdownSubscriberTest {
 
     @Test
     public void testParsedData() {
-        int[] expected = {2012, 2013, 2014, 2015};
+        int[] expected = {2015, 2014, 2013, 2012};
         mSubscriber.call(mYearsParticipated);
         verify(mCallback).updateYearsParticipated(expected);
     }


### PR DESCRIPTION
Fixes #459 so that years are now ordered in reverse chronological order.

I also moved around some of the stuff that deals with year selection. This slightly improves separations of concerns.