### PR TITLE
Realigns text on the "info" pages to the 72dp keyline

### DIFF
--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -56,10 +56,12 @@
         <item name="android:textColor">@color/secondary_text_color</item>
     </style>
 
+    <!-- marginLeft is (72dp - 8dp) to account for the fact that this view is always wrapped
+    in a card with a left margin of 8dp; this keeps text aligned to the 72dp keyline -->
     <style name="InfoItemTextStyle">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_marginLeft">72dp</item>
+        <item name="android:layout_marginLeft">64dp</item>
         <item name="android:textSize">16sp</item>
         <item name="android:layout_alignParentLeft">true</item>
         <item name="android:layout_centerVertical">true</item>
@@ -73,10 +75,12 @@
         <item name="android:layout_centerVertical">true</item>
     </style>
 
+    <!-- marginLeft is (72dp - 8dp) to account for the fact that this view is always wrapped
+    in a card with a left margin of 8dp; this keeps things aligned to the 72dp keyline -->
     <style name="InfoItemDividerStyle">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_marginLeft">72dp</item>
+        <item name="android:layout_marginLeft">64dp</item>
         <item name="android:background">?android:attr/listDivider</item>
     </style>
 


### PR DESCRIPTION
When I wrapped the team info stuff in cards, I forgot to account for the 8dp margin around the cards. This PR realigns the text in the cards with the 72dp keyline, because #materialyolo

Before:
![Imgur](http://i.imgur.com/FL1wQJbl.png)

After:
![Imgur](http://i.imgur.com/KloZCVCl.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/573)
<!-- Reviewable:end -->
