### PR TITLE
Tweak No Data binding logic

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/binders/ExpandableListViewBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/ExpandableListViewBinder.java
@@ -1,16 +1,16 @@
 package com.thebluealliance.androidclient.binders;
 
-import android.support.annotation.Nullable;
-import android.util.Log;
-import android.view.View;
-import android.widget.ProgressBar;
-
 import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.adapters.ExpandableListViewAdapter;
 import com.thebluealliance.androidclient.listitems.ListGroup;
 import com.thebluealliance.androidclient.renderers.ModelRendererSupplier;
 import com.thebluealliance.androidclient.views.ExpandableListView;
+
+import android.support.annotation.Nullable;
+import android.util.Log;
+import android.view.View;
+import android.widget.ProgressBar;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,12 +55,16 @@ public class ExpandableListViewBinder extends AbstractDataBinder<List<ListGroup>
     @Override
     public void updateData(@Nullable List<ListGroup> data) {
         if (data == null || expandableListView == null) {
-            setDataBound(false);
+            if (!isDataBound()) {
+                setDataBound(false);
+            }
             return;
         }
         if (data.isEmpty()) {
             Log.d(Constants.LOG_TAG, "DATA IS EMPTY");
-            setDataBound(false);
+            if (!isDataBound()) {
+                setDataBound(false);
+            }
             return;
         }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/ListViewBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/ListViewBinder.java
@@ -32,11 +32,15 @@ public class ListViewBinder extends AbstractDataBinder<List<ListItem>> {
     @Override
     public void updateData(@Nullable List<ListItem> data) {
         if (data == null || listView == null) {
-            setDataBound(false);
+            if (!isDataBound()) {
+                setDataBound(false);
+            }
             return;
         }
         if (data.isEmpty()) {
-            setDataBound(false);
+            if (!isDataBound()) {
+                setDataBound(false);
+            }
             return;
         }
         long startTime = System.currentTimeMillis();

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/MatchBreakdownBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/MatchBreakdownBinder.java
@@ -23,7 +23,9 @@ public class MatchBreakdownBinder extends AbstractDataBinder<JsonObject> {
     @Override
     public void updateData(@Nullable JsonObject data) {
         if (data == null || breakdown == null) {
-            setDataBound(false);
+            if (!isDataBound()) {
+                setDataBound(false);
+            }
             return;
         }
         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
If the binder receives invalid data, but there is already data bound,
that means the following case is most likely:
 - There was data available in the local cache that we can display
 - The network call returned an error/still is cached with an empty
   value

This can happen when the user receives a push notification which writes
some data locally, but the remote endpoint has not had its cache
cleaered yet, causing the display to flicker between correct data and no
data view.

Fixes #638

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/645)
<!-- Reviewable:end -->