### PR TITLE
FAB layout fixes

### DIFF
--- a/android/src/main/res/layout/activity_gameday.xml
+++ b/android/src/main/res/layout/activity_gameday.xml
@@ -32,15 +32,6 @@
                 android:layout_height="match_parent"
                 android:layout_below="@id/tabs" />
 
-            <android.support.design.widget.FloatingActionButton
-                android:id="@+id/filter_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentBottom="true"
-                android:layout_alignParentRight="true"
-                android:layout_margin="@dimen/fab_margin"
-                android:src="@drawable/ic_filter_list_white_24dp"
-                app:fabSize="normal" />
         </RelativeLayout>
 
         <LinearLayout
@@ -58,4 +49,13 @@
                 android:visibility="gone" />
         </LinearLayout>
     </RelativeLayout>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/filter_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|right"
+        android:layout_margin="@dimen/fab_margin"
+        android:src="@drawable/ic_filter_list_white_24dp"
+        app:fabSize="normal" />
 </android.support.design.widget.CoordinatorLayout>

--- a/android/src/main/res/layout/activity_gameday.xml
+++ b/android/src/main/res/layout/activity_gameday.xml
@@ -1,56 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
-        android:id="@+id/toolbar"
-        style="@style/DefaultToolbarStyle" />
-
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_above="@+id/overlay_container"
-        android:layout_below="@id/toolbar"
-        android:orientation="vertical">
+        android:layout_height="match_parent">
 
-        <com.thebluealliance.androidclient.views.SlidingTabs
-            android:id="@+id/tabs"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_alignParentTop="true"
-            android:background="@color/primary" />
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            style="@style/DefaultToolbarStyle" />
 
-        <android.support.v4.view.ViewPager
-            android:id="@+id/view_pager"
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_below="@id/tabs" />
+            android:layout_above="@+id/overlay_container"
+            android:layout_below="@id/toolbar"
+            android:orientation="vertical">
 
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/filter_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_alignParentRight="true"
-            android:layout_margin="@dimen/fab_margin"
-            android:src="@drawable/ic_filter_list_white_24dp"
-            app:fabSize="normal" />
+            <com.thebluealliance.androidclient.views.SlidingTabs
+                android:id="@+id/tabs"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:layout_alignParentTop="true"
+                android:background="@color/primary" />
+
+            <android.support.v4.view.ViewPager
+                android:id="@+id/view_pager"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@id/tabs" />
+
+            <android.support.design.widget.FloatingActionButton
+                android:id="@+id/filter_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_alignParentRight="true"
+                android:layout_margin="@dimen/fab_margin"
+                android:src="@drawable/ic_filter_list_white_24dp"
+                app:fabSize="normal" />
+        </RelativeLayout>
+
+        <LinearLayout
+            android:id="@+id/overlay_container"
+            style="@style/ContentOverlayStyle">
+
+            <TextView
+                android:id="@+id/info_container"
+                style="@style/InfoOverlayStyle"
+                android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/warning_container"
+                style="@style/WarningOverlayStyle"
+                android:visibility="gone" />
+        </LinearLayout>
     </RelativeLayout>
-
-    <LinearLayout
-        android:id="@+id/overlay_container"
-        style="@style/ContentOverlayStyle">
-
-        <TextView
-            android:id="@+id/info_container"
-            style="@style/InfoOverlayStyle"
-            android:visibility="gone" />
-
-        <TextView
-            android:id="@+id/warning_container"
-            style="@style/WarningOverlayStyle"
-            android:visibility="gone" />
-    </LinearLayout>
-</RelativeLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/android/src/main/res/layout/activity_mytba_model_settings.xml
+++ b/android/src/main/res/layout/activity_mytba_model_settings.xml
@@ -23,16 +23,6 @@
             android:layout_below="@id/toolbar"
             android:orientation="vertical" />
 
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/close_notification_settings_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_alignParentRight="true"
-            android:layout_margin="@dimen/fab_margin"
-            android:src="@drawable/ic_check_white_24dp"
-            app:fabSize="normal" />
-
         <FrameLayout
             android:id="@+id/green_container"
             android:layout_width="match_parent"
@@ -40,4 +30,13 @@
             android:background="@color/accent"
             android:visibility="invisible" />
     </RelativeLayout>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/close_notification_settings_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|right"
+        android:layout_margin="@dimen/fab_margin"
+        android:src="@drawable/ic_check_white_24dp"
+        app:fabSize="normal" />
 </android.support.design.widget.CoordinatorLayout>

--- a/android/src/main/res/layout/activity_mytba_model_settings.xml
+++ b/android/src/main/res/layout/activity_mytba_model_settings.xml
@@ -1,40 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
-        android:id="@+id/toolbar"
-        style="@style/DefaultLightToolbarStyle"
-        android:background="@color/accent"
-        app:contentInsetStart="72dp"
-        app:navigationContentDescription="@string/close"
-        app:navigationIcon="@drawable/ic_close_black_24dp" />
-
-    <FrameLayout
-        android:id="@+id/settings_list"
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@id/toolbar"
-        android:orientation="vertical" />
+        android:layout_height="match_parent">
 
-    <android.support.design.widget.FloatingActionButton
-        android:id="@+id/close_notification_settings_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentRight="true"
-        android:layout_margin="@dimen/fab_margin"
-        android:src="@drawable/ic_check_white_24dp"
-        app:fabSize="normal" />
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            style="@style/DefaultLightToolbarStyle"
+            android:background="@color/accent"
+            app:contentInsetStart="72dp"
+            app:navigationContentDescription="@string/close"
+            app:navigationIcon="@drawable/ic_close_black_24dp" />
 
-    <FrameLayout
-        android:id="@+id/green_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/accent"
-        android:visibility="invisible" />
+        <FrameLayout
+            android:id="@+id/settings_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@id/toolbar"
+            android:orientation="vertical" />
 
-</RelativeLayout>
+        <android.support.design.widget.FloatingActionButton
+            android:id="@+id/close_notification_settings_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentRight="true"
+            android:layout_margin="@dimen/fab_margin"
+            android:src="@drawable/ic_check_white_24dp"
+            app:fabSize="normal" />
+
+        <FrameLayout
+            android:id="@+id/green_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/accent"
+            android:visibility="invisible" />
+    </RelativeLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/android/src/main/res/values-v21/dimens.xml
+++ b/android/src/main/res/values-v21/dimens.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <dimen name="fab_margin">16dp</dimen>
+
 </resources>


### PR DESCRIPTION
This should fix the weird FAB layout behavior we were seeing on 4.x devices. It turns out that if FABs are placed as a direct child of a CoordinatorLayout, the CL will translate the FAB to account for the extra padding that's added on 4.x devices to allow for the shadow. So, we still have to provide a margin for the FAB.

People with 4.x devices, please test this! I was able to test 2/3 activities with FABs, but not the myTBA settings activity that's launched from the myTBA fav/sub lists (I was running on an emulator where I couldn't enable myTBA).