### PR TITLE
Subscriber Bugfix: Clear data to bind after check

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/binders/EventInfoBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/EventInfoBinder.java
@@ -80,6 +80,13 @@ public class EventInfoBinder extends AbstractDataBinder<EventInfoBinder.Model> {
 
     @Override
     public void updateData(@Nullable Model data) {
+        if (data == null) {
+            if (!isDataBound()) {
+                bindNoDataView();
+            }
+            return;
+        }
+
         mSocialClickListener.setModelKey(data.eventKey);
         mIsLive = data.isLive;
         eventName.setText(data.nameString);

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamInfoBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamInfoBinder.java
@@ -54,6 +54,12 @@ public class TeamInfoBinder extends AbstractDataBinder<TeamInfoBinder.Model> {
 
     @Override
     public void updateData(@Nullable TeamInfoBinder.Model data) {
+        if (data == null) {
+            if (!isDataBound()) {
+                bindNoDataView();
+            }
+            return;
+        }
         mSocialClickListener.setModelKey(data.teamKey);
 
         if (data.nickname.isEmpty()) {

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/APISubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/APISubscriber.java
@@ -1,9 +1,9 @@
 package com.thebluealliance.androidclient.datafeed;
 
-import android.support.annotation.Nullable;
-
 import com.thebluealliance.androidclient.adapters.ListViewAdapter;
 import com.thebluealliance.androidclient.models.BasicModel;
+
+import android.support.annotation.Nullable;
 
 /**
  * An interface that a {@link rx.Subscriber} in the package
@@ -14,6 +14,9 @@ import com.thebluealliance.androidclient.models.BasicModel;
 public interface APISubscriber<T> {
     /**
      * Parse data from the API and construct the values to return, if necessary
+     * For example, {@link com.thebluealliance.androidclient.subscribers.BaseAPISubscriber} will
+     * not call this method unless the data is valid (not-null), but this is not a hard guarantee
+     * and should be handled
      * Usually creates a {@link ListViewAdapter}
      */
     void parseData() throws BasicModel.FieldNotDefinedException;

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/DatafeedModule.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/DatafeedModule.java
@@ -1,5 +1,7 @@
 package com.thebluealliance.androidclient.datafeed;
 
+import com.facebook.stetho.common.Util;
+import com.facebook.stetho.okhttp.StethoInterceptor;
 import com.google.android.gms.analytics.Tracker;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -94,6 +96,9 @@ public class DatafeedModule {
     public OkHttpClient getOkHttp(Cache responseCache) {
         OkHttpClient client = new OkHttpClient();
         client.interceptors().add(new APIv2RequestInterceptor());
+        if (Utilities.isDebuggable()) {
+            client.networkInterceptors().add(new StethoInterceptor());
+        }
         client.setCache(responseCache);
         return client;
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/AllianceListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/AllianceListSubscriber.java
@@ -20,10 +20,11 @@ public class AllianceListSubscriber extends BaseAPISubscriber<Event, List<ListIt
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null) {
             return;
         }
+        mDataToBind.clear();
+
         mRenderer.renderAlliances(mAPIData, mDataToBind);
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/AllianceListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/AllianceListSubscriber.java
@@ -20,9 +20,6 @@ public class AllianceListSubscriber extends BaseAPISubscriber<Event, List<ListIt
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null) {
-            return;
-        }
         mDataToBind.clear();
 
         mRenderer.renderAlliances(mAPIData, mDataToBind);

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/AwardsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/AwardsListSubscriber.java
@@ -33,10 +33,11 @@ public class AwardsListSubscriber extends BaseAPISubscriber<List<Award>, List<Li
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null || mAPIData.isEmpty()) {
             return;
         }
+
+        mDataToBind.clear();
         Map<String, Team> teams = Utilities.getMapForPlatform(String.class, Team.class);
         for (int i = 0; i < mAPIData.size(); i++) {
             Award award = mAPIData.get(i);

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/AwardsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/AwardsListSubscriber.java
@@ -33,10 +33,6 @@ public class AwardsListSubscriber extends BaseAPISubscriber<List<Award>, List<Li
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null || mAPIData.isEmpty()) {
-            return;
-        }
-
         mDataToBind.clear();
         Map<String, Team> teams = Utilities.getMapForPlatform(String.class, Team.class);
         for (int i = 0; i < mAPIData.size(); i++) {
@@ -52,5 +48,9 @@ public class AwardsListSubscriber extends BaseAPISubscriber<List<Award>, List<Li
             AwardRenderer.RenderArgs args = new AwardRenderer.RenderArgs(teams, mTeamKey);
             mDataToBind.add(mRenderer.renderFromModel(award, args));
         }
+    }
+
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && !mAPIData.isEmpty();
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/BaseAPISubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/BaseAPISubscriber.java
@@ -24,6 +24,11 @@ import rx.android.schedulers.AndroidSchedulers;
  * This class takes an input of data directly from Retrofit (using {@link rx.Subscriber} and
  * provides a callback to
  *
+ * Subclasses should implement {@link #parseData()} to take the data set in {@link #mAPIData} and
+ * produce something bindable and store it in {@link #mDataToBind}. Subclasses should also
+ * initialize {@link #mDataToBind} in their constructors, as it's possible that the variable
+ * is accessed before {@link #parseData()} is called
+ *
  * @param <APIType>  Datatype to be returned from the API (one from {@link APIv2}
  * @param <BindType> Datatype to be returned for binding to views
  */
@@ -91,7 +96,9 @@ public abstract class BaseAPISubscriber<APIType, BindType>
         setApiData(data);
         postToEventBus(EventBus.getDefault());
         try {
-            parseData();
+            if (isDataValid()) {
+                parseData();
+            }
             if (shouldBindImmediately || shouldBindOnce) {
                 bindViewsIfNeeded();
                 bindData();
@@ -187,6 +194,15 @@ public abstract class BaseAPISubscriber<APIType, BindType>
      */
     protected boolean shouldPostToEventBus() {
         return false;
+    }
+
+    /**
+     * Subclasses can override this method to determine if {@link #mAPIData} is valid.
+     * Default to simply checking if null
+     */
+    @VisibleForTesting
+    public boolean isDataValid() {
+        return mAPIData != null;
     }
 
     private void sendTimingUpdate(long timeSpent) {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/ContributorListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/ContributorListSubscriber.java
@@ -19,11 +19,6 @@ public class ContributorListSubscriber extends BaseAPISubscriber<JsonElement, Li
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-
-        if (mAPIData == null || !mAPIData.isJsonArray()) {
-            return;
-        }
-
         mDataToBind.clear();
         JsonArray data = mAPIData.getAsJsonArray();
         for (JsonElement e : data) {
@@ -33,5 +28,9 @@ public class ContributorListSubscriber extends BaseAPISubscriber<JsonElement, Li
             String avatarUrl = user.get("avatar_url").getAsString();
             mDataToBind.add(new ContributorListElement(username, contributionCount, avatarUrl));
         }
+    }
+
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && mAPIData.isJsonArray();
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/ContributorListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/ContributorListSubscriber.java
@@ -19,12 +19,12 @@ public class ContributorListSubscriber extends BaseAPISubscriber<JsonElement, Li
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
 
         if (mAPIData == null || !mAPIData.isJsonArray()) {
             return;
         }
 
+        mDataToBind.clear();
         JsonArray data = mAPIData.getAsJsonArray();
         for (JsonElement e : data) {
             JsonObject user = e.getAsJsonObject();

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictListSubscriber.java
@@ -28,11 +28,11 @@ public class DistrictListSubscriber extends BaseAPISubscriber<List<District>, Li
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null) {
             return;
         }
 
+        mDataToBind.clear();
         for (int i = 0; i < mAPIData.size(); i++) {
             District district = mAPIData.get(i);
             int numEvents = getNumEventsForDistrict(district.getKey());

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictListSubscriber.java
@@ -1,15 +1,15 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.database.Cursor;
-
 import com.thebluealliance.androidclient.database.Database;
 import com.thebluealliance.androidclient.database.tables.DistrictsTable;
 import com.thebluealliance.androidclient.database.tables.EventsTable;
-import com.thebluealliance.androidclient.types.DistrictType;
 import com.thebluealliance.androidclient.listitems.ListItem;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.District;
 import com.thebluealliance.androidclient.renderers.DistrictRenderer;
+import com.thebluealliance.androidclient.types.DistrictType;
+
+import android.database.Cursor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,10 +28,6 @@ public class DistrictListSubscriber extends BaseAPISubscriber<List<District>, Li
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null) {
-            return;
-        }
-
         mDataToBind.clear();
         for (int i = 0; i < mAPIData.size(); i++) {
             District district = mAPIData.get(i);

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictPointsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictPointsListSubscriber.java
@@ -40,11 +40,11 @@ public class DistrictPointsListSubscriber extends BaseAPISubscriber<JsonElement,
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null || !mAPIData.isJsonObject()) {
             return;
         }
 
+        mDataToBind.clear();
         JsonObject rankingsData = mAPIData.getAsJsonObject();
         if (!rankingsData.has("points")) {
             return;

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictPointsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictPointsListSubscriber.java
@@ -40,10 +40,6 @@ public class DistrictPointsListSubscriber extends BaseAPISubscriber<JsonElement,
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null || !mAPIData.isJsonObject()) {
-            return;
-        }
-
         mDataToBind.clear();
         JsonObject rankingsData = mAPIData.getAsJsonObject();
         if (!rankingsData.has("points")) {
@@ -80,6 +76,10 @@ public class DistrictPointsListSubscriber extends BaseAPISubscriber<JsonElement,
             pointBreakdowns.get(i).setRank(i + 1);
             mDataToBind.add(mRenderer.renderFromModel(pointBreakdowns.get(i), null));
         }
+    }
+
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && mAPIData.isJsonObject();
     }
 
     /**

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictRankingsSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictRankingsSubscriber.java
@@ -26,10 +26,11 @@ public class DistrictRankingsSubscriber
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null) {
             return;
         }
+
+        mDataToBind.clear();
         for (int i = 0; i < mAPIData.size(); i++) {
             DistrictTeam districtTeam = mAPIData.get(i);
             Team teamData = mDb.getTeamsTable().get(districtTeam.getTeamKey());

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictRankingsSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/DistrictRankingsSubscriber.java
@@ -1,7 +1,5 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.util.Log;
-
 import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.database.Database;
 import com.thebluealliance.androidclient.listitems.DistrictTeamListElement;
@@ -9,6 +7,8 @@ import com.thebluealliance.androidclient.listitems.ListItem;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.DistrictTeam;
 import com.thebluealliance.androidclient.models.Team;
+
+import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,10 +26,6 @@ public class DistrictRankingsSubscriber
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null) {
-            return;
-        }
-
         mDataToBind.clear();
         for (int i = 0; i < mAPIData.size(); i++) {
             DistrictTeam districtTeam = mAPIData.get(i);

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriber.java
@@ -6,13 +6,18 @@ import com.thebluealliance.androidclient.models.Event;
 
 public class EventInfoSubscriber extends BaseAPISubscriber<Event, Model> {
 
+    public EventInfoSubscriber() {
+        mDataToBind = null;
+    }
+
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind = new Model();
         if (mAPIData == null) {
             // no need to parse Event model
             return;
         }
+
+        mDataToBind = new Model();
         mDataToBind.eventKey = mAPIData.getKey();
         mDataToBind.nameString = mAPIData.getEventName();
         mDataToBind.actionBarTitle = mAPIData.getEventYear() + " " + mAPIData.getEventShortName();

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriber.java
@@ -12,11 +12,6 @@ public class EventInfoSubscriber extends BaseAPISubscriber<Event, Model> {
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null) {
-            // no need to parse Event model
-            return;
-        }
-
         mDataToBind = new Model();
         mDataToBind.eventKey = mAPIData.getKey();
         mDataToBind.nameString = mAPIData.getEventName();

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventListSubscriber.java
@@ -35,10 +35,11 @@ public class EventListSubscriber extends BaseAPISubscriber<List<Event>, List<Lis
 
     @Override
     public void parseData() {
-        mDataToBind.clear();
         if (mAPIData == null) {
             return;
         }
+
+        mDataToBind.clear();
         switch (mRenderMode) {
             case MODE_WEEK:
             default:

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventListSubscriber.java
@@ -35,10 +35,6 @@ public class EventListSubscriber extends BaseAPISubscriber<List<Event>, List<Lis
 
     @Override
     public void parseData() {
-        if (mAPIData == null) {
-            return;
-        }
-
         mDataToBind.clear();
         switch (mRenderMode) {
             case MODE_WEEK:

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriber.java
@@ -25,10 +25,6 @@ public class EventTabSubscriber extends BaseAPISubscriber<List<Event>, List<Even
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null || mAPIData.isEmpty()) {
-            return;
-        }
-
         mDataToBind.clear();
         Collections.sort(mAPIData, mEventComparator);
 
@@ -53,5 +49,9 @@ public class EventTabSubscriber extends BaseAPISubscriber<List<Event>, List<Even
                 lastEventWeek = competitionWeek;
             }
         }
+    }
+
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && !mAPIData.isEmpty();
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriber.java
@@ -25,10 +25,11 @@ public class EventTabSubscriber extends BaseAPISubscriber<List<Event>, List<Even
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null || mAPIData.isEmpty()) {
             return;
         }
+
+        mDataToBind.clear();
         Collections.sort(mAPIData, mEventComparator);
 
         Calendar cal = Calendar.getInstance();

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/FavoriteListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/FavoriteListSubscriber.java
@@ -26,10 +26,11 @@ public class FavoriteListSubscriber extends BaseAPISubscriber<List<Favorite>, Li
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null) {
             return;
         }
+
+        mDataToBind.clear();
         int lastModel = -1;
         Collections.sort(mAPIData, mComparator);
         for (int i = 0; i < mAPIData.size(); i++) {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/FavoriteListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/FavoriteListSubscriber.java
@@ -26,10 +26,6 @@ public class FavoriteListSubscriber extends BaseAPISubscriber<List<Favorite>, Li
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null) {
-            return;
-        }
-
         mDataToBind.clear();
         int lastModel = -1;
         Collections.sort(mAPIData, mComparator);

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchInfoSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchInfoSubscriber.java
@@ -52,9 +52,6 @@ public class MatchInfoSubscriber extends BaseAPISubscriber<Model, List<ListItem>
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null || mAPIData.event == null || mAPIData.match == null) {
-            return;
-        }
         mDataToBind.clear();
 
         mDataToBind.add(mRenderer.renderFromModel(mAPIData.match, MatchRenderer.RENDER_MATCH_INFO));
@@ -72,6 +69,10 @@ public class MatchInfoSubscriber extends BaseAPISubscriber<Model, List<ListItem>
         }
 
         updateActionBarTitle(mAPIData.event.getEventShortName());
+    }
+
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && mAPIData.event != null && mAPIData.match != null;
     }
 
     private void updateActionBarTitle(String eventName) {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchInfoSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchInfoSubscriber.java
@@ -52,10 +52,10 @@ public class MatchInfoSubscriber extends BaseAPISubscriber<Model, List<ListItem>
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null || mAPIData.event == null || mAPIData.match == null) {
             return;
         }
+        mDataToBind.clear();
 
         mDataToBind.add(mRenderer.renderFromModel(mAPIData.match, MatchRenderer.RENDER_MATCH_INFO));
 

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchListSubscriber.java
@@ -1,18 +1,18 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.content.res.Resources;
-
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.comparators.MatchSortByDisplayOrderComparator;
 import com.thebluealliance.androidclient.comparators.MatchSortByPlayOrderComparator;
 import com.thebluealliance.androidclient.database.Database;
 import com.thebluealliance.androidclient.eventbus.EventMatchesEvent;
 import com.thebluealliance.androidclient.eventbus.LiveEventMatchUpdateEvent;
-import com.thebluealliance.androidclient.types.MatchType;
 import com.thebluealliance.androidclient.listitems.ListGroup;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.Event;
 import com.thebluealliance.androidclient.models.Match;
+import com.thebluealliance.androidclient.types.MatchType;
+
+import android.content.res.Resources;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -53,9 +53,6 @@ public class MatchListSubscriber extends BaseAPISubscriber<List<Match>, List<Lis
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null || mAPIData.isEmpty()) {
-            return;
-        }
         mDataToBind.clear();
         mQualMatches.clear();
         mQuarterMatches.clear();
@@ -146,6 +143,10 @@ public class MatchListSubscriber extends BaseAPISubscriber<List<Match>, List<Lis
         }
 
         mEventBus.post(new LiveEventMatchUpdateEvent(lastMatch, nextMatch));
+    }
+
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && !mAPIData.isEmpty();
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchListSubscriber.java
@@ -53,14 +53,14 @@ public class MatchListSubscriber extends BaseAPISubscriber<List<Match>, List<Lis
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
+        if (mAPIData == null || mAPIData.isEmpty()) {
+            return;
+        }
         mDataToBind.clear();
         mQualMatches.clear();
         mQuarterMatches.clear();
         mSemiMatches.clear();
         mFinalMatches.clear();
-        if (mAPIData == null || mAPIData.isEmpty()) {
-            return;
-        }
 
         int[] record = {0, 0, 0}; //wins, losses, ties
         Match nextMatch = null;

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/MediaListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/MediaListSubscriber.java
@@ -1,11 +1,11 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.content.res.Resources;
-
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.listitems.ListGroup;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.Media;
+
+import android.content.res.Resources;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,9 +23,6 @@ public class MediaListSubscriber extends BaseAPISubscriber<List<Media>, List<Lis
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException{
-        if (mAPIData == null) {
-            return;
-        }
         mDataToBind.clear();
         mCdPhotos.clear();
         mYtVideos.clear();

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/MediaListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/MediaListSubscriber.java
@@ -23,12 +23,13 @@ public class MediaListSubscriber extends BaseAPISubscriber<List<Media>, List<Lis
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException{
-        mDataToBind.clear();
-        mCdPhotos.clear();
-        mYtVideos.clear();
         if (mAPIData == null) {
             return;
         }
+        mDataToBind.clear();
+        mCdPhotos.clear();
+        mYtVideos.clear();
+
         for (int i=0; i < mAPIData.size(); i++) {
             Media media = mAPIData.get(i);
             switch (media.getMediaType()) {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriber.java
@@ -32,10 +32,6 @@ public class RankingsListSubscriber extends BaseAPISubscriber<JsonElement, List<
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null || !mAPIData.isJsonArray()) {
-            return;
-        }
-
         mDataToBind.clear();
         JsonArray rankingsData = mAPIData.getAsJsonArray();
         if (rankingsData.size() == 0) return;
@@ -89,6 +85,10 @@ public class RankingsListSubscriber extends BaseAPISubscriber<JsonElement, List<
                             rankingString));
         }
         mEventBus.post(new EventRankingsEvent(generateTopRanksString(rankingsData)));
+    }
+
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && mAPIData.isJsonArray();
     }
 
     private String generateTopRanksString(JsonArray rankingsData) {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/RankingsListSubscriber.java
@@ -32,10 +32,11 @@ public class RankingsListSubscriber extends BaseAPISubscriber<JsonElement, List<
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null || !mAPIData.isJsonArray()) {
             return;
         }
+
+        mDataToBind.clear();
         JsonArray rankingsData = mAPIData.getAsJsonArray();
         if (rankingsData.size() == 0) return;
         JsonArray headerRow = rankingsData.get(0).getAsJsonArray();

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/RecentNotificationsSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/RecentNotificationsSubscriber.java
@@ -28,12 +28,11 @@ public class RecentNotificationsSubscriber extends BaseAPISubscriber<List<Stored
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
-
         if (mAPIData == null || mAPIData.isEmpty()) {
             return;
         }
 
+        mDataToBind.clear();
         for (int i = 0; i < mAPIData.size(); i++) {
             StoredNotification notification = mAPIData.get(i);
             BaseNotification renderable = notification.getNotification(mWriter);

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/RecentNotificationsSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/RecentNotificationsSubscriber.java
@@ -1,7 +1,5 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.util.Log;
-
 import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.database.DatabaseWriter;
 import com.thebluealliance.androidclient.eventbus.NotificationsUpdatedEvent;
@@ -9,6 +7,8 @@ import com.thebluealliance.androidclient.gcm.notifications.BaseNotification;
 import com.thebluealliance.androidclient.listitems.ListItem;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.StoredNotification;
+
+import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,10 +28,6 @@ public class RecentNotificationsSubscriber extends BaseAPISubscriber<List<Stored
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null || mAPIData.isEmpty()) {
-            return;
-        }
-
         mDataToBind.clear();
         for (int i = 0; i < mAPIData.size(); i++) {
             StoredNotification notification = mAPIData.get(i);
@@ -41,6 +37,10 @@ public class RecentNotificationsSubscriber extends BaseAPISubscriber<List<Stored
                 mDataToBind.add(renderable);
             }
         }
+    }
+
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && !mAPIData.isEmpty();
     }
 
     /**

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/StatsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/StatsListSubscriber.java
@@ -1,9 +1,8 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.content.res.Resources;
-
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.comparators.StatListElementComparator;
 import com.thebluealliance.androidclient.database.Database;
@@ -13,6 +12,8 @@ import com.thebluealliance.androidclient.listitems.StatsListElement;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.Stat;
 import com.thebluealliance.androidclient.models.Team;
+
+import android.content.res.Resources;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,12 +43,6 @@ public class StatsListSubscriber extends BaseAPISubscriber<JsonElement, List<Lis
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null ||
-          !mAPIData.isJsonObject()) {
-
-            return;
-        }
-
         mDataToBind.clear();
         JsonObject statsData = mAPIData.getAsJsonObject();
         if (!statsData.has("oprs") || !statsData.get("oprs").isJsonObject() ||
@@ -84,6 +79,10 @@ public class StatsListSubscriber extends BaseAPISubscriber<JsonElement, List<Lis
         }
         Collections.sort(mDataToBind, new StatListElementComparator(mStatToSortBy));
         mEventBus.post(new EventStatsEvent(getTopStatsString()));
+    }
+
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && mAPIData.isJsonObject();
     }
 
     private String getTopStatsString() {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/StatsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/StatsListSubscriber.java
@@ -42,13 +42,13 @@ public class StatsListSubscriber extends BaseAPISubscriber<JsonElement, List<Lis
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null ||
           !mAPIData.isJsonObject()) {
 
             return;
         }
 
+        mDataToBind.clear();
         JsonObject statsData = mAPIData.getAsJsonObject();
         if (!statsData.has("oprs") || !statsData.get("oprs").isJsonObject() ||
           !statsData.has("dprs") ||!statsData.get("dprs").isJsonObject() ||

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/SubscriptionListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/SubscriptionListSubscriber.java
@@ -27,10 +27,6 @@ public class SubscriptionListSubscriber
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null) {
-            return;
-        }
-
         mDataToBind.clear();
         Collections.sort(mAPIData, mComparator);
         int lastModel = -1;

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/SubscriptionListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/SubscriptionListSubscriber.java
@@ -27,11 +27,11 @@ public class SubscriptionListSubscriber
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null) {
             return;
         }
 
+        mDataToBind.clear();
         Collections.sort(mAPIData, mComparator);
         int lastModel = -1;
         for (int i = 0; i < mAPIData.size(); i++) {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictBreakdownSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictBreakdownSubscriber.java
@@ -1,9 +1,8 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.content.res.Resources;
-
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+
 import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.database.Database;
 import com.thebluealliance.androidclient.listitems.ListGroup;
@@ -11,6 +10,8 @@ import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.DistrictPointBreakdown;
 import com.thebluealliance.androidclient.models.DistrictTeam;
 import com.thebluealliance.androidclient.models.Event;
+
+import android.content.res.Resources;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,10 +34,6 @@ public class TeamAtDistrictBreakdownSubscriber
 
     @Override
     public synchronized void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null) {
-            return;
-        }
-
         mDataToBind.clear();
         Map<String, JsonObject> eventBreakdowns =
           Utilities.getMapForPlatform(String.class, JsonObject.class);

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictBreakdownSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictBreakdownSubscriber.java
@@ -33,10 +33,11 @@ public class TeamAtDistrictBreakdownSubscriber
 
     @Override
     public synchronized void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null) {
             return;
         }
+
+        mDataToBind.clear();
         Map<String, JsonObject> eventBreakdowns =
           Utilities.getMapForPlatform(String.class, JsonObject.class);
         JsonObject rawDistrictTeam = mGson.fromJson(mAPIData.getJson(), JsonObject.class);

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictSummarySubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictSummarySubscriber.java
@@ -1,7 +1,5 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.content.res.Resources;
-
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.database.Database;
@@ -14,6 +12,8 @@ import com.thebluealliance.androidclient.listitems.ListItem;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.DistrictTeam;
 import com.thebluealliance.androidclient.models.Event;
+
+import android.content.res.Resources;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,10 +47,6 @@ public class TeamAtDistrictSummarySubscriber
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null) {
-            return;
-        }
-
         mDataToBind.clear();
         EventsTable eventsTable = mDb.getEventsTable();
         mDataToBind.add(new LabelValueListItem(mResources.getString(R.string.district_point_rank),

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictSummarySubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictSummarySubscriber.java
@@ -47,11 +47,11 @@ public class TeamAtDistrictSummarySubscriber
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null) {
             return;
         }
 
+        mDataToBind.clear();
         EventsTable eventsTable = mDb.getEventsTable();
         mDataToBind.add(new LabelValueListItem(mResources.getString(R.string.district_point_rank),
           mAPIData.getRank() + Utilities.getOrdinalFor(mAPIData.getRank())));

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtEventSummarySubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtEventSummarySubscriber.java
@@ -64,12 +64,12 @@ public class TeamAtEventSummarySubscriber extends BaseAPISubscriber<Model, List<
 
     @Override
     public synchronized void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (!mIsMatchListLoaded || mAPIData == null ||
           mAPIData.event == null || mAPIData.teamAtEventRank == null) {
             return;
         }
 
+        mDataToBind.clear();
         Match nextMatch = null, lastMatch = null;
         Collections.sort(mMatches, new MatchSortByPlayOrderComparator());
 

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtEventSummarySubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtEventSummarySubscriber.java
@@ -1,9 +1,7 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.content.res.Resources;
-import android.util.Log;
-
 import com.google.gson.JsonArray;
+
 import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
@@ -20,6 +18,9 @@ import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.Event;
 import com.thebluealliance.androidclient.models.Match;
 import com.thebluealliance.androidclient.renderers.MatchRenderer;
+
+import android.content.res.Resources;
+import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,11 +65,6 @@ public class TeamAtEventSummarySubscriber extends BaseAPISubscriber<Model, List<
 
     @Override
     public synchronized void parseData() throws BasicModel.FieldNotDefinedException {
-        if (!mIsMatchListLoaded || mAPIData == null ||
-          mAPIData.event == null || mAPIData.teamAtEventRank == null) {
-            return;
-        }
-
         mDataToBind.clear();
         Match nextMatch = null, lastMatch = null;
         Collections.sort(mMatches, new MatchSortByPlayOrderComparator());
@@ -199,6 +195,11 @@ public class TeamAtEventSummarySubscriber extends BaseAPISubscriber<Model, List<
 
     }
 
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && mIsMatchListLoaded && mAPIData.event != null
+                && mAPIData.teamAtEventRank != null;
+    }
+
     /**
      * Load matches for team@event
      * Posted by {@link com.thebluealliance.androidclient.fragments.event.EventMatchesFragment}
@@ -211,8 +212,10 @@ public class TeamAtEventSummarySubscriber extends BaseAPISubscriber<Model, List<
         mIsMatchListLoaded = true;
         mMatches = new ArrayList<>(matches.getMatches());
         try {
-            parseData();
-            bindData();
+            if (isDataValid()) {
+                parseData();
+                bindData();
+            }
         } catch (BasicModel.FieldNotDefinedException e) {
             e.printStackTrace();
         }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamInfoSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamInfoSubscriber.java
@@ -7,13 +7,17 @@ import com.thebluealliance.androidclient.models.Team;
 
 public class TeamInfoSubscriber extends BaseAPISubscriber<Team, TeamInfoBinder.Model>{
 
+    public TeamInfoSubscriber() {
+        mDataToBind = null;
+    }
+
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException{
-        mDataToBind = new TeamInfoBinder.Model();
         if (mAPIData == null) {
             return;
         }
 
+        mDataToBind = new TeamInfoBinder.Model();
         mDataToBind.teamKey = mAPIData.getKey();
         mDataToBind.fullName = mAPIData.getFullName();
         mDataToBind.nickname = mAPIData.getNickname();

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamInfoSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamInfoSubscriber.java
@@ -13,10 +13,6 @@ public class TeamInfoSubscriber extends BaseAPISubscriber<Team, TeamInfoBinder.M
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException{
-        if (mAPIData == null) {
-            return;
-        }
-
         mDataToBind = new TeamInfoBinder.Model();
         mDataToBind.teamKey = mAPIData.getKey();
         mDataToBind.fullName = mAPIData.getFullName();

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamListSubscriber.java
@@ -31,10 +31,6 @@ public class TeamListSubscriber extends BaseAPISubscriber<List<Team>, List<ListI
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null) {
-            return;
-        }
-
         mDataToBind.clear();
         Collections.sort(mAPIData, mComparator);
         for (int i=0; i < mAPIData.size(); i++) {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamListSubscriber.java
@@ -31,10 +31,11 @@ public class TeamListSubscriber extends BaseAPISubscriber<List<Team>, List<ListI
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null) {
             return;
         }
+
+        mDataToBind.clear();
         Collections.sort(mAPIData, mComparator);
         for (int i=0; i < mAPIData.size(); i++) {
             Team team = mAPIData.get(i);

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamStatsSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamStatsSubscriber.java
@@ -1,14 +1,15 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.content.res.Resources;
-
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.listitems.LabelValueListItem;
 import com.thebluealliance.androidclient.listitems.ListItem;
 import com.thebluealliance.androidclient.models.BasicModel;
 import com.thebluealliance.androidclient.models.Stat;
+
+import android.content.res.Resources;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,10 +26,6 @@ public class TeamStatsSubscriber extends BaseAPISubscriber<JsonElement, List<Lis
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null || !mAPIData.isJsonObject()) {
-            return;
-        }
-
         mDataToBind.clear();
         JsonObject statsData = mAPIData.getAsJsonObject();
         if (statsData.has("opr")) {
@@ -46,5 +43,9 @@ public class TeamStatsSubscriber extends BaseAPISubscriber<JsonElement, List<Lis
               mResources.getString(R.string.ccwm_no_colon),
               Stat.displayFormat.format(statsData.get("ccwm").getAsDouble())));
         }
+    }
+
+    @Override public boolean isDataValid() {
+        return super.isDataValid() && mAPIData.isJsonObject();
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamStatsSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamStatsSubscriber.java
@@ -25,10 +25,11 @@ public class TeamStatsSubscriber extends BaseAPISubscriber<JsonElement, List<Lis
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null || !mAPIData.isJsonObject()) {
             return;
         }
+
+        mDataToBind.clear();
         JsonObject statsData = mAPIData.getAsJsonObject();
         if (statsData.has("opr")) {
             mDataToBind.add(new LabelValueListItem(

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/WebcastListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/WebcastListSubscriber.java
@@ -24,10 +24,11 @@ public class WebcastListSubscriber extends BaseAPISubscriber<List<Event>, List<L
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        mDataToBind.clear();
         if (mAPIData == null) {
             return;
         }
+        
+        mDataToBind.clear();
         Collections.sort(mAPIData, mComparator);
 
         for (int i = 0; i < mAPIData.size(); i++) {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/WebcastListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/WebcastListSubscriber.java
@@ -24,10 +24,6 @@ public class WebcastListSubscriber extends BaseAPISubscriber<List<Event>, List<L
 
     @Override
     public void parseData() throws BasicModel.FieldNotDefinedException {
-        if (mAPIData == null) {
-            return;
-        }
-        
         mDataToBind.clear();
         Collections.sort(mAPIData, mComparator);
 

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriber.java
@@ -21,9 +21,6 @@ public class YearsParticipatedDropdownSubscriber implements Action1<JsonArray> {
 
     @Override
     public void call(JsonArray apiYears) {
-        if (apiYears == null) {
-            return;
-        }
         int[] years = new int[apiYears.size()];
         for (int i = apiYears.size() - 1; i >= 0; i--) {
             years[i] = apiYears.get(i).getAsInt();

--- a/android/src/test/java/com/thebluealliance/androidclient/datafeed/framework/SubscriberTestController.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/datafeed/framework/SubscriberTestController.java
@@ -52,7 +52,9 @@ public class SubscriberTestController<API, VIEW> {
 
     public SubscriberTestController<API, VIEW> parse() throws BasicModel.FieldNotDefinedException {
         checkPreconditions();
-        mSubscriber.parseData();
+        if (mSubscriber.isDataValid()) {
+            mSubscriber.parseData();
+        }
         hasParsed = true;
         return this;
     }

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriberTest.java
@@ -29,7 +29,7 @@ public class YearsParticipatedDropdownSubscriberTest {
         mYearsParticipated = ModelMaker.getModel(JsonArray.class, "frc1124_years_participated");
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testParseNullData() {
         mSubscriber.call(null);
     }


### PR DESCRIPTION
If the first time it executes goes successfully and we generate some
data to bind, but the second time has some error (like the server side
erroring), keep the old data. Only clear when we know we have something
to replace it with

Fixes #551

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/554)
<!-- Reviewable:end -->
