### PR TITLE
Reduces status rate limiting for users who are not logged in

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/DatafeedModule.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/DatafeedModule.java
@@ -106,8 +106,9 @@ public class DatafeedModule {
     }
 
     @Provides @Singleton
-    public TBAStatusController provideTbaStatusController(SharedPreferences prefs, Gson gson, Tracker tracker) {
-        return new TBAStatusController(prefs, gson, tracker);
+    public TBAStatusController provideTbaStatusController(SharedPreferences prefs, Gson gson,
+                                                          Tracker tracker, Context context) {
+        return new TBAStatusController(prefs, gson, tracker, context);
     }
 
     public static Gson getGson() {

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/status/TBAStatusController.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/status/TBAStatusController.java
@@ -62,7 +62,6 @@ public class TBAStatusController implements Application.ActivityLifecycleCallbac
     private long mLastDialogTime;
 
     private boolean mUserIsLoggedIn;
-    @Inject Context context;
 
     @Inject
     public TBAStatusController(SharedPreferences prefs, Gson gson, Tracker tracker, Context context) {

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/status/TBAStatusController.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/status/TBAStatusController.java
@@ -57,7 +57,6 @@ public class TBAStatusController implements Application.ActivityLifecycleCallbac
     private final SharedPreferences mPrefs;
     private final Gson mGson;
     private final Tracker mAnalyticsTracker;
-    private final Context mContext;
 
     private long mLastUpdateTime;
     private long mLastDialogTime;
@@ -70,7 +69,6 @@ public class TBAStatusController implements Application.ActivityLifecycleCallbac
         mPrefs = prefs;
         mGson = gson;
         mAnalyticsTracker = tracker;
-        mContext = context;
         mLastUpdateTime = Long.MIN_VALUE;
         mLastDialogTime = Long.MIN_VALUE;
 


### PR DESCRIPTION
Because users who aren't logged in won't receive GCM notifications of status updates, we should poll more frequently.

This also sets a separate timeout for showing the "Please upgrade" dialog (we don't want to spam users with that). I would almost feel comfortable making that last days or even weeks. We want to remind users that a new version is available, but don't want to annoy them by asking too frequently. In that case, the "last shown" time should be a persistent preference that will last across application restarts.