### PR TITLE
Make notification cards more dense

### DIFF
--- a/android/src/main/res/layout/list_item_notification_alliance_selection.xml
+++ b/android/src/main/res/layout/list_item_notification_alliance_selection.xml
@@ -14,20 +14,11 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
-            <FrameLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@color/gameday_ticker_alliance_selection_header">
-
                 <TextView
                     android:id="@+id/card_header"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textColor="@color/white"
-                    android:textSize="20sp"
+                    style="@style/NotificationCardHeader"
+                    android:background="@color/gameday_ticker_alliance_selection_header"
                     tools:text="Test header" />
-            </FrameLayout>
 
             <LinearLayout
                 android:id="@+id/summary_container"

--- a/android/src/main/res/values/styles_notifications.xml
+++ b/android/src/main/res/values/styles_notifications.xml
@@ -14,7 +14,7 @@
     <style name="NotificationCardHeader">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:padding">16dp</item>
+        <item name="android:padding">8dp</item>
         <item name="android:textColor">@color/white</item>
         <item name="android:textSize">20sp</item>
     </style>
@@ -28,7 +28,7 @@
         <item name="android:focusable">true</item>
         <item name="android:gravity">center_vertical</item>
         <item name="android:minHeight">72dp</item>
-        <item name="android:padding">16dp</item>
+        <item name="android:padding">8dp</item>
     </style>
 
     <style name="NotificationCardBodyTitle">
@@ -55,6 +55,7 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_alignParentEnd">true</item>
         <item name="android:layout_alignParentRight">true</item>
-        <item name="android:padding">8dp</item>
+        <item name="android:textSize">12sp</item>
+        <item name="android:padding">4dp</item>
     </style>
 </resources>


### PR DESCRIPTION
**Summary:** Tightens up the padding on notification cards to increase information density

**Issues Reference:** N/A

**Test Plan:** N/A

**Screenshots**

Before on the left, after on the right

![Imgur](http://i.imgur.com/Vwitearl.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/751)
<!-- Reviewable:end -->
