### PR TITLE
Fix auto week tab selection

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/HomeActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/HomeActivity.java
@@ -171,7 +171,9 @@ public class HomeActivity extends DatafeedActivity implements HasFragmentCompone
         switch (id) {
             default:
             case R.id.nav_item_events:
-                int weekTab = savedInstanceState != null ? savedInstanceState.getInt(EventsByWeekFragment.TAB, 0) : 0;
+                int weekTab = savedInstanceState != null
+                        ? savedInstanceState.getInt(EventsByWeekFragment.TAB, -1)
+                        : -1;
                 fragment = EventsByWeekFragment.newInstance(mMaxCompYear - mCurrentSelectedYearPosition, weekTab);
                 break;
             case R.id.nav_item_districts:

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/EventTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/EventTabBinder.java
@@ -1,9 +1,9 @@
 package com.thebluealliance.androidclient.binders;
 
-import android.support.annotation.Nullable;
-
 import com.thebluealliance.androidclient.fragments.EventsByWeekFragment;
 import com.thebluealliance.androidclient.models.EventWeekTab;
+
+import android.support.annotation.Nullable;
 
 import java.util.List;
 
@@ -20,7 +20,7 @@ public class EventTabBinder extends AbstractDataBinder<List<EventWeekTab>> {
 
     @Override
     public void updateData(@Nullable List<EventWeekTab> data) {
-        if (data != null && !data.equals(mTabs)) {
+        if (data != null && !data.isEmpty() && !data.equals(mTabs)) {
             mTabs = data;
             mFragment.updateLabels(mTabs);
         }

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/EventsByWeekFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/EventsByWeekFragment.java
@@ -1,15 +1,7 @@
 package com.thebluealliance.androidclient.fragments;
 
-import android.os.Bundle;
-import android.os.Parcelable;
-import android.support.v4.view.ViewCompat;
-import android.support.v4.view.ViewPager;
-import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-
 import com.google.common.base.Preconditions;
+
 import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
@@ -21,6 +13,15 @@ import com.thebluealliance.androidclient.models.Event;
 import com.thebluealliance.androidclient.models.EventWeekTab;
 import com.thebluealliance.androidclient.subscribers.EventTabSubscriber;
 import com.thebluealliance.androidclient.views.SlidingTabs;
+
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.view.ViewPager;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
 
 import java.util.List;
 
@@ -65,10 +66,13 @@ public class EventsByWeekFragment
         super.onCreate(savedInstanceState);
         Log.d(Constants.LOG_TAG, "EventsByWeekFragment created!");
         mYear = mStatusController.getMaxCompYear();
+        mSelectedTab = -1;
         if (getArguments() != null) {
             // Default to the current year if no year is provided in the arguments
             mYear = getArguments().getInt(YEAR, mStatusController.getMaxCompYear());
             mSelectedTab = getArguments().getInt(TAB, -1);
+        } else if (savedInstanceState != null && savedInstanceState.containsKey(TAB)) {
+            mSelectedTab = savedInstanceState.getInt(TAB);
         }
         mBinder.setFragment(this);
     }
@@ -134,12 +138,16 @@ public class EventsByWeekFragment
         if (mPagerState != null) {
             mViewPager.onRestoreInstanceState(mPagerState);
             mFragmentAdapter.restoreState(mAdapterState, ClassLoader.getSystemClassLoader());
+        } else if (mSelectedTab != -1) {
+            mViewPager.setCurrentItem(mSelectedTab);
+            mFragmentBinder.onPageSelected(mSelectedTab);
         } else {
             setPagerWeek();
-        }
-        if (mSelectedTab != -1) {
             mViewPager.setCurrentItem(mSelectedTab);
+            mFragmentBinder.onPageSelected(mSelectedTab);
         }
+
+
 
         mFragmentAdapter.setAutoBindOnceAtPosition(mViewPager.getCurrentItem(), true);
     }
@@ -172,14 +180,11 @@ public class EventsByWeekFragment
         int weekCount = mViewPager.getAdapter().getCount();
 
         if (currentYear != mYear && week1Index > -1) {
-            mViewPager.setCurrentItem(week1Index);
-            mFragmentBinder.onPageSelected(week1Index);
+            mSelectedTab = week1Index;
         } else if (currentIndex < weekCount && currentIndex > -1) {
-            mViewPager.setCurrentItem(currentIndex);
-            mFragmentBinder.onPageSelected(currentIndex);
+            mSelectedTab = currentIndex;
         } else {
-            mViewPager.setCurrentItem(0);
-            mFragmentBinder.onPageSelected(0);
+            mSelectedTab = 0;
         }
     }
 


### PR DESCRIPTION
HomeActivity was always telling us to start at tab 0 even when we
weren't restoring instance state. Instead, tell to start at -1, which we
can then use to determine ourselves which tab is for the current week

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/579)
<!-- Reviewable:end -->
