### PR TITLE
Fixes #545

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/database/tables/EventTeamsTable.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/tables/EventTeamsTable.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.androidclient.database.tables;
 
 import android.database.Cursor;
+import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.thebluealliance.androidclient.database.Database;
@@ -23,7 +24,7 @@ public class EventTeamsTable extends ModelTable<EventTeam> {
 
     private SQLiteDatabase mDb;
 
-    public EventTeamsTable(SQLiteDatabase db){
+    public EventTeamsTable(SQLiteDatabase db) {
         super(db);
         this.mDb = db;
     }
@@ -33,17 +34,26 @@ public class EventTeamsTable extends ModelTable<EventTeam> {
      */
     public List<Event> getEvents(String teamKey, int year) {
         // INNER JOIN EventTeams + Events on KEY, select where teamKey and year = args
-        String query = String.format("SELECT * FROM %1$s JOIN %2$s ON %1$s.%3$s = %2$s.%4$s " +
-          "WHERE %1$s.%5$s = ? AND %1$s.%6$s = ?",
-          Database.TABLE_EVENTTEAMS, Database.TABLE_EVENTS, EVENTKEY, EventsTable.KEY, TEAMKEY, YEAR);
+        String query = String.format("SELECT %1$s FROM %2$s JOIN %3$s ON %2$s.%4$s = %3$s.%5$s " +
+                        "WHERE %2$s.%6$s = ? AND %2$s.%7$s = ?",
+                EventsTable.getAllColumnsForJoin(), Database.TABLE_EVENTTEAMS, Database.TABLE_EVENTS, EVENTKEY, EventsTable.KEY, TEAMKEY, YEAR);
         Cursor cursor = mDb.rawQuery(query, new String[]{teamKey, Integer.toString(year)});
         ArrayList<Event> results = new ArrayList<>();
+        System.out.println("query: " + query);
+        System.out.println("cursor row count: " + cursor.getCount());
+        if (cursor != null && cursor.moveToFirst()) {
+            do {
+                String contents = DatabaseUtils.dumpCurrentRowToString(cursor);
+                System.out.println(contents);
+            } while (cursor.moveToNext());
+        }
         if (cursor != null && cursor.moveToFirst()) {
             do {
                 results.add(ModelInflater.inflateEvent(cursor));
             } while (cursor.moveToNext());
         }
         return results;
+        /*return new ArrayList<>();*/
     }
 
     /**
@@ -52,8 +62,8 @@ public class EventTeamsTable extends ModelTable<EventTeam> {
     public List<Team> getTeams(String eventKey) {
         // INNER JOIN EventTeams + TEAMS on KEY, select where eventKey = args
         String query = String.format("SELECT * FROM %1$s JOIN %2$s ON %1$s.%3$s = %2$s.%4$s " +
-            "WHERE %1$s.%3$s = ?",
-          Database.TABLE_EVENTTEAMS, Database.TABLE_TEAMS, TEAMKEY, TeamsTable.KEY);
+                        "WHERE %1$s.%3$s = ?",
+                Database.TABLE_EVENTTEAMS, Database.TABLE_TEAMS, TEAMKEY, TeamsTable.KEY);
         Cursor cursor = mDb.rawQuery(query, new String[]{eventKey});
         ArrayList<Team> results = new ArrayList<>();
         if (cursor != null && cursor.moveToFirst()) {

--- a/android/src/main/java/com/thebluealliance/androidclient/database/tables/EventTeamsTable.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/tables/EventTeamsTable.java
@@ -45,7 +45,6 @@ public class EventTeamsTable extends ModelTable<EventTeam> {
             } while (cursor.moveToNext());
         }
         return results;
-        /*return new ArrayList<>();*/
     }
 
     /**

--- a/android/src/main/java/com/thebluealliance/androidclient/database/tables/EventTeamsTable.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/tables/EventTeamsTable.java
@@ -39,14 +39,6 @@ public class EventTeamsTable extends ModelTable<EventTeam> {
                 EventsTable.getAllColumnsForJoin(), Database.TABLE_EVENTTEAMS, Database.TABLE_EVENTS, EVENTKEY, EventsTable.KEY, TEAMKEY, YEAR);
         Cursor cursor = mDb.rawQuery(query, new String[]{teamKey, Integer.toString(year)});
         ArrayList<Event> results = new ArrayList<>();
-        System.out.println("query: " + query);
-        System.out.println("cursor row count: " + cursor.getCount());
-        if (cursor != null && cursor.moveToFirst()) {
-            do {
-                String contents = DatabaseUtils.dumpCurrentRowToString(cursor);
-                System.out.println(contents);
-            } while (cursor.moveToNext());
-        }
         if (cursor != null && cursor.moveToFirst()) {
             do {
                 results.add(ModelInflater.inflateEvent(cursor));

--- a/android/src/main/java/com/thebluealliance/androidclient/database/tables/EventsTable.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/tables/EventsTable.java
@@ -14,6 +14,7 @@ import com.thebluealliance.androidclient.database.ModelTable;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.Event;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class EventsTable extends ModelTable<Event> {
@@ -45,6 +46,51 @@ public class EventsTable extends ModelTable<Event> {
         mDb = db;
     }
 
+    /**
+     * Generates a comma-separated list of all this model's columns, like the following:
+     * <p>
+     * event.key, events.name, events.year... and so on.
+     * <p>
+     * This is useful for when we only want to select the event table's columns during a join, it
+     * saves us from having to type all this out in place.
+     *
+     * @return comma-separated list of this model's columns
+     */
+    public static String getAllColumnsForJoin() {
+        List<String> columns = new ArrayList<>();
+        columns.add(KEY);
+        columns.add(YEAR);
+        columns.add(NAME);
+        columns.add(SHORTNAME);
+        columns.add(LOCATION);
+        columns.add(VENUE);
+        columns.add(TYPE);
+        columns.add(DISTRICT);
+        columns.add(DISTRICT_STRING);
+        columns.add(DISTRICT_POINTS);
+        columns.add(START);
+        columns.add(END);
+        columns.add(OFFICIAL);
+        columns.add(WEEK);
+        columns.add(TEAMS);
+        columns.add(RANKINGS);
+        columns.add(ALLIANCES);
+        columns.add(WEBCASTS);
+        columns.add(STATS);
+        columns.add(WEBSITE);
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < columns.size(); i++) {
+            builder.append(Database.TABLE_EVENTS);
+            builder.append(".");
+            builder.append(columns.get(i));
+            if (i != columns.size() - 1) {
+                builder.append(", ");
+            }
+        }
+        return builder.toString();
+    }
+
     @Override
     protected void insertCallback(Event event) {
         ContentValues cv = new ContentValues();
@@ -73,7 +119,7 @@ public class EventsTable extends ModelTable<Event> {
             mDb.update(Database.TABLE_SEARCH_EVENTS, cv, Database.SearchEvent.KEY + "=?", new String[]{event.getKey()});
         } catch (BasicModel.FieldNotDefinedException e) {
             Log.e(Constants.LOG_TAG, "Can't insert event search item without the following fields:" +
-              "Database.Events.KEY, Database.Events.YEAR");
+                    "Database.Events.KEY, Database.Events.YEAR");
         }
     }
 
