### PR TITLE
Rebind ButterKnife after parent activity stop

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/binders/ListViewBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/ListViewBinder.java
@@ -1,15 +1,15 @@
 package com.thebluealliance.androidclient.binders;
 
+import com.thebluealliance.androidclient.Constants;
+import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.adapters.ListViewAdapter;
+import com.thebluealliance.androidclient.listitems.ListItem;
+
 import android.support.annotation.Nullable;
 import android.util.Log;
 import android.view.View;
 import android.widget.ListView;
 import android.widget.ProgressBar;
-
-import com.thebluealliance.androidclient.Constants;
-import com.thebluealliance.androidclient.R;
-import com.thebluealliance.androidclient.adapters.ListViewAdapter;
-import com.thebluealliance.androidclient.listitems.ListItem;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,10 +19,8 @@ import butterknife.ButterKnife;
 
 public class ListViewBinder extends AbstractDataBinder<List<ListItem>> {
 
-    @Bind(R.id.list)
-    ListView listView;
-    @Bind(R.id.progress)
-    ProgressBar progressBar;
+    @Bind(R.id.list) ListView listView;
+    @Bind(R.id.progress) ProgressBar progressBar;
 
     ListViewAdapter mAdapter;
 

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/DatafeedFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/DatafeedFragment.java
@@ -1,9 +1,7 @@
 package com.thebluealliance.androidclient.fragments;
 
-import android.os.Bundle;
-import android.support.v4.app.Fragment;
-
 import com.google.android.gms.analytics.Tracker;
+
 import com.thebluealliance.androidclient.binders.AbstractDataBinder;
 import com.thebluealliance.androidclient.binders.NoDataBinder;
 import com.thebluealliance.androidclient.datafeed.CacheableDatafeed;
@@ -11,12 +9,15 @@ import com.thebluealliance.androidclient.datafeed.refresh.RefreshController;
 import com.thebluealliance.androidclient.datafeed.refresh.RefreshController.RefreshType;
 import com.thebluealliance.androidclient.datafeed.refresh.Refreshable;
 import com.thebluealliance.androidclient.datafeed.retrofit.APIv2;
-import com.thebluealliance.androidclient.models.NoDataViewParams;
-import com.thebluealliance.androidclient.subscribers.SubscriberModule;
 import com.thebluealliance.androidclient.di.components.FragmentComponent;
 import com.thebluealliance.androidclient.di.components.HasFragmentComponent;
+import com.thebluealliance.androidclient.models.NoDataViewParams;
 import com.thebluealliance.androidclient.subscribers.BaseAPISubscriber;
 import com.thebluealliance.androidclient.subscribers.EventBusSubscriber;
+import com.thebluealliance.androidclient.subscribers.SubscriberModule;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
 
 import javax.inject.Inject;
 
@@ -87,6 +88,13 @@ public abstract class DatafeedFragment
             if (shouldRegisterSubscriberToEventBus()) {
                 mEventBus.unregister(mSubscriber);
             }
+        }
+    }
+
+    @Override public void onStop() {
+        super.onStop();
+        if (mSubscriber != null) {
+            mSubscriber.onParentStop();
         }
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/BaseAPISubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/BaseAPISubscriber.java
@@ -11,6 +11,7 @@ import com.thebluealliance.androidclient.helpers.AnalyticsHelper;
 import com.thebluealliance.androidclient.models.BasicModel;
 
 import android.support.annotation.Nullable;
+import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
 import android.support.annotation.WorkerThread;
 import android.util.Log;
@@ -88,6 +89,11 @@ public abstract class BaseAPISubscriber<APIType, BindType>
         if (refreshType == RefreshController.REQUESTED_BY_USER) {
             sendRefreshUpdate();
         }
+    }
+
+    @UiThread
+    public void onParentStop() {
+        hasBinderBoundViews = false;
     }
 
     @Override


### PR DESCRIPTION
It seems like that references to views in the binder were going away
after leaving/coming back to the screen, so it's probably the framework
recreating instances.

BaseAPISubscriber.hasBinderBound is sticky, we we want to reset it when
the parent fragment is stopped so we rebind ButterKnife (and potentially
do other things in the future) if/when we come back.

Fixes #565

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/571)
<!-- Reviewable:end -->
