### PR TITLE
Makes the full team name view expandable

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamInfoBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamInfoBinder.java
@@ -129,7 +129,6 @@ public class TeamInfoBinder extends AbstractDataBinder<TeamInfoBinder.Model> {
             teamFullName.setEllipsize(TextUtils.TruncateAt.END);
 
             teamFullNameContainer.setOnClickListener((view) -> {
-                Log.d(Constants.LOG_TAG, "team full name clicked!");
                 toggleFullTeamNameExpanded();
             });
         }

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamInfoBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamInfoBinder.java
@@ -1,12 +1,17 @@
 package com.thebluealliance.androidclient.binders;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.ObjectAnimator;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.text.Spannable;
 import android.text.SpannableString;
+import android.text.TextUtils;
 import android.text.style.TextAppearanceSpan;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.thebluealliance.androidclient.Constants;
@@ -19,6 +24,8 @@ import butterknife.Bind;
 import butterknife.ButterKnife;
 
 public class TeamInfoBinder extends AbstractDataBinder<TeamInfoBinder.Model> {
+
+    private static final int TEAM_FULL_NAME_COLLAPSED_MAX_LINES = 3;
 
     @Inject SocialClickListener mSocialClickListener;
 
@@ -118,6 +125,13 @@ public class TeamInfoBinder extends AbstractDataBinder<TeamInfoBinder.Model> {
             string.setSpan(new TextAppearanceSpan(mActivity,
                     R.style.InfoItemLabelStyle), 0, 3, Spannable.SPAN_INCLUSIVE_INCLUSIVE);
             teamFullName.setText(string);
+            teamFullName.setMaxLines(TEAM_FULL_NAME_COLLAPSED_MAX_LINES);
+            teamFullName.setEllipsize(TextUtils.TruncateAt.END);
+
+            teamFullNameContainer.setOnClickListener((view) -> {
+                Log.d(Constants.LOG_TAG, "team full name clicked!");
+                toggleFullTeamNameExpanded();
+            });
         }
 
         teamNextMatchLabel.setVisibility(View.GONE);
@@ -129,7 +143,6 @@ public class TeamInfoBinder extends AbstractDataBinder<TeamInfoBinder.Model> {
         content.setVisibility(View.VISIBLE);
         mNoDataBinder.unbindData();
         setDataBound(true);
-
     }
 
     @Override
@@ -163,6 +176,55 @@ public class TeamInfoBinder extends AbstractDataBinder<TeamInfoBinder.Model> {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private void toggleFullTeamNameExpanded() {
+        int currentMaxLines = teamFullName.getMaxLines();
+        if (currentMaxLines == TEAM_FULL_NAME_COLLAPSED_MAX_LINES) {
+            // The text view is collapsed, expand it
+
+            final int height = teamFullName.getMeasuredHeight();
+
+            teamFullName.setMaxLines(Integer.MAX_VALUE);
+            teamFullName.measure(
+                    View.MeasureSpec.makeMeasureSpec(teamFullName.getMeasuredWidth(), View.MeasureSpec.AT_MOST),
+                    View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+            final int newHeight = teamFullName.getMeasuredHeight();
+
+            ObjectAnimator animation = ObjectAnimator.ofInt(teamFullName, "height", height, newHeight);
+            animation.setDuration(500);
+            animation.addListener(new AnimatorListenerAdapter() {
+                @Override public void onAnimationEnd(Animator animation) {
+                    teamFullName.setMaxLines(Integer.MAX_VALUE);
+                    teamFullName.setMinHeight(0);
+                }
+            });
+            animation.start();
+        } else {
+            // We need to collapse the text view
+
+            final int height = teamFullName.getMeasuredHeight();
+
+            // Only set max lines while we measure; max lines will be permanently
+            // reduced one the animation completes
+            teamFullName.setMaxLines(TEAM_FULL_NAME_COLLAPSED_MAX_LINES);
+            teamFullName.measure(
+                    View.MeasureSpec.makeMeasureSpec(teamFullName.getMeasuredWidth(), View.MeasureSpec.AT_MOST),
+                    View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+            teamFullName.setMaxLines(Integer.MAX_VALUE);
+
+            final int newHeight = teamFullName.getMeasuredHeight();
+            ObjectAnimator animation = ObjectAnimator.ofInt(teamFullName, "height", height, newHeight);
+            animation.setDuration(500);
+            animation.addListener(new AnimatorListenerAdapter() {
+                @Override public void onAnimationEnd(Animator animation) {
+                    teamFullName.setMaxLines(TEAM_FULL_NAME_COLLAPSED_MAX_LINES);
+                    teamFullName.setMinHeight(0);
+                }
+            });
+            animation.start();
+        }
+
     }
 
     @Override

--- a/android/src/main/res/layout/fragment_team_info.xml
+++ b/android/src/main/res/layout/fragment_team_info.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
     <ScrollView
         android:id="@+id/content"
         android:layout_width="match_parent"
@@ -17,8 +18,7 @@
             android:orientation="vertical">
 
             <!-- General team info card -->
-            <android.support.v7.widget.CardView
-                style="@style/InfoItemCardStyle">
+            <android.support.v7.widget.CardView style="@style/InfoItemCardStyle">
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -71,13 +71,12 @@
                     <FrameLayout
                         android:id="@+id/team_full_name_container"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
+                        android:layout_height="wrap_content"
+                        android:background="?android:attr/selectableItemBackground">
 
                         <View style="@style/InfoItemDividerStyle" />
 
-                        <RelativeLayout
-                            style="@style/InfoItemStyle"
-                            android:clickable="true">
+                        <RelativeLayout style="@style/InfoItemStyle">
 
                             <com.thebluealliance.androidclient.views.RecoloredImageView
                                 android:id="@+id/team_full_name_icon"
@@ -110,8 +109,8 @@
                             <com.thebluealliance.androidclient.views.RecoloredImageView
                                 android:id="@+id/team_motto_icon"
                                 style="@style/InfoItemImageStyle"
-                                android:src="@drawable/ic_format_quote_black_24dp"
                                 android:scaleX="-1"
+                                android:src="@drawable/ic_format_quote_black_24dp"
                                 app:tintColor="@color/primary" />
 
                             <TextView
@@ -149,9 +148,9 @@
                         android:id="@+id/team_current_event"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:foreground="?android:attr/selectableItemBackground"
                         android:clickable="true"
                         android:focusable="true"
+                        android:foreground="?android:attr/selectableItemBackground"
                         android:orientation="vertical" />
                 </LinearLayout>
             </android.support.v7.widget.CardView>
@@ -233,7 +232,7 @@
                             android:id="@+id/team_website_title"
                             style="@style/InfoItemTextStyle"
                             android:layout_toRightOf="@id/team_website_icon"
-                            tools:text="google link goes here"/>
+                            tools:text="google link goes here" />
                     </RelativeLayout>
 
                     <View style="@style/InfoItemDividerStyle" />
@@ -255,7 +254,7 @@
                             android:id="@+id/team_twitter_title"
                             style="@style/InfoItemTextStyle"
                             android:layout_toRightOf="@id/team_twitter_icon"
-                            tools:text="Twitter link goes here"/>
+                            tools:text="Twitter link goes here" />
                     </RelativeLayout>
 
                     <View style="@style/InfoItemDividerStyle" />
@@ -277,7 +276,7 @@
                             android:id="@+id/team_youtube_title"
                             style="@style/InfoItemTextStyle"
                             android:layout_toRightOf="@id/team_youtube_icon"
-                            tools:text="YouTube link goes here"/>
+                            tools:text="YouTube link goes here" />
                     </RelativeLayout>
 
                     <View style="@style/InfoItemDividerStyle" />

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -59,7 +59,7 @@
     <!-- marginLeft is (72dp - 8dp) to account for the fact that this view is always wrapped
     in a card with a left margin of 8dp; this keeps text aligned to the 72dp keyline -->
     <style name="InfoItemTextStyle">
-        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginLeft">64dp</item>
         <item name="android:textSize">16sp</item>


### PR DESCRIPTION
For teams with really long full team names (254, for instance), they are now limited to 3 lines at first, and ellipsized. Clicking the full name expands the view to show the full team name.

Fixes #233

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/665)
<!-- Reviewable:end -->