### PR TITLE
Return to script-generated GCE Interfaces

### DIFF
--- a/gce/gce2retrofit.jar
+++ b/gce/gce2retrofit.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4d771be3fac194b6f58f2565a60da317d6b9c96bc7fa46bd82b1c0f6e065c9d
-size 62901750
+oid sha256:619a92526a9b8365971a9fdb4602dd4c849a104d6d63806659bccaaff560340c
+size 62901719

--- a/gce/gce_discovery.json
+++ b/gce/gce_discovery.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "\"u_zXkMELIlX4ktyNbM2XKD4vK8E/DAxq4RtoWYUAiLNQNdgcsxE_-V0\"",
+ "etag": "\"H01Z-1ikbwOw463Un2bFZHenx1g/YttKTkJY66lGXmr4gRv34CuMkNA\"",
  "discoveryVersion": "v1",
  "id": "tbaMobile:v9",
  "name": "tbaMobile",

--- a/scripts/update_cloud_endpoints.sh
+++ b/scripts/update_cloud_endpoints.sh
@@ -49,6 +49,7 @@ git apply $TBA_ANDROID_HOME/scripts/patches/endpoints_remove_sitevar.patch
 
 # Generate discovery document
 # $GAE_HOME/endpointscfg.py get_client_lib java -o $TBA_ANDROID_HOME -bs gradle mobile_main.MobileAPI
+echo "Getting discovery.json for $TBA_APP_ID"
 $GAE_HOME/endpointscfg.py get_discovery_doc -o $TBA_ANDROID_HOME/gce/ mobile_main.MobileAPI
 RES="$?"
 
@@ -67,6 +68,6 @@ echo "Renaming discovery document to gce/gce_discovery.json"
 mv gce/tbaMobile-v*.discovery gce/gce_discovery.json
 
 echo "Generating retrofit services"
-java -jar gce/gce2retrofit.jar gce/gce_discovery.json ./tbaMobile/src/main/java/ -methods sync,async,reactive
+java -jar gce/gce2retrofit.jar gce/gce_discovery.json ./tbaMobile/src/main/java/ -methods async,reactive
 
 exit $RES

--- a/tbaMobile/src/main/java/com/appspot/tbatv_prod_hrd/Favorites.java
+++ b/tbaMobile/src/main/java/com/appspot/tbatv_prod_hrd/Favorites.java
@@ -1,10 +1,16 @@
 package com.appspot.tbatv_prod_hrd;
 
-import com.appspot.tbatv_prod_hrd.model.ModelsMobileApiMessagesFavoriteCollection;
+import com.appspot.tbatv_prod_hrd.model.*;
 
 import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
 import retrofit2.http.Header;
+import retrofit2.http.PATCH;
 import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
 import rx.Observable;
 
 public interface Favorites {

--- a/tbaMobile/src/main/java/com/appspot/tbatv_prod_hrd/Model.java
+++ b/tbaMobile/src/main/java/com/appspot/tbatv_prod_hrd/Model.java
@@ -3,7 +3,6 @@ package com.appspot.tbatv_prod_hrd;
 import com.appspot.tbatv_prod_hrd.model.*;
 
 import retrofit2.Call;
-import retrofit2.Callback;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
 import retrofit2.http.GET;

--- a/tbaMobile/src/main/java/com/appspot/tbatv_prod_hrd/Subscriptions.java
+++ b/tbaMobile/src/main/java/com/appspot/tbatv_prod_hrd/Subscriptions.java
@@ -3,7 +3,6 @@ package com.appspot.tbatv_prod_hrd;
 import com.appspot.tbatv_prod_hrd.model.*;
 
 import retrofit2.Call;
-import retrofit2.Callback;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
 import retrofit2.http.GET;

--- a/tbaMobile/src/main/java/com/appspot/tbatv_prod_hrd/Tbamobile.java
+++ b/tbaMobile/src/main/java/com/appspot/tbatv_prod_hrd/Tbamobile.java
@@ -1,12 +1,16 @@
 package com.appspot.tbatv_prod_hrd;
 
-import com.appspot.tbatv_prod_hrd.model.ModelsMobileApiMessagesBaseResponse;
-import com.appspot.tbatv_prod_hrd.model.ModelsMobileApiMessagesRegistrationRequest;
+import com.appspot.tbatv_prod_hrd.model.*;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
 import retrofit2.http.Header;
+import retrofit2.http.PATCH;
 import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
 import rx.Observable;
 
 public interface Tbamobile {

--- a/tbaMobile/src/main/java/com/appspot/tbatv_prod_hrd/TeamMedia.java
+++ b/tbaMobile/src/main/java/com/appspot/tbatv_prod_hrd/TeamMedia.java
@@ -1,12 +1,16 @@
 package com.appspot.tbatv_prod_hrd;
 
-import com.appspot.tbatv_prod_hrd.model.ModelsMobileApiMessagesBaseResponse;
-import com.appspot.tbatv_prod_hrd.model.ModelsMobileApiMessagesMediaSuggestionMessage;
+import com.appspot.tbatv_prod_hrd.model.*;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
 import retrofit2.http.Header;
+import retrofit2.http.PATCH;
 import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
 import rx.Observable;
 
 public interface TeamMedia {


### PR DESCRIPTION
When we upgraded to retrofit2, there were some manual changes made to the GCE interfaces.

This pull updates the `gce2retrofit` jar (code on [this branch](https://github.com/phil-lopreiato/gce2retrofit/tree/gce-auth)) and returns to generated interfaces.

To update in the future, be sure to run `./scripts/update_cloud_endpoints.sh`

Towards #716 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/721)
<!-- Reviewable:end -->
