### PR TITLE
Only show padding for the myTBA FAB if the FAB is visible

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventInfoFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/event/EventInfoFragment.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.androidclient.fragments.event;
 
 import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.accounts.AccountHelper;
 import com.thebluealliance.androidclient.binders.EventInfoBinder;
 import com.thebluealliance.androidclient.fragments.DatafeedFragment;
 import com.thebluealliance.androidclient.models.Event;
@@ -46,6 +47,10 @@ public class EventInfoFragment
         mBinder.setInflater(inflater);
         mBinder.setRootView(view);
         mBinder.setNoDataView((NoDataView) view.findViewById(R.id.no_data));
+
+        // Only show space for the FAB if the FAB is visible
+        boolean myTbaEnabled = AccountHelper.isMyTBAEnabled(getActivity());
+        view.findViewById(R.id.fab_padding).setVisibility(myTbaEnabled ? View.VISIBLE : View.GONE);
 
         return view;
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/team/TeamInfoFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/team/TeamInfoFragment.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.androidclient.fragments.team;
 
 import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.accounts.AccountHelper;
 import com.thebluealliance.androidclient.binders.TeamInfoBinder;
 import com.thebluealliance.androidclient.eventbus.LiveEventUpdateEvent;
 import com.thebluealliance.androidclient.fragments.DatafeedFragment;
@@ -54,11 +55,12 @@ public class TeamInfoFragment
     }
 
     @Override
-    public View onCreateView(
-            LayoutInflater inflater,
-            ViewGroup container,
-            Bundle savedInstanceState) {
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_team_info, container, false);
+
+        // Only show space for the FAB if the FAB is visible
+        boolean myTbaEnabled = AccountHelper.isMyTBAEnabled(getActivity());
+        view.findViewById(R.id.fab_padding).setVisibility(myTbaEnabled ? View.VISIBLE : View.GONE);
 
         mBinder.setRootView(view);
 

--- a/android/src/main/res/layout/fragment_event_info.xml
+++ b/android/src/main/res/layout/fragment_event_info.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <ScrollView
         android:id="@+id/content"
@@ -90,27 +91,28 @@
                     </FrameLayout>
 
                     <FrameLayout
-                            android:id="@+id/event_webcast_container"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:background="?android:attr/selectableItemBackground"
-                            android:clickable="true"
-                            android:focusable="true"
-                            android:visibility="gone"
-                            tools:visibility="visible">
+                        android:id="@+id/event_webcast_container"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:visibility="gone"
+                        tools:visibility="visible">
 
                         <View style="@style/InfoItemDividerStyle" />
 
-                        <Button android:id="@+id/event_webcast_button"
+                        <Button
+                            android:id="@+id/event_webcast_button"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_horizontal"
+                            android:layout_margin="8dp"
                             android:background="@color/primary"
+                            android:padding="12dp"
                             android:textColor="@color/white"
                             android:textSize="14sp"
-                            android:padding="12dp"
-                            android:layout_margin="8dp"
-                            tools:text="View Broadcast on Twitch"/>
+                            tools:text="View Broadcast on Twitch" />
                     </FrameLayout>
                 </LinearLayout>
             </android.support.v7.widget.CardView>
@@ -346,11 +348,16 @@
                 </LinearLayout>
             </android.support.v7.widget.CardView>
 
+            <!-- Provides padding after the last list item -->
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="8dp" />
 
             <!-- Provides padding for the FAB -->
             <Space
-                android:layout_width="0dp"
-                android:layout_height="88dp" />
+                android:id="@+id/fab_padding"
+                android:layout_width="match_parent"
+                android:layout_height="80dp" />
         </LinearLayout>
     </ScrollView>
 

--- a/android/src/main/res/layout/fragment_team_info.xml
+++ b/android/src/main/res/layout/fragment_team_info.xml
@@ -303,10 +303,16 @@
                 </LinearLayout>
             </android.support.v7.widget.CardView>
 
+            <!-- Provides padding after the last list item -->
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="8dp" />
+
             <!-- Provides padding for the FAB -->
             <Space
-                android:layout_width="0dp"
-                android:layout_height="88dp" />
+                android:id="@+id/fab_padding"
+                android:layout_width="match_parent"
+                android:layout_height="80dp" />
         </LinearLayout>
     </ScrollView>
 


### PR DESCRIPTION
We don't need the extra 80dps of padding at the bottom of the team/event info view if myTBA is disabled and the FAB is not visible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/695)
<!-- Reviewable:end -->