### PR TITLE
GPG Sign Release Tags

### DIFF
--- a/scripts/do_release.py
+++ b/scripts/do_release.py
@@ -169,7 +169,7 @@ def create_tag(args):
     print("To skip creating a new tag, run with --skip_tag")
     time.sleep(2)
     if not args.dry_run:
-        subprocess.call(["git", "tag", "-a", "v{}".format(args.tag), "-m", name])
+        subprocess.call(["git", "tag", "-s", "v{}".format(args.tag), "-m", name])
 
 
 def validate_build(dry_run):


### PR DESCRIPTION
Because GitHub supports that now: https://github.com/blog/2144-gpg-signature-verification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/666)
<!-- Reviewable:end -->