### PR TITLE
Fixed issue with Firebase memory

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -250,7 +250,7 @@ dependencies {
     compile 'de.hdodenhof:circleimageview:1.3.0'
     compile 'com.facebook.stetho:stetho:1.1.1'
     compile 'com.facebook.stetho:stetho-okhttp:1.1.1'
-    compile 'com.firebase:firebase-client-android:2.3.1'
+    compile 'com.firebase:firebase-client-android:2.5.2'
     compile "io.reactivex:rxandroid:${rxJavaVersion}"
     compile 'io.reactivex:rxjava-math:1.0.0'
     compile 'me.relex:circleindicator:1.1.5@aar'

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/DatafeedModule.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/DatafeedModule.java
@@ -11,10 +11,12 @@ import com.thebluealliance.androidclient.database.DatabaseWriter;
 import com.thebluealliance.androidclient.datafeed.maps.RetrofitResponseMap;
 import com.thebluealliance.androidclient.datafeed.refresh.RefreshController;
 import com.thebluealliance.androidclient.datafeed.retrofit.APIv2;
+import com.thebluealliance.androidclient.datafeed.retrofit.FirebaseAPI;
 import com.thebluealliance.androidclient.datafeed.retrofit.GitHubAPI;
 import com.thebluealliance.androidclient.datafeed.retrofit.LenientGsonConverterFactory;
 import com.thebluealliance.androidclient.datafeed.status.TBAStatusController;
 import com.thebluealliance.androidclient.di.TBAAndroidModule;
+import com.thebluealliance.androidclient.fragments.FirebaseTickerFragment;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -55,6 +57,17 @@ public class DatafeedModule {
                 .build();
     }
 
+    @Provides @Singleton @Named("firebase_retrofit")
+    public Retrofit provideFirebaseRetrofit(Context context, Gson gson, OkHttpClient okHttpClient) {
+        String firebaseUrl = Utilities.readLocalProperty(context, "firebase.url", FirebaseTickerFragment.FIREBASE_URL_DEFAULT);
+        return new Retrofit.Builder()
+                .baseUrl(firebaseUrl)
+                .client(okHttpClient)
+                .addConverterFactory(LenientGsonConverterFactory.create(gson))
+                .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+                .build();
+    }
+
     @Provides @Singleton @Named("tba_api")
     public APIv2 provideTBAAPI(@Named("tba_retrofit") Retrofit retrofit) {
         return retrofit.create(APIv2.class);
@@ -63,6 +76,11 @@ public class DatafeedModule {
     @Provides @Singleton @Named("github_api")
     public GitHubAPI provideGitHubAPI(@Named("github_retrofit") Retrofit retrofit) {
         return retrofit.create(GitHubAPI.class);
+    }
+
+    @Provides @Singleton @Named("firebase_api")
+    public FirebaseAPI provideFirebaseAPI(@Named("firebase_retrofit") Retrofit retrofit) {
+        return retrofit.create(FirebaseAPI.class);
     }
 
 

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/retrofit/FirebaseAPI.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/retrofit/FirebaseAPI.java
@@ -1,0 +1,13 @@
+package com.thebluealliance.androidclient.datafeed.retrofit;
+
+import com.google.gson.JsonElement;
+
+import retrofit.http.GET;
+import retrofit.http.Path;
+import rx.Observable;
+
+public interface FirebaseAPI {
+
+    @GET("/{nodePath}.json?limitToLast=1&orderBy=\"$key\"")
+    Observable<JsonElement> getOneItemFromNode(@Path("nodePath") String node);
+}

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/FirebaseTickerFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/FirebaseTickerFragment.java
@@ -1,5 +1,7 @@
 package com.thebluealliance.androidclient.fragments;
 
+import com.google.gson.JsonObject;
+
 import com.firebase.client.DataSnapshot;
 import com.firebase.client.Firebase;
 import com.firebase.client.FirebaseError;
@@ -9,6 +11,7 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.adapters.ListViewAdapter;
 import com.thebluealliance.androidclient.database.DatabaseWriter;
+import com.thebluealliance.androidclient.datafeed.retrofit.FirebaseAPI;
 import com.thebluealliance.androidclient.di.components.FragmentComponent;
 import com.thebluealliance.androidclient.di.components.HasFragmentComponent;
 import com.thebluealliance.androidclient.firebase.FirebaseChildType;
@@ -38,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
@@ -46,11 +50,19 @@ import rx.schedulers.Schedulers;
 
 public abstract class FirebaseTickerFragment extends Fragment implements Action1<List<FirebaseNotification>>, View.OnClickListener {
 
-    private static final String FIREBASE_URL_DEFAULT = "https://thebluealliance.firebaseio.com/";
-    private static final int FIREBASE_LOAD_DEPTH_DEFAULT = 25;
+    public static final String FIREBASE_URL_DEFAULT = "https://thebluealliance.firebaseio.com/";
+    public static final int FIREBASE_LOAD_DEPTH_DEFAULT = 25;
 
+    private enum FirebaseChildNodesState {
+        LOADING,
+        HAS_CHILDREN,
+        NO_CHILDREN
+    }
+
+    @Inject DatabaseWriter mWriter;
     @Inject
-    DatabaseWriter mWriter;
+    @Named("firebase_api")
+    FirebaseAPI mFirebaseApi;
 
     private ListView mListView;
     private ListView mFilterListView;
@@ -61,13 +73,14 @@ public abstract class FirebaseTickerFragment extends Fragment implements Action1
     private Parcelable mListState;
     private int mFirstVisiblePosition;
     private List<FirebaseNotification> mAllNotifications = new ArrayList<>();
+    private boolean mAreFilteredNotificationsVisible = false;
     private ResumeableRxFirebase mFirebaseSubscriber;
 
     private TextView leftButton, rightButton;
     private Set<String> enabledNotifications;
     private boolean filterListShowing;
 
-    private boolean mChildHasBeenAdded = false;
+    private FirebaseChildNodesState mChildNodeState = FirebaseChildNodesState.LOADING;
     private String mFirebaseUrl;
     private int mFirebaseLoadDepth;
 
@@ -105,30 +118,26 @@ public abstract class FirebaseTickerFragment extends Fragment implements Action1
                     mNoDataView.setVisibility(View.VISIBLE);
                     mNoDataView.setText(R.string.firebase_no_matching_items);
                 });
+
         Firebase.setAndroidContext(getActivity());
         Firebase ticker = new Firebase(mFirebaseUrl);
-        ticker.limitToLast(mFirebaseLoadDepth).addChildEventListener(mFirebaseSubscriber);
-        ticker.addValueEventListener(new ValueEventListener() {
-            @Override
-            public void onDataChange(DataSnapshot dataSnapshot) {
-                if (dataSnapshot.getChildrenCount() == 0) {
-                    mNoDataView.setVisibility(View.VISIBLE);
-                    mNoDataView.setText(R.string.firebase_empty_ticker);
-                    mListView.setVisibility(View.GONE);
-                    mProgressBar.setVisibility(View.GONE);
-                } else {
-                    mNoDataView.setVisibility(View.GONE);
-                }
-            }
+        ticker.orderByKey().limitToLast(mFirebaseLoadDepth).addChildEventListener(mFirebaseSubscriber);
 
-            @Override
-            public void onCancelled(FirebaseError firebaseError) {
-                mNoDataView.setVisibility(View.VISIBLE);
-                mNoDataView.setText(R.string.firebase_error);
-                mListView.setVisibility(View.GONE);
-                mProgressBar.setVisibility(View.GONE);
-            }
-        });
+        mFirebaseApi.getOneItemFromNode(getFirebaseUrlSuffix())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(result -> {
+                    if (result.isJsonNull()) {
+                        mChildNodeState = FirebaseChildNodesState.NO_CHILDREN;
+                    } else if (result.isJsonObject()) {
+                        if (((JsonObject) result).entrySet().size() > 0) {
+                            mChildNodeState = FirebaseChildNodesState.HAS_CHILDREN;
+                        } else {
+                            mChildNodeState = FirebaseChildNodesState.NO_CHILDREN;
+                        }
+                    }
+                    updateViewVisibility();
+                });
 
         filterListShowing = false;
     }
@@ -153,10 +162,7 @@ public abstract class FirebaseTickerFragment extends Fragment implements Action1
 
         mListView = (ListView) v.findViewById(R.id.list);
         mProgressBar = (ProgressBar) v.findViewById(R.id.progress);
-        if (mChildHasBeenAdded) {
-            // If view is being recreated and a child has been added, hide the progress bar
-            mProgressBar.setVisibility(View.GONE);
-        }
+        updateViewVisibility();
 
         if (mNotificationsAdapter != null) {
             mListView.setAdapter(mNotificationsAdapter);
@@ -171,6 +177,39 @@ public abstract class FirebaseTickerFragment extends Fragment implements Action1
         setUpFilterListViews();
 
         return v;
+    }
+
+    private void updateViewVisibility() {
+        if (mAllNotifications.size() > 0) {
+            if (mAreFilteredNotificationsVisible) {
+                // We've received at least one notification from the client library, and it's
+                // visible with the current applied filter. Show the list!
+                mListView.setVisibility(View.VISIBLE);
+                mProgressBar.setVisibility(View.GONE);
+                mNoDataView.setVisibility(View.GONE);
+            } else {
+                // We've received at least one notification from the client library, but no
+                // notification are visible with the current applied filter. Show the no data view,
+                // but with a special "none found with that filter" message
+                mListView.setVisibility(View.GONE);
+                mProgressBar.setVisibility(View.GONE);
+                mNoDataView.setVisibility(View.VISIBLE);
+                mNoDataView.setText(R.string.firebase_no_matching_items);
+            }
+        } else if (mChildNodeState == FirebaseChildNodesState.NO_CHILDREN) {
+            // We've received the result of the REST call to the server and the list is (at least
+            // for now) definitely empty. Show the no data view
+            mListView.setVisibility(View.GONE);
+            mProgressBar.setVisibility(View.GONE);
+            mNoDataView.setVisibility(View.VISIBLE);
+            mNoDataView.setText(R.string.firebase_empty_ticker);
+        } else {
+            // We haven't yet received any notifications from the client library, but we also
+            // aren't certain that the list is empty. Show the spinner.
+            mListView.setVisibility(View.GONE);
+            mProgressBar.setVisibility(View.VISIBLE);
+            mNoDataView.setVisibility(View.GONE);
+        }
     }
 
     @Override
@@ -288,31 +327,22 @@ public abstract class FirebaseTickerFragment extends Fragment implements Action1
                 .toList()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(notificationsList -> {
+                    mAreFilteredNotificationsVisible = !notificationsList.isEmpty();
+
                     if (!FirebaseTickerFragment.this.isResumed() || getView() == null) {
                         return;
                     }
-                    if (notificationsList.isEmpty()) {
-                        // Show the "none found" warning
-                        mProgressBar.setVisibility(View.GONE);
-                        mListView.setVisibility(View.GONE);
-                        mNoDataView.setVisibility(View.VISIBLE);
-                        mNoDataView.setText(R.string.firebase_no_matching_items);
-                    } else {
-                        mNotificationsAdapter.values.clear();
-                        mNotificationsAdapter.values.addAll(notificationsList);
-                        mNotificationsAdapter.notifyDataSetChanged();
-                        mListView.setVisibility(View.VISIBLE);
-                        mNoDataView.setVisibility(View.GONE);
-                        mProgressBar.setVisibility(View.GONE);
-                    }
+
+                    mNotificationsAdapter.clear();
+                    mNotificationsAdapter.addAll(notificationsList);
+                    mNotificationsAdapter.notifyDataSetChanged();
+                    updateViewVisibility();
                 }, throwable -> {
                     Log.e(Constants.LOG_TAG, "Firebase error");
                     throwable.printStackTrace();
                     // Show the "none found" warning
-                    mProgressBar.setVisibility(View.GONE);
-                    mListView.setVisibility(View.GONE);
-                    mNoDataView.setVisibility(View.VISIBLE);
-                    mNoDataView.setText(R.string.firebase_no_matching_items);
+                    mAreFilteredNotificationsVisible = false;
+                    updateViewVisibility();
                 });
     }
 
