### PR TITLE
Null check setting team years participated

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/database/writers/YearsParticipatedWriter.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/writers/YearsParticipatedWriter.java
@@ -1,10 +1,11 @@
 package com.thebluealliance.androidclient.database.writers;
 
-import android.support.annotation.WorkerThread;
-
 import com.google.gson.JsonArray;
+
 import com.thebluealliance.androidclient.database.Database;
 import com.thebluealliance.androidclient.models.Team;
+
+import android.support.annotation.WorkerThread;
 
 import javax.inject.Inject;
 
@@ -24,7 +25,7 @@ public class YearsParticipatedWriter extends BaseDbWriter<YearsParticipatedInfo>
     @WorkerThread
     public void write(YearsParticipatedInfo yearsParticipatedInfo) {
         Team team = mDb.getTeamsTable().get(yearsParticipatedInfo.teamKey);
-        if (team != null) {
+        if (team != null && yearsParticipatedInfo.yearsParticipated != null) {
             team.setYearsParticipated(yearsParticipatedInfo.yearsParticipated);
             mTeamWriter.write(team);
         }


### PR DESCRIPTION
Fixes this crash from the play store:

```
java.lang.IllegalStateException: Fatal Exception thrown on Scheduler.Worker thread.
	at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:62)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:423)
	at java.util.concurrent.FutureTask.run(FutureTask.java:237)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:154)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:269)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
	at java.lang.Thread.run(Thread.java:818)
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String com.google.gson.JsonArray.toString()' on a null object reference
	at com.thebluealliance.androidclient.models.Team.setYearsParticipated(Team.java:122)
	at com.thebluealliance.androidclient.database.writers.YearsParticipatedWriter.write(YearsParticipatedWriter.java:28)
	at com.thebluealliance.androidclient.database.writers.YearsParticipatedWriter.write(YearsParticipatedWriter.java:13)
	at com.thebluealliance.androidclient.database.writers.BaseDbWriter.lambda$call$0(BaseDbWriter.java:66)
	at com.thebluealliance.androidclient.database.writers.BaseDbWriter.access$lambda$0(BaseDbWriter.java)
	at com.thebluealliance.androidclient.database.writers.BaseDbWriter$$Lambda$1.call(Unknown Source)
	at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:55)
	... 7 more
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/677)
<!-- Reviewable:end -->