### PR TITLE
Added null check for menu item in RefreshController

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/refresh/RefreshController.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/refresh/RefreshController.java
@@ -18,10 +18,9 @@ import javax.inject.Singleton;
 /**
  * Provides an easy way to manage a collection of {@link Refreshable} objects. {@link Refreshable}
  * objects should register themselves with this class; they will receive callbacks when a refresh
- * is
- * requested. Additionally, they can push their current state (refreshing or not) into this class.
- * This allows us to determine if any registered objects are currently refreshing and take the
- * appropriate action.
+ * is requested. Additionally, they can push their current state (refreshing or not) into this
+ * class. This allows us to determine if any registered objects are currently refreshing and take
+ * the appropriate action.
  * <p>
  * The primary way this class will be used is to work with a {@link MenuItem} that controls
  * refreshing. When you bind a {@link RefreshController} to a {@link MenuItem} with the {@link
@@ -29,8 +28,7 @@ import javax.inject.Singleton;
  * registered {@link Refreshable}s and replace the item's action view with a progress indicator and
  * revert the icon to its normal state when the refresh is finished. And, as long as you proxy
  * {@link android.app.Activity#onOptionsItemSelected(MenuItem)} calls through to this class, it
- * will
- * automatically start a refresh when the bound {@link MenuItem} is clicked.
+ * will automatically start a refresh when the bound {@link MenuItem} is clicked.
  */
 @Singleton
 public class RefreshController {
@@ -40,8 +38,7 @@ public class RefreshController {
      */
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({REQUESTED_BY_USER, NOT_REQUESTED_BY_USER})
-    public @interface RefreshType {
-    }
+    public @interface RefreshType {}
 
     public static final int REQUESTED_BY_USER = 0;
     public static final int NOT_REQUESTED_BY_USER = 1;
@@ -97,8 +94,7 @@ public class RefreshController {
     /**
      * Calls to {@link android.app.Activity#onOptionsItemSelected(MenuItem)} should be proxied
      * through to this method if you want to take advantage of automatically starting a refresh
-     * when
-     * the bound {@link MenuItem} is clicked.
+     * when the bound {@link MenuItem} is clicked.
      *
      * @param menuItem the {@link MenuItem} that was clicked.
      * @return true if the click was handled, false otherwise

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/refresh/RefreshController.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/refresh/RefreshController.java
@@ -17,7 +17,8 @@ import javax.inject.Singleton;
 
 /**
  * Provides an easy way to manage a collection of {@link Refreshable} objects. {@link Refreshable}
- * objects should register themselves with this class; they will receive callbacks when a refresh is
+ * objects should register themselves with this class; they will receive callbacks when a refresh
+ * is
  * requested. Additionally, they can push their current state (refreshing or not) into this class.
  * This allows us to determine if any registered objects are currently refreshing and take the
  * appropriate action.
@@ -27,7 +28,8 @@ import javax.inject.Singleton;
  * RefreshController#bindToMenuItem(MenuItem)} method, this class will monitor the state of its
  * registered {@link Refreshable}s and replace the item's action view with a progress indicator and
  * revert the icon to its normal state when the refresh is finished. And, as long as you proxy
- * {@link android.app.Activity#onOptionsItemSelected(MenuItem)} calls through to this class, it will
+ * {@link android.app.Activity#onOptionsItemSelected(MenuItem)} calls through to this class, it
+ * will
  * automatically start a refresh when the bound {@link MenuItem} is clicked.
  */
 @Singleton
@@ -38,7 +40,9 @@ public class RefreshController {
      */
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({REQUESTED_BY_USER, NOT_REQUESTED_BY_USER})
-    public @interface RefreshType {}
+    public @interface RefreshType {
+    }
+
     public static final int REQUESTED_BY_USER = 0;
     public static final int NOT_REQUESTED_BY_USER = 1;
 
@@ -92,13 +96,17 @@ public class RefreshController {
 
     /**
      * Calls to {@link android.app.Activity#onOptionsItemSelected(MenuItem)} should be proxied
-     * through to this method if you want to take advantage of automatically starting a refresh when
+     * through to this method if you want to take advantage of automatically starting a refresh
+     * when
      * the bound {@link MenuItem} is clicked.
      *
      * @param menuItem the {@link MenuItem} that was clicked.
      * @return true if the click was handled, false otherwise
      */
     public boolean onOptionsItemSelected(MenuItem menuItem) {
+        if (mMenuItem == null) {
+            return false;
+        }
         if (menuItem.getItemId() == mMenuItem.getItemId()) {
             // Refresh button clicked, start refresh
             startRefresh(REQUESTED_BY_USER);
@@ -126,7 +134,7 @@ public class RefreshController {
             return;
         }
         mIsRefreshing = true;
-        for (RefreshWrapper wrapper: mRefreshableStates.values()) {
+        for (RefreshWrapper wrapper : mRefreshableStates.values()) {
             Refreshable refreshable = wrapper.getRefreshable();
             if (refreshable != null) {
                 refreshable.onRefreshStart(refreshType);
@@ -136,10 +144,11 @@ public class RefreshController {
 
     /**
      * Called to notify this class that a {@link Refreshable}'s refreshing state has changed. Note
-     * that this will also register the {@link Refreshable} for future refresh start callbacks if it
+     * that this will also register the {@link Refreshable} for future refresh start callbacks if
+     * it
      * was not already registered.
      *
-     * @param refreshKey the String linking to the {@link Refreshable} object being updated
+     * @param refreshKey   the String linking to the {@link Refreshable} object being updated
      * @param isRefreshing true if the {@link Refreshable} is currently refreshing, false if it is
      *                     not
      */
@@ -180,7 +189,7 @@ public class RefreshController {
     @UiThread
     private boolean updateRefreshingState() {
         Collection<RefreshWrapper> refreshingStates = mRefreshableStates.values();
-        for (RefreshWrapper wrapper: refreshingStates) {
+        for (RefreshWrapper wrapper : refreshingStates) {
             if (wrapper.getRefreshState()) {
                 mIsRefreshing = true;
                 return true;

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/refresh/RefreshController.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/refresh/RefreshController.java
@@ -141,8 +141,7 @@ public class RefreshController {
     /**
      * Called to notify this class that a {@link Refreshable}'s refreshing state has changed. Note
      * that this will also register the {@link Refreshable} for future refresh start callbacks if
-     * it
-     * was not already registered.
+     * it was not already registered.
      *
      * @param refreshKey   the String linking to the {@link Refreshable} object being updated
      * @param isRefreshing true if the {@link Refreshable} is currently refreshing, false if it is


### PR DESCRIPTION
`HomeActivity` would crash if you clicked a menu item while refreshing was disabled (and the refresh menu item didn't exist).

Fixes #624

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/626)
<!-- Reviewable:end -->
