### PR TITLE
Fix buffering for Firebase tickers

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/FirebaseTickerFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/FirebaseTickerFragment.java
@@ -93,6 +93,7 @@ public abstract class FirebaseTickerFragment extends Fragment implements Action1
                 .filter(childEvent -> childEvent != null && childEvent.eventType == FirebaseChildType.CHILD_ADDED)
                 .map(childEvent1 -> childEvent1.snapshot.getValue(FirebaseNotification.class))
                 .buffer(5, TimeUnit.SECONDS, 5)
+                .filter(itemList -> itemList != null && !itemList.isEmpty())
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this, throwable -> {
@@ -328,6 +329,9 @@ public abstract class FirebaseTickerFragment extends Fragment implements Action1
     }
 
     public void call(List<FirebaseNotification> firebaseNotifications) {
+        if (firebaseNotifications.isEmpty()) {
+            return;
+        }
         mChildHasBeenAdded = true;
         mProgressBar.setVisibility(View.GONE);
         for (FirebaseNotification firebaseNotification : firebaseNotifications) {


### PR DESCRIPTION
If the ticker contains fewer elements than the existing buffer size,
then it'll hang forever waiting for enough items to come through and
fill the buffer.

Buffering is requried since we're pushing items into the Observable at
"for loop" speed, so we need to be able to slow down the processing (see
ResumableRxFirebase).

This now puts a time limit on the buffers, see
http://reactivex.io/RxJava/javadoc/rx/Observable.html#buffer%28long,%20java.util.concurrent.TimeUnit,%20int%29

The main downside is the onNext callback is executed every `period` of
time (with empty data). This commit has it at every 5 seconds - also the
max initial loading time. Not sure what the perf implications are.

Can some other people test this out before I merge and see if it affects
perf? It seems like it does to me, but I'm not sure if that's
confirmation bias now that I'm looking for it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/578)
<!-- Reviewable:end -->
