### PR TITLE
Major improvement to performance

### DIFF
--- a/android/src/main/res/layout/list_view_with_spinner.xml
+++ b/android/src/main/res/layout/list_view_with_spinner.xml
@@ -12,8 +12,8 @@
 
         <ListView
             android:id="@+id/list"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content" />
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
 
         <ProgressBar
             android:id="@+id/progress"


### PR DESCRIPTION
Long story short, if a `ListView` isn't absolutely sized (e.g. size specified in dps or `match_parent`), it has to call `getView()` on all the items in the list view several times to properly determine its size, which is actually really expensive. By telling the `ListView` how big it should be in terms of its parent view, we cut that down a lot, which makes things much more performant. Yay!

Measuring jank is hard, so I don't have any numbers to prove this improves the UX, but a great way to see this in action is to swipe really fast through the 2016 event tabs in this branch and compare it to prod. At least on my N5, the difference was remarkable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/584)
<!-- Reviewable:end -->
