### PR TITLE
Show Team Number in Event Top OPRs

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/eventbus/EventStatsEvent.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/eventbus/EventStatsEvent.java
@@ -12,4 +12,12 @@ public class EventStatsEvent {
     public String getStatString() {
         return mTopStatString;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return o != null
+                && o instanceof EventStatsEvent
+                && (((EventStatsEvent) o).getStatString() == null && getStatString() == null
+                    || ((EventStatsEvent) o).getStatString().equals(getStatString()));
+    }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/listitems/StatsListElement.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/listitems/StatsListElement.java
@@ -1,12 +1,12 @@
 package com.thebluealliance.androidclient.listitems;
 
+import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.models.Stat;
+
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
-
-import com.thebluealliance.androidclient.R;
-import com.thebluealliance.androidclient.models.Stat;
 
 public class StatsListElement extends ListElement {
 
@@ -85,6 +85,10 @@ public class StatsListElement extends ListElement {
 
     public String getFormattedCcwm() {
         return Stat.displayFormat.format(ccwm);
+    }
+
+    public String getTeamNumberString() {
+        return String.format("Team %1$s", teamNumber);
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/StatsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/StatsListSubscriber.java
@@ -89,7 +89,8 @@ public class StatsListSubscriber extends BaseAPISubscriber<JsonElement, List<Lis
         String statsString = "";
         for (int i = 0; i < Math.min(EventStatsEvent.SIZE, mDataToBind.size()); i++) {
             String opr = ((StatsListElement)mDataToBind.get(i)).getFormattedOpr();
-            statsString += (i + 1) + ". <b>" + opr + "</b>";
+            String teamName = ((StatsListElement)mDataToBind.get(i)).getTeamNumberString();
+            statsString += (i + 1) + ". " + teamName + " - <b>" + opr + "</b>";
             if (i < Math.min(EventStatsEvent.SIZE, mDataToBind.size()) - 1) {
                 statsString += "<br>";
             }

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/StatsListSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/StatsListSubscriberTest.java
@@ -1,8 +1,7 @@
 package com.thebluealliance.androidclient.subscribers;
 
-import android.content.res.Resources;
-
 import com.google.gson.JsonObject;
+
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.database.Database;
 import com.thebluealliance.androidclient.database.DatabaseMocker;
@@ -21,12 +20,14 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import android.content.res.Resources;
+
 import java.util.List;
 
 import de.greenrobot.event.EventBus;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +61,7 @@ public class StatsListSubscriberTest {
     @Test
     public void testSimpleBinding() throws BasicModel.FieldNotDefinedException {
         DatafeedTestDriver.testSimpleParsing(mSubscriber, mStats);
-        verify(mEventBus).post(any(EventStatsEvent.class));
+        verify(mEventBus).post(eq(new EventStatsEvent("1. Team 195 - <b>87.96</b>")));
     }
 
     @Test


### PR DESCRIPTION
Also updates test coverage to make sure we're posting the right string
to the eventbus :)

All better...
![screenshot_20160222-220907](https://cloud.githubusercontent.com/assets/2754863/13240598/dce39910-d9b1-11e5-8968-9f036abe6295.png)


Fixes #568

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/570)
<!-- Reviewable:end -->
