### PR TITLE
Fix Caching Issues

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/LaunchActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/LaunchActivity.java
@@ -107,10 +107,10 @@ public class LaunchActivity extends AppCompatActivity {
         boolean redownload = false;
         Log.d(Constants.LOG_TAG, "Last version: " + lastVersion + "/" + BuildConfig.VERSION_CODE + " " + prefs.contains(Constants.APP_VERSION_KEY));
 
-        /* Clear OkHttp cache for the new version. */
-        clearDatafeedCache();
-
         if (prefs.contains(Constants.APP_VERSION_KEY) && lastVersion < BuildConfig.VERSION_CODE) {
+            /* Clear OkHttp cache for the new version. */
+            mStatusController.clearOkCacheIfNeeded(mStatusController.fetchApiStatus(), true);
+
             // We are updating the app. Do stuffs, if necessary.
             // TODO: make sure to modify changelog.txt with any recent changes
             if (lastVersion < 14) {
@@ -223,17 +223,6 @@ public class LaunchActivity extends AppCompatActivity {
 
         // Default to kicking the user to the events list if none of the URIs match
         goToHome();
-    }
-
-    private void clearDatafeedCache() {
-        Schedulers.io().createWorker().schedule(() -> {
-            Log.i(Constants.LOG_TAG, "Clearing okhttp cache");
-            try {
-                mDatafeedCache.evictAll();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        });
     }
 
     private DatafeedComponent getComponenet() {

--- a/android/src/main/java/com/thebluealliance/androidclient/database/writers/EventTeamAndTeamListWriter.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/writers/EventTeamAndTeamListWriter.java
@@ -24,6 +24,9 @@ public class EventTeamAndTeamListWriter extends BaseDbWriter<EventTeamAndTeamLis
 
     @Override
     public void write(EventTeamAndTeam newModels) {
+        if (newModels == null) {
+            return;
+        }
         mDb.getWritableDatabase().beginTransaction();
         try {
             mEventTeamListWriter.write(newModels.eventTeams);

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/DatafeedModule.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/DatafeedModule.java
@@ -134,8 +134,8 @@ public class DatafeedModule {
 
     @Provides @Singleton
     public TBAStatusController provideTbaStatusController(SharedPreferences prefs, Gson gson,
-                                                          Tracker tracker, Context context) {
-        return new TBAStatusController(prefs, gson, tracker, context);
+                                                          Cache cache, Context context) {
+        return new TBAStatusController(prefs, gson, cache, context);
     }
 
     public static Gson getGson() {

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/DatafeedModule.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/DatafeedModule.java
@@ -1,5 +1,7 @@
 package com.thebluealliance.androidclient.datafeed;
 
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.okhttp.StethoInterceptor;
 import com.google.android.gms.analytics.Tracker;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -94,6 +96,9 @@ public class DatafeedModule {
     public OkHttpClient getOkHttp(Cache responseCache) {
         OkHttpClient client = new OkHttpClient();
         client.interceptors().add(new APIv2RequestInterceptor());
+        if (Utilities.isDebuggable()) {
+            client.networkInterceptors().add(new StethoInterceptor());
+        }
         client.setCache(responseCache);
         return client;
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/combiners/TeamAndEventTeamCombiner.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/combiners/TeamAndEventTeamCombiner.java
@@ -26,6 +26,9 @@ public class TeamAndEventTeamCombiner implements Func1<List<Team>, EventTeamAndT
     public EventTeamAndTeam call(List<Team> teams) {
         int year = EventHelper.getYear(mEventKey);
         List<EventTeam> eventTeams = new ArrayList<>();
+        if (teams == null) {
+            return null;
+        }
         for (int i = 0; i < teams.size(); i++) {
             Team team = teams.get(i);
             EventTeam eventTeam = new EventTeam();

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/deserializers/APIStatusDeserializer.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/deserializers/APIStatusDeserializer.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 import com.thebluealliance.androidclient.models.APIStatus;
 
 import java.lang.reflect.Type;
@@ -25,6 +26,7 @@ public class APIStatusDeserializer implements JsonDeserializer<APIStatus> {
     public static final String MESSAGE_DICT = "message";
     public static final String MESSAGE_TEXT = "text";
     public static final String MESSAGE_EXPIRATION = "expiration";
+    public static final String LAST_OKHTTP_CACHE_CLEAR = "last_cache_clear";
 
     @Override
     public APIStatus deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
@@ -92,6 +94,15 @@ public class APIStatusDeserializer implements JsonDeserializer<APIStatus> {
             status.setMessageExipration(new Date(messageExpiration.getAsLong() * MS_PER_SECOND));
         } else {
             status.setHasMessage(false);
+        }
+
+        JsonElement lastCacheClear = data.get(LAST_OKHTTP_CACHE_CLEAR);
+        if (lastCacheClear != null && !lastCacheClear.isJsonNull() && lastCacheClear.isJsonPrimitive()) {
+            JsonPrimitive lastCacheTime = lastCacheClear.getAsJsonPrimitive();
+            long lastTimestamp = lastCacheTime.getAsLong();
+            status.setLastOkHttpCacheClear(lastTimestamp);
+        } else {
+            status.setLastOkHttpCacheClear(-1);
         }
 
         status.setJsonBlob(json.toString());

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/status/TBAStatusController.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/status/TBAStatusController.java
@@ -127,7 +127,7 @@ public class TBAStatusController implements Application.ActivityLifecycleCallbac
                 try {
                     mOkHttpCache.evictAll();
                     mPrefs.edit()
-                            .putLong(STATUS_CACHE_CLEAR_KEY, System.currentTimeMillis() / 1000l)
+                            .putLong(STATUS_CACHE_CLEAR_KEY, System.currentTimeMillis() / 1000L)
                             .apply();
                 } catch (IOException e) {
                     e.printStackTrace();

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/status/TBAStatusController.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/status/TBAStatusController.java
@@ -3,7 +3,9 @@ package com.thebluealliance.androidclient.datafeed.status;
 import com.google.android.gms.analytics.Tracker;
 import com.google.gson.Gson;
 
+import com.squareup.okhttp.Cache;
 import com.thebluealliance.androidclient.BuildConfig;
+import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.accounts.AccountHelper;
 import com.thebluealliance.androidclient.activities.UpdateRequiredActivity;
@@ -19,12 +21,16 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
+import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import rx.schedulers.Schedulers;
 
 /**
  * A class to handle the TBA Status API
@@ -34,6 +40,7 @@ import javax.inject.Singleton;
 public class TBAStatusController implements Application.ActivityLifecycleCallbacks {
 
     public static final String STATUS_PREF_KEY = "tba_status";
+    public static final String STATUS_CACHE_CLEAR_KEY = "last_okcache_clear";
 
     /**
      * We use different timeouts for logged in users and not logged in users. Logged-in users will
@@ -51,7 +58,7 @@ public class TBAStatusController implements Application.ActivityLifecycleCallbac
 
     private final SharedPreferences mPrefs;
     private final Gson mGson;
-    private final Tracker mAnalyticsTracker;
+    private final Cache mOkHttpCache;
 
     private long mLastUpdateTime;
     private long mLastDialogTime;
@@ -60,10 +67,10 @@ public class TBAStatusController implements Application.ActivityLifecycleCallbac
     private boolean mUserIsLoggedIn;
 
     @Inject
-    public TBAStatusController(SharedPreferences prefs, Gson gson, Tracker tracker, Context context) {
+    public TBAStatusController(SharedPreferences prefs, Gson gson, Cache cache, Context context) {
         mPrefs = prefs;
         mGson = gson;
-        mAnalyticsTracker = tracker;
+        mOkHttpCache = cache;
         mLastUpdateTime = Long.MIN_VALUE;
         mLastDialogTime = Long.MIN_VALUE;
 
@@ -108,6 +115,25 @@ public class TBAStatusController implements Application.ActivityLifecycleCallbac
             return BuildConfig.VERSION_CODE;
         }
         return status.getLatestAppersion();
+    }
+
+    public void clearOkCacheIfNeeded(@Nullable APIStatus status, boolean forceClear) {
+        long lastCacheClear = mPrefs.getLong(STATUS_CACHE_CLEAR_KEY, Long.MIN_VALUE);
+        if (status != null
+                && mOkHttpCache != null
+                && (forceClear || lastCacheClear < status.getLastOkHttpCacheClear())) {
+            Schedulers.io().createWorker().schedule(() -> {
+                Log.i(Constants.LOG_TAG, "Clearing OkHttp cache");
+                try {
+                    mOkHttpCache.evictAll();
+                    mPrefs.edit()
+                            .putLong(STATUS_CACHE_CLEAR_KEY, System.currentTimeMillis() / 1000l)
+                            .apply();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            });
+        }
     }
 
     @Override
@@ -168,6 +194,9 @@ public class TBAStatusController implements Application.ActivityLifecycleCallbac
                     .show();
             mLastMessageTime = System.nanoTime();
         }
+
+        /* Clear OkHttp Cache when commanded */
+        clearOkCacheIfNeeded(status, false);
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/models/APIStatus.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/models/APIStatus.java
@@ -8,6 +8,7 @@ public class APIStatus {
     private boolean fmsApiDown;
     private int minAppVersion;
     private int latestAppersion;
+    private long lastOkHttpCacheClear;
     private List<String> downEvents;
     private String jsonBlob;
 
@@ -90,5 +91,13 @@ public class APIStatus {
 
     public void setMessageExipration(Date messageExipration) {
         this.messageExipration = messageExipration;
+    }
+
+    public long getLastOkHttpCacheClear() {
+        return lastOkHttpCacheClear;
+    }
+
+    public void setLastOkHttpCacheClear(long lastOkHttpCacheClear) {
+        this.lastOkHttpCacheClear = lastOkHttpCacheClear;
     }
 }

--- a/android/src/test/java/com/thebluealliance/androidclient/datafeed/deserializers/APIStatusDeserializerTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/datafeed/deserializers/APIStatusDeserializerTest.java
@@ -55,6 +55,7 @@ public class APIStatusDeserializerTest {
         assertTrue(mStatus.hasMessage());
         assertEquals("This is only a test", mStatus.getMessageText());
         assertEquals(new Date(1449698422l * 1000), mStatus.getMessageExipration());
+        assertEquals(1449698422, mStatus.getLastOkHttpCacheClear());
 
         List<String> downKeys = mStatus.getDownEvents();
         assertNotNull(downKeys);
@@ -164,5 +165,12 @@ public class APIStatusDeserializerTest {
         mJsonData.get(APIStatusDeserializer.MESSAGE_DICT).getAsJsonObject()
           .remove(APIStatusDeserializer.MESSAGE_EXPIRATION);
         mStatus = mDeserializer.deserialize(mJsonData, APIStatus.class, mContext);
+    }
+
+    @Test
+    public void testNoLastCacheClear() {
+        mJsonData.remove(APIStatusDeserializer.LAST_OKHTTP_CACHE_CLEAR);
+        mStatus = mDeserializer.deserialize(mJsonData, APIStatus.class, mContext);
+        assertEquals(-1, mStatus.getLastOkHttpCacheClear());
     }
 }

--- a/android/src/test/resources/api_status.json
+++ b/android/src/test/resources/api_status.json
@@ -15,5 +15,6 @@
   "message": {
     "text": "This is only a test",
     "expiration": 1449698422
-  }
+  },
+  "last_cache_clear": 1449698422
 }


### PR DESCRIPTION
Caching is hard...
The issue in the screenshot happened because the original event was deleted on the server and the new response was in OkHttp's cache, but it never registered as needing to update in the app's db. I was able to fix it by clearing my local data, but that's not a scalable solution. So I added a timestamp to the TBAStatus model. We can set a timestamp server side and each app will clear its local cache exactly once after that (tracked via "last clear" timestamp stored in sharedPrefs). We'll also clear the cache on app updates, just to try and avoid things getting stuck in it.

Fixes #546 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/549)
<!-- Reviewable:end -->
