### PR TITLE
Enable generic URLs for ping/broadcast notifications

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/Utilities.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/Utilities.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -127,6 +128,15 @@ public class Utilities {
     public static Intent getIntentForTBAUrl(Context c, Uri data) {
         Log.d(Constants.LOG_TAG, "Uri: " + data.toString());
         List<String> urlParts = data.getPathSegments();
+
+        // Check if this is actually a TBA URL
+        // Simply checks if the host matches (*.)thebluealliance.com
+        String tbaHostPattern = "(.*\\.?)thebluealliance.com";
+        Pattern pattern = Pattern.compile(tbaHostPattern);
+        if (!pattern.matcher(data.getHost()).matches()) {
+            return null;
+        }
+
         Intent intent = null;
         if (urlParts != null) {
             if (urlParts.isEmpty()) {
@@ -412,7 +422,7 @@ public class Utilities {
      * On API 23+, this allows us to set the color of the status bar icons (either light or dark)
      * to look better with the status bar background. If the background is light, the icons will be
      * tinted gray/black; otherwise, they will be the default white.
-     *
+     * <p>
      * This is safe to be called from any API level, as this method checks the API level before
      * trying to use the new feature.
      *

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/GenericNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/GenericNotification.java
@@ -64,8 +64,19 @@ public class GenericNotification extends BaseNotification {
         if (jsonData.has(URL)) {
             Uri uri = Uri.parse(jsonData.get(URL).getAsString());
             Intent launch = Utilities.getIntentForTBAUrl(context, uri);
+            if (launch == null) {
+                // The URI didn't match anything that TBA can process
+                // Pass off the URI to a general View intent
+                launch = new Intent(Intent.ACTION_VIEW, uri);
+
+            }
             launch.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            intent = PendingIntent.getActivity(context, 0, launch, 0);
+            if (launch.resolveActivity(context.getPackageManager()) != null) {
+                intent = PendingIntent.getActivity(context, 0, launch, 0);
+            } else {
+                // Nothing can process this URI, pretend it doesn't exist and go on our merry way
+                intent = null;
+            }
         } else {
             Intent launch = RecentNotificationsActivity.newInstance(context);
             intent = PendingIntent.getActivity(context, getNotificationId(), launch, 0);


### PR DESCRIPTION
If for some reason we want to direct users to a non-TBA URL via a ping or broadcast notification, we can now do that! This simply passes off any URL not in the thebluealliance.com domain to a generic View intent, which will fire off the approriate app/browser.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/559)
<!-- Reviewable:end -->
