### PR TITLE
Change event rankings to properly handle ####B team numbers. Fixes #530.

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/listitems/RankingListElement.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/listitems/RankingListElement.java
@@ -9,13 +9,13 @@ import com.thebluealliance.androidclient.R;
 
 public class RankingListElement extends ListElement {
 
-    public final int teamNumber;
+    public final String teamNumber;
     public final String teamName;
     public final int teamRank;
     public final String teamRecord;
     public final String teamBreakdown;
 
-    public RankingListElement(String key, int number, String name, int ranking, String record, String breakdown) {
+    public RankingListElement(String key, String number, String name, int ranking, String record, String breakdown) {
         super(key);
         teamNumber = number;
         teamName = name;
@@ -41,7 +41,7 @@ public class RankingListElement extends ListElement {
             holder = (ViewHolder) convertView.getTag();
         }
 
-        holder.teamNumber.setText("" + teamNumber);
+        holder.teamNumber.setText(teamNumber);
 
         if (teamName.equals("")) {
             holder.teamName.setVisibility(View.INVISIBLE);
@@ -76,7 +76,7 @@ public class RankingListElement extends ListElement {
             return false;
         }
         RankingListElement element = (RankingListElement) o;
-        return teamNumber == element.teamNumber &&
+        return teamNumber.equals(element.teamNumber) &&
           teamName.equals(element.teamName) &&
           teamRank == element.teamRank &&
           teamRecord.equals(element.teamRecord) &&

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriber.java
@@ -2,6 +2,8 @@ package com.thebluealliance.androidclient.subscribers;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+
+import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.database.Database;
 import com.thebluealliance.androidclient.eventbus.EventRankingsEvent;
 import com.thebluealliance.androidclient.helpers.EventHelper;
@@ -10,6 +12,8 @@ import com.thebluealliance.androidclient.listitems.ListItem;
 import com.thebluealliance.androidclient.listitems.RankingListElement;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.Team;
+
+import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,9 +59,9 @@ public class RankingsListSubscriber extends BaseAPISubscriber<JsonElement, List<
                 Set<String> keys = rankingElements.keySet();
                 if (keys.contains("wins") && keys.contains("losses") && keys.contains("ties")) {
                     record = String.format("(%1$s-%2$s-%3$s",
-                      rankingElements.get("wins"),
-                      rankingElements.get("losses"),
-                      rankingElements.get("ties"));
+                            rankingElements.get("wins"),
+                            rankingElements.get("losses"),
+                            rankingElements.get("ties"));
                     rankingElements.remove("wins");
                     rankingElements.remove("losses");
                     rankingElements.remove("ties");
@@ -77,13 +81,13 @@ public class RankingsListSubscriber extends BaseAPISubscriber<JsonElement, List<
                 nickname = "Team " + teamKey.substring(3);
             }
             mDataToBind.add(
-              new RankingListElement(
-                teamKey,
-                row.get(1).getAsInt(), // team number
-                nickname,
-                row.get(0).getAsInt(), // rank
-                record,
-                rankingString));
+                    new RankingListElement(
+                            teamKey,
+                            row.get(1).getAsString(), // team number
+                            nickname,
+                            row.get(0).getAsInt(), // rank
+                            record,
+                            rankingString));
         }
         mEventBus.post(new EventRankingsEvent(generateTopRanksString(rankingsData)));
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriber.java
@@ -3,7 +3,6 @@ package com.thebluealliance.androidclient.subscribers;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 
-import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.database.Database;
 import com.thebluealliance.androidclient.eventbus.EventRankingsEvent;
 import com.thebluealliance.androidclient.helpers.EventHelper;
@@ -12,8 +11,6 @@ import com.thebluealliance.androidclient.listitems.ListItem;
 import com.thebluealliance.androidclient.listitems.RankingListElement;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.Team;
-
-import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -80,6 +77,7 @@ public class RankingsListSubscriber extends BaseAPISubscriber<JsonElement, List<
             } else {
                 nickname = "Team " + teamKey.substring(3);
             }
