### PR TITLE
Add onError to YearsParticipatedDropdwnSubscriber

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/binders/EventTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/EventTabBinder.java
@@ -1,9 +1,11 @@
 package com.thebluealliance.androidclient.binders;
 
+import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.fragments.EventsByWeekFragment;
 import com.thebluealliance.androidclient.models.EventWeekTab;
 
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import java.util.List;
 
@@ -46,6 +48,7 @@ public class EventTabBinder extends AbstractDataBinder<List<EventWeekTab>> {
 
     @Override
     public void onError(Throwable throwable) {
-
+        Log.e(Constants.LOG_TAG, "Error fetching event years");
+        throwable.printStackTrace();
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriber.java
@@ -1,16 +1,20 @@
 package com.thebluealliance.androidclient.subscribers;
 
 import com.google.gson.JsonArray;
+
+import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.interfaces.YearsParticipatedUpdate;
+
+import android.util.Log;
 
 import java.util.Arrays;
 
 import javax.inject.Inject;
 
+import rx.Subscriber;
 import rx.android.schedulers.AndroidSchedulers;
-import rx.functions.Action1;
 
-public class YearsParticipatedDropdownSubscriber implements Action1<JsonArray> {
+public class YearsParticipatedDropdownSubscriber extends Subscriber<JsonArray> {
 
     private final YearsParticipatedUpdate mCallback;
 
@@ -20,7 +24,18 @@ public class YearsParticipatedDropdownSubscriber implements Action1<JsonArray> {
     }
 
     @Override
-    public void call(JsonArray apiYears) {
+    public void onCompleted() {
+
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        Log.e(Constants.LOG_TAG, "Error fetching team years");
+        e.printStackTrace();
+    }
+
+    @Override
+    public void onNext(JsonArray apiYears) {
         int[] years = new int[apiYears.size()];
         for (int i = apiYears.size() - 1; i >= 0; i--) {
             years[i] = apiYears.get(i).getAsInt();

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/YearsParticipatedDropdownSubscriberTest.java
@@ -31,13 +31,13 @@ public class YearsParticipatedDropdownSubscriberTest {
 
     @Test(expected = NullPointerException.class)
     public void testParseNullData() {
-        mSubscriber.call(null);
+        mSubscriber.onNext(null);
     }
 
     @Test
     public void testParsedData() {
         int[] expected = {2015, 2014, 2013, 2012};
-        mSubscriber.call(mYearsParticipated);
+        mSubscriber.onNext(mYearsParticipated);
         verify(mCallback).updateYearsParticipated(expected);
     }
 }


### PR DESCRIPTION
Otherwise, when we have network errors, an
OnErrorNotImplementedException will be thrown, which we don't want.

Fixes #589

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/594)
<!-- Reviewable:end -->
