### PR TITLE
Fix myTBA preference, bump platform/libarary versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-23.0.1
+    - build-tools-23.0.2
     - android-23
     - extra-android-m2repository
     - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-22.0.1
-    - android-22
+    - build-tools-23.0.1
+    - android-23
     - extra-android-m2repository
     - extra-google-m2repository
     - extra-google-google_play_services
 
 env:
   matrix:
-    - ANDROID_TARGET=android-22  ANDROID_ABI=armeabi-v7a
+    - ANDROID_TARGET=android-23  ANDROID_ABI=armeabi-v7a
 
 script: ./gradlew testDevDebugUnitTest -i
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,8 +29,8 @@ tasks.withType(Test) {
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.2'
 
     signingConfigs {
         release {
@@ -191,19 +191,19 @@ dependencies {
     compile files('libs/tbaMobile-v9-1.19.0-SNAPSHOT.jar')
 
     // Android support libraries
-    compile 'com.android.support:support-v13:22.2.1'
-    compile 'com.android.support:cardview-v7:22.2.1'
-    compile 'com.android.support:support-v4:22.2.1'
-    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:support-v13:23.1.1'
+    compile 'com.android.support:cardview-v7:23.1.1'
+    compile 'com.android.support:support-v4:23.1.1'
+    compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:multidex:1.0.1'
-    compile 'com.android.support:design:22.2.1'
+    compile 'com.android.support:design:23.1.1'
 
     // Play Services Libraries
     // See http://developer.android.com/google/play-services/setup.html
-    compile 'com.google.android.gms:play-services-base:7.3.0'
-    compile 'com.google.android.gms:play-services-plus:7.3.0'
-    compile 'com.google.android.gms:play-services-analytics:7.3.0'
-    compile 'com.google.android.gms:play-services-gcm:7.3.0'
+    compile 'com.google.android.gms:play-services-base:8.3.0'
+    compile 'com.google.android.gms:play-services-plus:8.3.0'
+    compile 'com.google.android.gms:play-services-analytics:8.3.0'
+    compile 'com.google.android.gms:play-services-gcm:8.3.0'
 
     // Square Libraries
     compile 'com.squareup.picasso:picasso:2.5.2'

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/settings/SettingsActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/settings/SettingsActivity.java
@@ -131,6 +131,15 @@ public class SettingsActivity extends AppCompatActivity {
                 listView.setPadding(0, 0, 0, 0);
             }
         }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+
+            // Enable might have failed; update the state of the switch when we resume
+            SwitchPreference enable_mytba = (SwitchPreference) findPreference("mytba_enabled");
+            enable_mytba.setChecked(AccountHelper.isMyTBAEnabled(getActivity()));
+        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/NavigationDrawerFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/NavigationDrawerFragment.java
@@ -157,11 +157,13 @@ public class NavigationDrawerFragment extends Fragment {
         profilePicture = (CircleImageView) v.findViewById(R.id.profile_image);
         coverPhoto = (ImageView) v.findViewById(R.id.profile_cover_image);
         if (AccountHelper.isMyTBAEnabled(getActivity())) {
+            Log.d("NavDrawerFragment", "MyTBA enabled; configuring navigation drawer");
             accountDetailsContainer.setVisibility(View.VISIBLE);
             profilePicture.setVisibility(View.VISIBLE);
             profileName.setVisibility(View.VISIBLE);
             setDrawerProfileInfo();
         } else {
+            Log.d("NavDrawerFragment", "MyTBA not enabled; hiding profile in nav drawer");
             accountDetailsContainer.setVisibility(View.GONE);
         }
 


### PR DESCRIPTION
Before, if you clicked to enable myTBA in settings but then canceled it, the preference switch would show that myTBA was enabled until the next time the settings activity was recreated. Now, the PreferenceFragment driving everything will check if myTBA is enabled in onResume and update the UI to reflect that.

This also targets API23 (Marshmallow) and bumps build tools, the support libraries, and Play Services to their latest respective versions.