+
             mDataToBind.add(
                     new RankingListElement(
                             teamKey,

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriberTest.java
@@ -36,6 +36,8 @@ public class RankingsListSubscriberTest {
 
     RankingsListSubscriber mSubscriber;
     JsonArray mRankings;
+    // Includes a team with a number like "####B"
+    JsonArray mRankingsMultiTeam;
 
     @Before
     public void setUp() {
@@ -44,6 +46,7 @@ public class RankingsListSubscriberTest {
 
         mSubscriber = new RankingsListSubscriber(mDb, mEventBus);
         mRankings = ModelMaker.getModel(JsonArray.class, "2015necmp_rankings");
+        mRankingsMultiTeam = ModelMaker.getModel(JsonArray.class, "2015ohri_rankings");
     }
 
     @Test
@@ -74,6 +77,23 @@ public class RankingsListSubscriberTest {
         String breakdown = EventHelper.createRankingBreakdown(rankingElements);
         RankingListElement expected =
           new RankingListElement("frc1519", "1519", "Team 1519", 1, "", breakdown);
+
+        assertEquals(1, data.size());
+        assertEquals(expected, data.get(0));
+    }
+
+    @Test
+    public void testParsedDataWithMultiTeam() throws BasicModel.FieldNotDefinedException {
+        List<ListItem> data = DatafeedTestDriver.getParsedData(mSubscriber, mRankingsMultiTeam);
+        EventHelper.CaseInsensitiveMap<String> rankingElements = new EventHelper.CaseInsensitiveMap<>();
+        for (int j = 2; j < mRankingsMultiTeam.get(0).getAsJsonArray().size(); j++) {
+            rankingElements.put(
+                    mRankingsMultiTeam.get(0).getAsJsonArray().get(j).getAsString(),
+                    mRankingsMultiTeam.get(1).getAsJsonArray().get(j).getAsString());
+        }
+        String breakdown = EventHelper.createRankingBreakdown(rankingElements);
+        RankingListElement expected =
+                new RankingListElement("frc1038B", "1038B", "Team 1038B", 30, "", breakdown);
 
         assertEquals(1, data.size());
         assertEquals(expected, data.get(0));

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriberTest.java
@@ -73,7 +73,7 @@ public class RankingsListSubscriberTest {
         }
         String breakdown = EventHelper.createRankingBreakdown(rankingElements);
         RankingListElement expected =
-          new RankingListElement("frc1519", 1519, "Team 1519", 1, "", breakdown);
+          new RankingListElement("frc1519", "1519", "Team 1519", 1, "", breakdown);
 
         assertEquals(1, data.size());
         assertEquals(expected, data.get(0));

--- a/android/src/test/resources/2015necmp_rankings.json
+++ b/android/src/test/resources/2015necmp_rankings.json
@@ -1,1 +1,1 @@
-[["Rank", "Team", "Qual Avg", "Auto", "Container", "Coopertition", "Litter", "Tote", "Played"], [1, 1519, 200.08000000000001, 214, 880, 440, 313, 566, 12]]
+[["Rank", "Team", "Qual Avg", "Auto", "Container", "Coopertition", "Litter", "Tote", "Played"], ["1", "1519", "200.08000000000001", "214", "880", "440", "313", "566', '12"]]

--- a/android/src/test/resources/2015necmp_rankings.json
+++ b/android/src/test/resources/2015necmp_rankings.json
@@ -1,1 +1,1 @@
-[["Rank", "Team", "Qual Avg", "Auto", "Container", "Coopertition", "Litter", "Tote", "Played"], ["1", "1519", "200.08000000000001", "214", "880", "440", "313", "566', '12"]]
+[["Rank", "Team", "Qual Avg", "Auto", "Container", "Coopertition", "Litter", "Tote", "Played"], ["1", "1519", "200.08000000000001", "214", "880", "440", "313", "566", "12"]]

--- a/android/src/test/resources/2015ohri_rankings.json
+++ b/android/src/test/resources/2015ohri_rankings.json
@@ -1,0 +1,1 @@
+[["Rank", "Team", "Qual Avg", "Coopertition", "Auto", "Container", "Tote", "Litter", "DQ", "Played"], ["30", "1038B", "2", "0", "0", "0", "8", "0", "3", "4"]]


### PR DESCRIPTION
This just treats the team number as a generic string instead of explicitly as an integer, which is fine because the integer value is never used for comparisons or anything.