@@ -332,12 +362,12 @@ public abstract class FirebaseTickerFragment extends Fragment implements Action1
         if (firebaseNotifications.isEmpty()) {
             return;
         }
-        mChildHasBeenAdded = true;
-        mProgressBar.setVisibility(View.GONE);
+
         for (FirebaseNotification firebaseNotification : firebaseNotifications) {
             firebaseNotification.setDatabaseWriter(mWriter);
             mAllNotifications.add(0, firebaseNotification);
         }
+
         updateList();
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/FirebaseTickerFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/FirebaseTickerFragment.java
@@ -60,9 +60,7 @@ public abstract class FirebaseTickerFragment extends Fragment implements Action1
     }
 
     @Inject DatabaseWriter mWriter;
-    @Inject
-    @Named("firebase_api")
-    FirebaseAPI mFirebaseApi;
+    @Inject @Named("firebase_api") FirebaseAPI mFirebaseApi;
 
     private ListView mListView;
     private ListView mFilterListView;

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:2.1.0-alpha1'
         classpath 'me.tatarka:gradle-retrolambda:3.2.2'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
 


### PR DESCRIPTION
With the way things were being done before, we were accidentally loading the entire Firebase notifications node into memory, which, because of how much data there was, resulted in ~170MB of allocations, not to mention a whole lot of data use. We had to load the whole node to count how many notifications there were so we could decide if we should show the "ticker empty" message or not.

We now use Firebase's REST API to attempt to fetch a single record from the target node. If that record does not exist, we know that we need to show the no data view. That network call has pretty low overhead (2-4KB response, 50-200ms to complete, according to Postman). This results in things loading and displaying much faster.

This does not solve the issue of the UI lagging when the ticker list is being displayed; that's caused entirely by rendering the notification list items themselves.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/622)
<!-- Reviewable:end -->