@@ -131,20 +177,20 @@ public class EventsTable extends ModelTable<Event> {
         String table = getTableName();
         String searchTable = Database.TABLE_SEARCH_EVENTS;
         String rawQuery = "SELECT " + table + ".rowid as '_id',"
-            + table + "." + KEY + ","
-            + table + "." + NAME + ","
-            + table + "." + SHORTNAME + ","
-            + table + "." + TYPE + ","
-            + table + "." + DISTRICT + ","
-            + table + "." + START + ","
-            + table + "." + END + ","
-            + table + "." + LOCATION + ","
-            + table + "." + VENUE + ","
-            + table + "." + OFFICIAL + ","
-            + table + "." + DISTRICT_STRING
-            + " FROM " + getTableName()
-            + " JOIN (SELECT " + searchTable + "." + Database.SearchEvent.KEY + " FROM " + searchTable + " WHERE " + searchTable + "." + Database.SearchEvent.TITLES + " MATCH ?)" +
-            " as 'tempevents' ON tempevents." +Database.SearchEvent.KEY+ " = " + table + "." + KEY + " ORDER BY " + table + "." + YEAR + " DESC";
+                + table + "." + KEY + ","
+                + table + "." + NAME + ","
+                + table + "." + SHORTNAME + ","
+                + table + "." + TYPE + ","
+                + table + "." + DISTRICT + ","
+                + table + "." + START + ","
+                + table + "." + END + ","
+                + table + "." + LOCATION + ","
+                + table + "." + VENUE + ","
+                + table + "." + OFFICIAL + ","
+                + table + "." + DISTRICT_STRING
+                + " FROM " + getTableName()
+                + " JOIN (SELECT " + searchTable + "." + Database.SearchEvent.KEY + " FROM " + searchTable + " WHERE " + searchTable + "." + Database.SearchEvent.TITLES + " MATCH ?)" +
+                " as 'tempevents' ON tempevents." + Database.SearchEvent.KEY + " = " + table + "." + KEY + " ORDER BY " + table + "." + YEAR + " DESC";
         Cursor cursor = mDb.rawQuery(rawQuery, new String[]{query});
 
         if (cursor == null) {


### PR DESCRIPTION
Turns out this issue was being caused by an overly-inclusive JOIN statement. We were selecting all the columns from both the Events and EventTeams table, both of which contained a "key" column. When the ModelInflater tried to use the EventTeams key as an Event model key, everything broke, and the rest is history. The fix was to only select the columns from the Events table.

This doesn't explain why EventTeams don't seem to be cached all the time, but that's another issue for another day.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/547)
<!-- Reviewable:end -->
