### PR TITLE
Set custom user agent with gzip for GAE

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/Constants.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/Constants.java
@@ -36,6 +36,10 @@ public class Constants {
         return "the-blue-alliance:android:v" + BuildConfig.VERSION_NAME.replace(":", "");  // X-TBA-App-Id must have exactly 3 semicolons
     }
 
+    public static String getUserAgent() {
+        return "The Blue Alliance Android v" + BuildConfig.VERSION_NAME;
+    }
+
     //the week of the year that each event starts competition on, starting with 1992
     //this is the nth week beginning in the given year
     public static final int[] FIRST_COMP_WEEK =

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/APIv2RequestInterceptor.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/APIv2RequestInterceptor.java
@@ -24,7 +24,7 @@ public class APIv2RequestInterceptor implements Interceptor {
 
         Request.Builder newRequestBuilder = originalRequest.newBuilder()
             .addHeader("X-TBA-App-Id", Constants.getApiHeader())
-            .addHeader("User-Agent", "gzip");  // App engine seems to be unhappy with OkHttp's User Agent. https://cloud.google.com/appengine/kb/#compression
+            .addHeader("User-Agent", Constants.getUserAgent() + " (gzip)");  // Include 'gzip' to force App Engine to serve gzipped content. https://cloud.google.com/appengine/kb/#compression
 
         // If we've specified via a header that we want to force from cache/web, build the
         // proper CacheControl header to send with the requests


### PR DESCRIPTION
Seems like 'gzip' only needs to be present in the user agent. Related to #628.
I put a partial user agent generated using the app's version name in constants, and then append '(gzip)' to the end of it in the request interceptor. Is that appropriate? Is that a decent user agent name?

http://googleappsdeveloper.blogspot.com/2011/12/optimizing-bandwidth-usage-with-gzip.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/629)
<!-- Reviewable:end -->
