### PR TITLE
Updated py script formatting and naming for consistency

### DIFF
--- a/scripts/test_notification.py
+++ b/scripts/test_notification.py
@@ -179,14 +179,18 @@ def ping_command(data=ping_sample):
 def broadcast_command(data=ping_sample):
     notify('broadcast', data)
 
+
 sync_status_sample = {}
-def status_sync_command(data=sync_status_sample):
+
+def sync_status_command(data=sync_status_sample):
     notify('sync_status', data)
+
 
 event_down_sample = {
     "event_key": "2015cthar",
     "event_name": "Hartford"
 }
+
 def event_down_command(data=event_down_sample):
     notify('event_down', data)
 

--- a/scripts/test_notification.py
+++ b/scripts/test_notification.py
@@ -170,13 +170,26 @@ def district_points_updated_command(data=district_points_updated_sample):
 
 ping_sample = {
     "title": "TBA Test Message",
-    "desc": "This is a test message ensuring your device can receive push messages from The Blue Alliance"
+    "desc": "This is a test message ensuring your device can receive push messages from The Blue Alliance",
+    "url": "https://www.youtube.com/watch?v=RpSgUrsghv4"
 }
 
-def ping_command(data=ping_sample):
+def ping_command(data=ping_sample, url="", no_url=False):
+    if url:
+        data["url"] = url
+
+    if no_url:
+        del data["url"]
+        
     notify('ping', data)
 
 def broadcast_command(data=ping_sample):
+    if url:
+        data["url"] = url
+
+    if no_url:
+        del data["url"]
+
     notify('broadcast', data)
 
 

--- a/scripts/test_notification.py
+++ b/scripts/test_notification.py
@@ -183,7 +183,7 @@ def ping_command(data=ping_sample, url="", no_url=False):
         
     notify('ping', data)
 
-def broadcast_command(data=ping_sample):
+def broadcast_command(data=ping_sample, url="", no_url=False):
     if url:
         data["url"] = url
 


### PR DESCRIPTION
I was working with the python scripts a bit when my OCD kicked in and I decided to make naming and formatting more consistent.

I also ended up adding some additional options to the `ping` and `broadcast` commands to make it easier to test them with different URLs or without a URL at all. The URL has a nice default.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/558)
<!-- Reviewable:end -->
