### PR TITLE
Fix team@event summary captain bug

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtEventSummarySubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtEventSummarySubscriber.java
@@ -88,7 +88,7 @@ public class TeamAtEventSummarySubscriber extends BaseAPISubscriber<Model, List<
 
         // Search for team in alliances
         JsonArray alliances = event.getAlliances();
-        int allianceNumber = 0, alliancePick = 0;
+        int allianceNumber = 0, alliancePick = -1;
 
         if (alliances == null || alliances.size() == 0) {
             // We don't have alliance data. Try to determine from matches.


### PR DESCRIPTION
We would erronously report every member of an alliance as the captian
when we don't have alliance data. This is because we set the wrong
default. Meh.

Fixes #605

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/612)
<!-- Reviewable:end -->
