### PR TITLE
Show event year as subtitle in ViewEventActivity

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewEventActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewEventActivity.java
@@ -256,6 +256,7 @@ public class ViewEventActivity extends MyTBASettingsActivity
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onActionBarTitleUpdated(ActionBarTitleEvent event) {
         setActionBarTitle(event.getTitle());
+        setActionBarSubtitle(event.getSubtitle());
     }
 
     public FragmentComponent getComponent() {

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/EventInfoBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/EventInfoBinder.java
@@ -197,7 +197,7 @@ public class EventInfoBinder extends AbstractDataBinder<EventInfoBinder.Model> {
         content.setVisibility(View.VISIBLE);
         progressBar.setVisibility(View.GONE);
 
-        EventBus.getDefault().post(new ActionBarTitleEvent(data.titleString));
+        EventBus.getDefault().post(new ActionBarTitleEvent(data.actionBarTitle, data.actionBarSubtitle));
 
         mNoDataBinder.unbindData();
         setDataBound(true);
@@ -247,12 +247,12 @@ public class EventInfoBinder extends AbstractDataBinder<EventInfoBinder.Model> {
     public static class Model {
         public String eventKey;
         public String actionBarTitle;
+        public String actionBarSubtitle;
         public String nameString;
         public String dateString;
         public String venueString;
         public String locationString;
         public String eventWebsite;
-        public String titleString;
         public boolean isLive;
         public JsonArray webcasts;
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriber.java
@@ -15,13 +15,13 @@ public class EventInfoSubscriber extends BaseAPISubscriber<Event, Model> {
         mDataToBind = new Model();
         mDataToBind.eventKey = mAPIData.getKey();
         mDataToBind.nameString = mAPIData.getEventName();
-        mDataToBind.actionBarTitle = mAPIData.getEventYear() + " " + mAPIData.getEventShortName();
+        mDataToBind.actionBarTitle = mAPIData.getEventShortName();
+        mDataToBind.actionBarSubtitle = String.valueOf(mAPIData.getEventYear());
         mDataToBind.venueString = mAPIData.getVenue();
         mDataToBind.locationString = mAPIData.getLocation();
         mDataToBind.eventWebsite = mAPIData.getWebsite();
         mDataToBind.dateString = mAPIData.getDateString();
         mDataToBind.isLive = mAPIData.isHappeningNow();
-        mDataToBind.titleString = mAPIData.getEventYear() + " " + mAPIData.getEventShortName();
         mDataToBind.webcasts = mAPIData.getWebcasts();
     }
 }

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriberTest.java
@@ -43,13 +43,13 @@ public class EventInfoSubscriberTest extends TestCase {
 
         assertEquals(data.eventKey, mEvent.getKey());
         assertEquals(data.nameString, mEvent.getEventName());
-        assertEquals(data.actionBarTitle, mEvent.getEventYear() + " " + mEvent.getEventShortName());
+        assertEquals(data.actionBarTitle, mEvent.getEventShortName());
+        assertEquals(data.actionBarSubtitle, String.valueOf(mEvent.getEventYear()));
         assertEquals(data.venueString, mEvent.getVenue());
         assertEquals(data.locationString, mEvent.getLocation());
         assertEquals(data.eventWebsite, mEvent.getWebsite());
         assertEquals(data.dateString, mEvent.getDateString());
         assertEquals(data.isLive, mEvent.isHappeningNow());
-        assertEquals(data.titleString, mEvent.getEventYear() + " " + mEvent.getEventShortName());
         assertEquals(data.webcasts, mEvent.getWebcasts());
     }
 }


### PR DESCRIPTION
**Summary**: Shows the event year as a subtitle in the Toolbar. This frees up a little bit of space in our already constrained Toolbar to show more of the event title.

**Issues Reference**: N/A

**Test Plan**: Updated existing tests to check the subtitle as well.

**Screenshot**

![Imgur](http://i.imgur.com/iAEP5f9l.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/749)
<!-- Reviewable:end -->
