### PR TITLE
Fixed issue where events lists weren't being bound

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/EventsByWeekFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/EventsByWeekFragment.java
@@ -151,10 +151,13 @@ public class EventsByWeekFragment
 
         if (currentYear != mYear && week1Index > -1) {
             mViewPager.setCurrentItem(week1Index);
+            mFragmentBinder.onPageSelected(week1Index);
         } else if (currentIndex < weekCount && currentIndex > -1) {
             mViewPager.setCurrentItem(currentIndex);
+            mFragmentBinder.onPageSelected(currentIndex);
         } else {
             mViewPager.setCurrentItem(0);
+            mFragmentBinder.onPageSelected(0);
         }
     }
 


### PR DESCRIPTION
If the events list pager was set to position 0 (the default), an onPageSelected event was never fired for the FragmentBinder, and the proper tabs weren't bound. This fixes that issue by manually calling onPageSelected when the proper tab is computed and selected.