### PR TITLE
Set okhttp user agent to 'gzip'

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/APIv2RequestInterceptor.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/APIv2RequestInterceptor.java
@@ -23,7 +23,8 @@ public class APIv2RequestInterceptor implements Interceptor {
         Log.d(Constants.LOG_TAG, "FETCHING " + url);
 
         Request.Builder newRequestBuilder = originalRequest.newBuilder()
-          .addHeader("X-TBA-App-Id", Constants.getApiHeader());
+            .addHeader("X-TBA-App-Id", Constants.getApiHeader())
+            .addHeader("User-Agent", "gzip");  // App engine seems to be unhappy with OkHttp's User Agent. https://cloud.google.com/appengine/kb/#compression
 
         // If we've specified via a header that we want to force from cache/web, build the
         // proper CacheControl header to send with the requests


### PR DESCRIPTION
Doing this forces App Engine to serve gzipped content. See https://cloud.google.com/appengine/kb/#compression

Personally I think it's weird that GAE checks both the User Agent and Accept-Encoding headers, but I read somewhere that their reasoning for doing so is because some clients improperly put gzip in the Accept-Encoding header even if it can't understand it, so it chooses to be extra safe with gzip.

Before:
![image](https://cloud.githubusercontent.com/assets/1421884/13726851/2c0edcd0-e8a7-11e5-992c-751e3c9fe90a.png)

After:
![image](https://cloud.githubusercontent.com/assets/1421884/13726855/31fee6b2-e8a7-11e5-80f1-d2b6898b3595.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/628)
<!-- Reviewable:end -->
