### PR TITLE
Workaround Google Play Service Analytics issue 784

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,6 +91,7 @@ android {
     }
 
     defaultConfig {
+        applicationId "com.thebluealliance.androidclient"
         minSdkVersion 16
         targetSdkVersion 22
         versionCode versionNum


### PR DESCRIPTION
There is an active issue in the Google Play Service Analytics library where a Provider com.google.android.gms.measurement.AppMeasurementContentProvider is being defined in all android applications which use this library unless defaultConfig.applicationId is defined

https://code.google.com/p/analytics-issues/issues/detail?id=784

This simple addition to the build.gradle is supposed to fix this issue and stop some users from getting the -505 error from the Google Play Store while installing the app when another app also using the Google Play Service Analytics Library without setting the defaultConfig.applicationId is already installed.

For instance I have the AMC Theaters application installed on my phone, today I wanted to install The Blue Alliance, logcat showed a warning with the following when doing so, and my phone showed error -505

W PackageManager: com.android.server.pm.PackageManagerException: Can't install because provider name com.google.android.gms.measurement.google_measurement_service (in package com.thebluealliance.androidclient) is already used by com.amc