### PR TITLE
Fixes #544 (lists scroll to top

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/adapters/ExpandableListViewAdapter.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/adapters/ExpandableListViewAdapter.java
@@ -16,30 +16,27 @@ import java.util.List;
 
 public class ExpandableListViewAdapter extends BaseExpandableListAdapter {
 
-    public final List<ListGroup> groups;
-    public LayoutInflater inflater;
+    public final List<ListGroup> mGroups;
+    public LayoutInflater mInflater;
     public Activity mActivity;
 
     private boolean mIsChildSelectable = true;
     protected ModelRendererSupplier mRendererSupplier;
 
     public ExpandableListViewAdapter() {
-        groups = new ArrayList<>();
+        mGroups = new ArrayList<>();
     }
 
-    public ExpandableListViewAdapter(
-      Activity activity,
-      ModelRendererSupplier supplier,
-      List<ListGroup> groups) {
+    public ExpandableListViewAdapter(Activity activity, ModelRendererSupplier supplier, List<ListGroup> groups) {
         mActivity = activity;
         mRendererSupplier = supplier;
-        this.groups = groups;
-        inflater = activity.getLayoutInflater();
+        mGroups = groups;
+        mInflater = activity.getLayoutInflater();
     }
 
     @Override
     public Object getChild(int groupPosition, int childPosition) {
-        return groups.get(groupPosition).children.get(childPosition);
+        return mGroups.get(groupPosition).children.get(childPosition);
     }
 
     @Override
@@ -49,27 +46,35 @@ public class ExpandableListViewAdapter extends BaseExpandableListAdapter {
 
     @Override
     public int getChildrenCount(int groupPosition) {
-        if (groups == null || groups.get(groupPosition) == null)
+        if (mGroups == null || mGroups.get(groupPosition) == null)
             return 0;
-        return groups.get(groupPosition).children.size();
+        return mGroups.get(groupPosition).children.size();
     }
 
     @Override
     public Object getGroup(int groupPosition) {
-        return groups.get(groupPosition);
+        return mGroups.get(groupPosition);
     }
 
     public void addGroup(int position, ListGroup group) {
-        groups.add(position, group);
+        mGroups.add(position, group);
     }
 
     public void addGroup(ListGroup group) {
-        groups.add(group);
+        mGroups.add(group);
+    }
+
+    public void addAllGroups(List<ListGroup> groups) {
+        mGroups.addAll(groups);
+    }
+
+    public void removeAllGroups() {
+        mGroups.clear();
     }
 
     @Override
     public int getGroupCount() {
-        return groups.size();
+        return mGroups.size();
     }
 
     @Override
@@ -90,7 +95,7 @@ public class ExpandableListViewAdapter extends BaseExpandableListAdapter {
     @Override
     public View getGroupView(int groupPosition, boolean isExpanded, View convertView, ViewGroup parent) {
         if (convertView == null) {
-            convertView = inflater.inflate(R.layout.expandable_list_group, null);
+            convertView = mInflater.inflate(R.layout.expandable_list_group, null);
         }
         ListGroup group = (ListGroup) getGroup(groupPosition);
         ((TextView) convertView.findViewById(R.id.group_name)).setText(group.string);
@@ -114,8 +119,8 @@ public class ExpandableListViewAdapter extends BaseExpandableListAdapter {
 
     @Override
     public View getChildView(int groupPosition, int childPosition, boolean isLastChild, View convertView, ViewGroup parent) {
-        return groups.get(groupPosition).children.get(childPosition)
-          .render(mRendererSupplier).getView(mActivity, inflater, convertView);
+        return mGroups.get(groupPosition).children.get(childPosition)
+                .render(mRendererSupplier).getView(mActivity, mInflater, convertView);
     }
 }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/adapters/MatchListAdapter.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/adapters/MatchListAdapter.java
@@ -34,15 +34,15 @@ public class MatchListAdapter extends ExpandableListViewAdapter {
 
     @Override
     public View getChildView(int groupPosition, int childPosition, boolean isLastChild, View convertView, ViewGroup parent) {
-        RenderableModel child = groups.get(groupPosition).children.get(childPosition);
+        RenderableModel child = mGroups.get(groupPosition).children.get(childPosition);
         if (child instanceof Match) {
             ((Match) child).setSelectedTeam(mTeamKey);
         }
         ListItem renderedChild = child.render(mRendererSupplier);
         if (renderedChild != null) {
-            return renderedChild.getView(mActivity, inflater, convertView);
+            return renderedChild.getView(mActivity, mInflater, convertView);
         } else {
-            return new LabelValueListItem("Match", "Unable to render").getView(mActivity, inflater, convertView);
+            return new LabelValueListItem("Match", "Unable to render").getView(mActivity, mInflater, convertView);
         }
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/ExpandableListViewBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/ExpandableListViewBinder.java
@@ -5,7 +5,6 @@ import android.util.Log;
 import android.view.View;
 import android.widget.ProgressBar;
 
-import com.google.common.collect.ImmutableList;
 import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.adapters.ExpandableListViewAdapter;
@@ -13,6 +12,7 @@ import com.thebluealliance.androidclient.listitems.ListGroup;
 import com.thebluealliance.androidclient.renderers.ModelRendererSupplier;
 import com.thebluealliance.androidclient.views.ExpandableListView;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -31,8 +31,7 @@ public class ExpandableListViewBinder extends AbstractDataBinder<List<ListGroup>
     @Bind(R.id.expandable_list) ExpandableListView expandableListView;
     @Bind(R.id.progress) ProgressBar progressBar;
 
-    //public ExpandableListView expandableListView;
-    //public ProgressBar progressBar;
+    private ExpandableListViewAdapter mAdapter;
 
     private short mExpandMode;
     protected ModelRendererSupplier mRendererSupplier;
@@ -65,9 +64,15 @@ public class ExpandableListViewBinder extends AbstractDataBinder<List<ListGroup>
             return;
         }
 
-        ExpandableListViewAdapter adapter = newAdapter(ImmutableList.copyOf(data));
-        expandableListView.setAdapter(adapter);
-        adapter.notifyDataSetChanged();
+        if (mAdapter == null) {
+            mAdapter = newAdapter(new ArrayList<>(data));
+            expandableListView.setAdapter(mAdapter);
+        } else {
+            mAdapter.removeAllGroups();
+            mAdapter.addAllGroups(new ArrayList<>(data));
+            mAdapter.notifyDataSetChanged();
+        }
+
         expandableListView.setVisibility(View.VISIBLE);
         expandForMode(data);
 
@@ -75,7 +80,6 @@ public class ExpandableListViewBinder extends AbstractDataBinder<List<ListGroup>
             progressBar.setVisibility(View.GONE);
         }
 
-        expandableListView.setVisibility(View.VISIBLE);
         mNoDataBinder.unbindData();
         setDataBound(true);
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/ListViewBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/ListViewBinder.java
@@ -11,6 +11,7 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.adapters.ListViewAdapter;
 import com.thebluealliance.androidclient.listitems.ListItem;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import butterknife.Bind;
@@ -43,11 +44,11 @@ public class ListViewBinder extends AbstractDataBinder<List<ListItem>> {
         long startTime = System.currentTimeMillis();
         Log.d(Constants.LOG_TAG, "BINDING DATA");
         if (mAdapter == null) {
-            mAdapter = newAdapter(data);
+            mAdapter = newAdapter(new ArrayList<>(data));
             listView.setAdapter(mAdapter);
         } else {
             mAdapter.clear();
-            mAdapter.addAll(data);
+            mAdapter.addAll(new ArrayList<>(data));
             mAdapter.notifyDataSetChanged();
         }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/ListViewBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/ListViewBinder.java
@@ -11,7 +11,6 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.adapters.ListViewAdapter;
 import com.thebluealliance.androidclient.listitems.ListItem;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import butterknife.Bind;
@@ -19,8 +18,12 @@ import butterknife.ButterKnife;
 
 public class ListViewBinder extends AbstractDataBinder<List<ListItem>> {
 
-    @Bind(R.id.list) ListView listView;
-    @Bind(R.id.progress) ProgressBar progressBar;
+    @Bind(R.id.list)
+    ListView listView;
+    @Bind(R.id.progress)
+    ProgressBar progressBar;
+
+    ListViewAdapter mAdapter;
 
     @Override
     public void bindViews() {
@@ -39,9 +42,14 @@ public class ListViewBinder extends AbstractDataBinder<List<ListItem>> {
         }
         long startTime = System.currentTimeMillis();
         Log.d(Constants.LOG_TAG, "BINDING DATA");
-        ListViewAdapter adapter = newAdapter(new ArrayList<>(data));
-        listView.setAdapter(adapter);
-        adapter.notifyDataSetChanged();
+        if (mAdapter == null) {
+            mAdapter = newAdapter(data);
+            listView.setAdapter(mAdapter);
+        } else {
+            mAdapter.clear();
+            mAdapter.addAll(data);
+            mAdapter.notifyDataSetChanged();
+        }
 
         if (progressBar != null) {
             progressBar.setVisibility(View.GONE);

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
@@ -1,11 +1,11 @@
 package com.thebluealliance.androidclient.binders;
 
-import com.thebluealliance.androidclient.adapters.TeamListFragmentPagerAdapter;
-import com.thebluealliance.androidclient.views.SlidingTabs;
-
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.view.ViewPager;
+
+import com.thebluealliance.androidclient.adapters.TeamListFragmentPagerAdapter;
+import com.thebluealliance.androidclient.views.SlidingTabs;
 
 import javax.inject.Inject;
 
@@ -16,6 +16,8 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
     public ViewPager viewPager;
     public SlidingTabs tabs;
     public FragmentManager fragmentManager;
+
+    private Integer oldData;
 
     private int mInitialTab;
 
@@ -31,6 +33,10 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
 
     @Override
     public void updateData(@Nullable Integer data) {
+        if (data != null && oldData != null && data.equals(oldData)) {
+            // No need to update anything
+            return;
+        }
         /**
          * Fix for really strange bug. Menu bar items wouldn't appear only when navigated to from 'Events' in the nav drawer
          * Bug is some derivation of this: https://code.google.com/p/android/issues/detail?id=29472
@@ -41,6 +47,8 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
             tabs.setViewPager(viewPager);
             viewPager.setCurrentItem(mInitialTab);
         });
+
+        oldData = data;
     }
 
     @Override


### PR DESCRIPTION
As best as I can tell, this fixes #544. The fix ended up relating to how data was bound to lists. We used to create a new adapter every time we got new data; setting that new adapter to the list would wipe any scroll state the list had. Now, we reuse the existing adapter, swap in the new data, and tell the adapter its data has changed. The system handles the rest, and everyone is happy.

Also fixes a related bug where the main teams list would reset to the top of the first tab whenever it was resumed. This is also caused by swapping in a new adapter when none is needed. Now, a new adapter is only created a) on the first data update, and b) if the number of tabs changes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/566)
<!-- Reviewable:end -->
