### PR TITLE
Changed handling of clicks on event items

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/Interactions.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/Interactions.java
@@ -1,0 +1,6 @@
+package com.thebluealliance.androidclient;
+
+public class Interactions {
+
+    public static final int EVENT_CLICKED = 1000;
+}

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/RecyclerViewBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/RecyclerViewBinder.java
@@ -8,8 +8,6 @@ import android.widget.ProgressBar;
 
 import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.R;
-import com.thebluealliance.androidclient.adapters.ListViewAdapter;
-import com.thebluealliance.androidclient.listitems.ListItem;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,12 +22,12 @@ public class RecyclerViewBinder extends AbstractDataBinder<List<Object>> {
     @Bind(R.id.list) RecyclerView mRecyclerView;
     @Bind(R.id.progress) ProgressBar mProgressBar;
 
-    protected RecyclerViewBinderMapper mMapper;
+    protected RecyclerViewAdapterCreatorInitializer mMapper;
     protected RecyclerMultiAdapter mAdapter;
 
     protected List<Object> mList;
 
-    public void setRecyclerViewBinderMapper(RecyclerViewBinderMapper mapper) {
+    public void setRecyclerViewBinderMapper(RecyclerViewAdapterCreatorInitializer mapper) {
         mMapper = mapper;
     }
 
@@ -50,7 +48,7 @@ public class RecyclerViewBinder extends AbstractDataBinder<List<Object>> {
             return;
         }
         if (mMapper == null) {
-            throw new RuntimeException(this.getClass().getName() + " does not have a RecyclerViewBinderMapper set!");
+            throw new RuntimeException(this.getClass().getName() + " does not have a RecyclerViewAdapterCreatorInitializer set!");
         }
 
         if (mAdapter == null) {
@@ -118,11 +116,11 @@ public class RecyclerViewBinder extends AbstractDataBinder<List<Object>> {
 
     protected void createAndInitializeAdapterForData(List<Object> data) {
         SmartAdapter.MultiAdaptersCreator creator = SmartAdapter.items(new ArrayList<>(data));
-        mMapper.initializeMaps(creator);
+        mMapper.initializeAdapterCreator(creator);
         mAdapter = creator.into(mRecyclerView);
     }
 
-    public interface RecyclerViewBinderMapper {
-        void initializeMaps(SmartAdapter.MultiAdaptersCreator creator);
+    public interface RecyclerViewAdapterCreatorInitializer {
+        void initializeAdapterCreator(SmartAdapter.MultiAdaptersCreator creator);
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/EventListFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/EventListFragment.java
@@ -1,6 +1,8 @@
 package com.thebluealliance.androidclient.fragments;
 
+import com.thebluealliance.androidclient.Interactions;
 import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.activities.ViewEventActivity;
 import com.thebluealliance.androidclient.binders.RecyclerViewBinder;
 import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.itemviews.EventItemView;
@@ -97,8 +99,15 @@ public class EventListFragment extends RecyclerViewFragment<List<Event>, EventLi
         return new NoDataViewParams(R.drawable.ic_event_black_48dp, R.string.no_events_found);
     }
 
-    @Override public void initializeMaps(SmartAdapter.MultiAdaptersCreator creator) {
+    @Override public void initializeAdapterCreator(SmartAdapter.MultiAdaptersCreator creator) {
         creator.map(EventViewModel.class, EventItemView.class);
         creator.map(ListSectionHeaderViewModel.class, ListSectionHeaderItemView.class);
+
+        creator.listener((actionId, item, position, view) -> {
+            if (actionId == Interactions.EVENT_CLICKED && item instanceof EventViewModel) {
+                EventViewModel event = (EventViewModel) item;
+                startActivity(ViewEventActivity.newInstance(getContext(), event.getKey()));
+            }
+        });
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/RecentNotificationsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/RecentNotificationsFragment.java
@@ -43,7 +43,7 @@ import rx.Observable;
 
 public class RecentNotificationsFragment
         extends DatafeedFragment<List<StoredNotification>, List<Object>, RecentNotificationsSubscriber, RecentNotificationsListBinder>
-        implements RecyclerViewBinder.RecyclerViewBinderMapper {
+        implements RecyclerViewBinder.RecyclerViewAdapterCreatorInitializer {
 
     @Inject Database mDb;
 
@@ -114,7 +114,7 @@ public class RecentNotificationsFragment
     }
 
     @Override
-    public void initializeMaps(SmartAdapter.MultiAdaptersCreator creator) {
+    public void initializeAdapterCreator(SmartAdapter.MultiAdaptersCreator creator) {
         creator.map(AllianceSelectionNotificationViewModel.class, AllianceSelectionNotificationItemView.class)
                 .map(AwardsPostedNotificationViewModel.class, AwardsPostedNotificationItemView.class)
                 .map(CompLevelStartingNotificationViewModel.class, CompLevelStartingNotificationItemView.class)

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/RecyclerViewFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/RecyclerViewFragment.java
@@ -19,7 +19,7 @@ import com.thebluealliance.androidclient.views.NoDataView;
 import java.util.List;
 
 public abstract class RecyclerViewFragment<T, S extends BaseAPISubscriber<T, List<Object>>, B extends RecyclerViewBinder>
-        extends DatafeedFragment<T, List<Object>, S, B> implements RecyclerViewBinder.RecyclerViewBinderMapper {
+        extends DatafeedFragment<T, List<Object>, S, B> implements RecyclerViewBinder.RecyclerViewAdapterCreatorInitializer {
 
     private Parcelable mListState;
     private RecyclerView.Adapter mAdapter;

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/TeamListFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/TeamListFragment.java
@@ -81,7 +81,7 @@ public class TeamListFragment extends RecyclerViewFragment<List<Team>, TeamListR
     }
 
     @Override
-    public void initializeMaps(SmartAdapter.MultiAdaptersCreator creator) {
+    public void initializeAdapterCreator(SmartAdapter.MultiAdaptersCreator creator) {
         creator.map(TeamViewModel.class, TeamItemView.class);
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/district/DistrictEventsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/district/DistrictEventsFragment.java
@@ -1,6 +1,8 @@
 package com.thebluealliance.androidclient.fragments.district;
 
+import com.thebluealliance.androidclient.Interactions;
 import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.activities.ViewEventActivity;
 import com.thebluealliance.androidclient.binders.RecyclerViewBinder;
 import com.thebluealliance.androidclient.fragments.RecyclerViewFragment;
 import com.thebluealliance.androidclient.helpers.DistrictHelper;
@@ -65,8 +67,15 @@ public class DistrictEventsFragment extends RecyclerViewFragment<List<Event>, Ev
         return new NoDataViewParams(R.drawable.ic_event_black_48dp, R.string.no_event_data);
     }
 
-    @Override public void initializeMaps(SmartAdapter.MultiAdaptersCreator creator) {
+    @Override public void initializeAdapterCreator(SmartAdapter.MultiAdaptersCreator creator) {
         creator.map(EventViewModel.class, EventItemView.class);
         creator.map(ListSectionHeaderViewModel.class, ListSectionHeaderItemView.class);
+
+        creator.listener((actionId, item, position, view) -> {
+            if (actionId == Interactions.EVENT_CLICKED && item instanceof EventViewModel) {
+                EventViewModel event = (EventViewModel) item;
+                startActivity(ViewEventActivity.newInstance(getContext(), event.getKey()));
+            }
+        });
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/team/TeamEventsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/team/TeamEventsFragment.java
@@ -1,7 +1,9 @@
 package com.thebluealliance.androidclient.fragments.team;
 
+import com.thebluealliance.androidclient.Interactions;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
+import com.thebluealliance.androidclient.activities.TeamAtEventActivity;
 import com.thebluealliance.androidclient.binders.RecyclerViewBinder;
 import com.thebluealliance.androidclient.datafeed.refresh.RefreshController;
 import com.thebluealliance.androidclient.eventbus.YearChangedEvent;
@@ -101,8 +103,15 @@ public class TeamEventsFragment extends RecyclerViewFragment<List<Event>, EventL
         return new NoDataViewParams(R.drawable.ic_event_black_48dp, R.string.no_event_data);
     }
 
-    @Override public void initializeMaps(SmartAdapter.MultiAdaptersCreator creator) {
+    @Override public void initializeAdapterCreator(SmartAdapter.MultiAdaptersCreator creator) {
         creator.map(EventViewModel.class, EventItemView.class);
         creator.map(ListSectionHeaderViewModel.class, ListSectionHeaderItemView.class);
+
+        creator.listener((actionId, item, position, view) -> {
+            if (actionId == Interactions.EVENT_CLICKED && item instanceof EventViewModel) {
+                EventViewModel event = (EventViewModel) item;
+                startActivity(TeamAtEventActivity.newInstance(getContext(), event.getKey(), mTeamKey));
+            }
+        });
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/EventItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/EventItemView.java
@@ -1,12 +1,10 @@
 package com.thebluealliance.androidclient.itemviews;
 
+import com.thebluealliance.androidclient.Interactions;
 import com.thebluealliance.androidclient.R;
-import com.thebluealliance.androidclient.listeners.EventClickListener;
 import com.thebluealliance.androidclient.listeners.ModelSettingsClickListener;
-import com.thebluealliance.androidclient.listeners.TeamClickListener;
 import com.thebluealliance.androidclient.types.ModelType;
 import com.thebluealliance.androidclient.viewmodels.EventViewModel;
-import com.thebluealliance.androidclient.viewmodels.TeamViewModel;
 
 import android.content.Context;
 import android.view.View;
@@ -42,7 +40,7 @@ public class EventItemView extends BindableFrameLayout<EventViewModel> {
 
     @Override
     public void bind(EventViewModel model) {
-        this.setOnClickListener(new EventClickListener(getContext(), model.getKey()));
+        this.setOnClickListener(v -> notifyItemAction(Interactions.EVENT_CLICKED));
         this.setClickable(true);
         this.setFocusable(true);
 


### PR DESCRIPTION
Fixes an issue where clicking on an event in a team's event list opened the event view instead of the team@event view. This is my fault for not verifying behavior when I switched the event lists to use RecyclerView.

This better exploits the features of the adapter library we are using; namely, it moved view event (clicks, etc) handling out of the item and into a listener attached to the adapter. See [here](https://github.com/mrmans0n/smart-adapters#assigning-listeners) for reference.

Going forward, as we make the transition to RecyclerView, this is how we should do things. It generally makes list items more reusable. I'd like to write a class that lets us compose listeners so that we can reuse click listeners throughout the app while still having the option of using multiple listeners per list. Something like this:

```java
ViewEventListenerComposer.Builder builder = new ViewEventListenerComposer.Builder();
builder.compose(new EventClickListener(mContext));
builder.compose(new MyTbaDetailsClickListener(mContext));
creator.listener(builder.build());
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/712)
<!-- Reviewable:end -->
