### PR TITLE
Switch to using the Support Library dialogs

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/Utilities.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/Utilities.java
@@ -1,8 +1,6 @@
 package com.thebluealliance.androidclient;
 
-import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.res.Resources;
@@ -10,6 +8,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
 import android.support.annotation.RawRes;
+import android.support.v7.app.AlertDialog;
 import android.text.Html;
 import android.text.format.DateFormat;
 import android.util.ArrayMap;

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/BaseActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/BaseActivity.java
@@ -12,7 +12,7 @@ import com.thebluealliance.androidclient.mytba.MyTbaUpdateService;
 import com.thebluealliance.androidclient.types.ModelType;
 
 import android.annotation.TargetApi;
-import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.nfc.NdefMessage;

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/HomeActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/HomeActivity.java
@@ -19,7 +19,7 @@ import com.thebluealliance.androidclient.listeners.ClickListenerModule;
 import com.thebluealliance.androidclient.listitems.NavDrawerItem;
 import com.thebluealliance.androidclient.subscribers.SubscriberModule;
 
-import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/OnboardingActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/OnboardingActivity.java
@@ -22,7 +22,7 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.animation.ValueAnimator;
-import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/RedownloadActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/RedownloadActivity.java
@@ -4,7 +4,7 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.animation.ValueAnimator;
-import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
@@ -1,6 +1,6 @@
 package com.thebluealliance.androidclient.activities;
 
-import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/status/TBAStatusController.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/status/TBAStatusController.java
@@ -11,7 +11,7 @@ import com.thebluealliance.androidclient.background.AnalyticsActions;
 import com.thebluealliance.androidclient.models.APIStatus;
 
 import android.app.Activity;
-import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.app.Application;
 import android.content.Context;
 import android.content.Intent;

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventStatsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventStatsFragment.java
@@ -1,6 +1,6 @@
 package com.thebluealliance.androidclient.fragments.event;
 
-import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.view.LayoutInflater;

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/mytba/MyTBAFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/mytba/MyTBAFragment.java
@@ -1,6 +1,6 @@
 package com.thebluealliance.androidclient.fragments.mytba;
 
-import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;


### PR DESCRIPTION
This brings nice Material dialogs to pre-Lollipop devices.

Shoutout to the Android team for making this stupidly easy to do.