### PR TITLE
Fixes #552

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/RecentNotificationsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/RecentNotificationsFragment.java
@@ -1,6 +1,13 @@
 package com.thebluealliance.androidclient.fragments;
 
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
 import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.database.Database;
 import com.thebluealliance.androidclient.models.NoDataViewParams;
 import com.thebluealliance.androidclient.models.StoredNotification;
@@ -22,6 +29,29 @@ public class RecentNotificationsFragment
     @Override
     protected void inject() {
         mComponent.inject(this);
+    }
+
+    /**
+     * The recent notifications list has to render things a little differently than the normal list.
+     * Specifically, we need to remove the dividers between items, adjust the padding, and disable
+     * clip-to-padding so that the list's content can scroll beneath the padding. To avoid having
+     * to special-case a subclass of DatafeedFragment and inflate a different view, we'll simply
+     * override all this stuff programmatically!
+     *
+     * @param view The View returned by {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}.
+     * @param savedInstanceState If non-null, this fragment is being re-constructed
+     * from a previous saved state as given here.
+     */
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        int pBottom, pLeft, pRight;
+        pBottom = mListView.getPaddingBottom();
+        pLeft = mListView.getPaddingLeft();
+        pRight = mListView.getPaddingRight();
+        mListView.setPadding(pLeft, Utilities.getPixelsFromDp(getContext(), 8), pRight, pBottom);
+        mListView.setDivider(null);
+        mListView.setDividerHeight(0);
+        mListView.setClipToPadding(false);
     }
 
     @Override


### PR DESCRIPTION
Makes the Recent Notifications list pretty again. Instead of defining the necessary stuff in XML, we just override it programmatically to avoid having to create another subclass of DatafeedFragment. Yay code reuse!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/556)
<!-- Reviewable:end -->
