### PR TITLE
Use status badges from shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 The Blue Alliance - Android App
 ===============================
 
-[![Build Status](https://travis-ci.org/the-blue-alliance/the-blue-alliance-android.png?branch=master)](https://travis-ci.org/the-blue-alliance/the-blue-alliance-android) [![Coverage Status](https://coveralls.io/repos/the-blue-alliance/the-blue-alliance-android/badge.svg)](https://coveralls.io/r/the-blue-alliance/the-blue-alliance-android) [![Stories in Ready](https://badge.waffle.io/the-blue-alliance/the-blue-alliance-android.png?label=ready&title=Ready)](https://github.com/the-blue-alliance/the-blue-alliance-android/labels/ready) [![Stories in Needs Review](https://badge.waffle.io/the-blue-alliance/the-blue-alliance-android.png?label=needs-review&title=Needs%20Review)](https://github.com/the-blue-alliance/the-blue-alliance-android/labels/needs-review) [![Stories in On Hold](https://badge.waffle.io/the-blue-alliance/the-blue-alliance-android.png?label=on-hold&title=On%20Hold)](https://github.com/the-blue-alliance/the-blue-alliance-android/labels/on-hold)
+[![Build Status](https://img.shields.io/travis/the-blue-alliance/the-blue-alliance-android/master.svg?style=flat-square)](https://travis-ci.org/the-blue-alliance/the-blue-alliance-android) [![Coverage Status](https://img.shields.io/coveralls/the-blue-alliance/the-blue-alliance-android.svg?style=flat-square)](https://coveralls.io/r/the-blue-alliance/the-blue-alliance-android) [![Stories in Ready](https://badge.waffle.io/the-blue-alliance/the-blue-alliance-android.png?label=ready&title=Ready)](https://github.com/the-blue-alliance/the-blue-alliance-android/labels/ready) [![Stories in Needs Review](https://badge.waffle.io/the-blue-alliance/the-blue-alliance-android.png?label=needs-review&title=Needs%20Review)](https://github.com/the-blue-alliance/the-blue-alliance-android/labels/needs-review) [![Stories in On Hold](https://badge.waffle.io/the-blue-alliance/the-blue-alliance-android.png?label=on-hold&title=On%20Hold)](https://github.com/the-blue-alliance/the-blue-alliance-android/labels/on-hold)
 
 An Android app for accessing information about the FIRST Robotics Competition. This is a native mobile version of [The Blue Alliance](http://www.thebluealliance.com).
 
@@ -9,6 +9,7 @@ The app has been released to the [Play Store](https://play.google.com/store/apps
 
 Contributing
 ============
+
 Want to add features, fix bugs, or just poke around the code? No problem!
 
 ### Project Management 


### PR DESCRIPTION
http://shields.io/ provides nice standardized status badges, and they have a pretty flat design too. Unfortunately waffle.io doesn't adhere to the badge spec, so those badges look a litle out of place right now.