### PR TITLE
Fixed issue caused by using an API 21+ method on all versions

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/Utilities.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/Utilities.java
@@ -361,12 +361,19 @@ public class Utilities {
             }
 
             if (beBold.apply(name.toString())) {
-                result.append(name, new StyleSpan(Typeface.BOLD), 0);
+                supportAppend(result, name, new StyleSpan(Typeface.BOLD), 0);
             } else {
                 result.append(name);
             }
         }
         return result;
+    }
+
+    private static SpannableStringBuilder supportAppend(SpannableStringBuilder builder, CharSequence text, Object what, int flags) {
+        int start = builder.length();
+        builder.append(text);
+        builder.setSpan(what, start, builder.length(), flags);
+        return builder;
     }
 
     final protected static char[] hexArray = "0123456789ABCDEF".toCharArray();


### PR DESCRIPTION
If a pre-Lollipop devices receives a notification with a team that should be bolded, the app will crash from calling a method (`SpannableStringBuilder.append(CharSequence, Object, int)`) that's API 21+ only. That method is really just a convenient wrapper for some other methods, so I copied that method's source into our project, and that version is used instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/627)
<!-- Reviewable:end -->
