### PR TITLE
Use actual padding for FAB padding instead of empty list item

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/background/mytba/CreateSubscriptionPanel.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/background/mytba/CreateSubscriptionPanel.java
@@ -109,10 +109,6 @@ public class CreateSubscriptionPanel extends AsyncTask<String, Void, Void> {
                 preference.setPersistent(false);
                 notificationSettingsCategory.addPreference(preference);
             }
-
-            Preference buffer = new Preference(context);
-            buffer.setLayoutResource(R.layout.buffer_preference);
-            notificationSettingsCategory.addPreference(buffer);
         }
         fragment.setPreferencesLoaded();
 

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/mytba/MyTBASettingsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/mytba/MyTBASettingsFragment.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.androidclient.fragments.mytba;
 
 import com.thebluealliance.androidclient.Constants;
+import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.background.mytba.CreateSubscriptionPanel;
 import com.thebluealliance.androidclient.helpers.ModelHelper;
 import com.thebluealliance.androidclient.helpers.ModelNotificationFavoriteSettings;
@@ -17,6 +18,8 @@ import android.preference.PreferenceGroup;
 import android.preference.PreferenceScreen;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ListView;
 
 import java.util.ArrayList;
 import java.util.Set;
@@ -74,11 +77,14 @@ public class MyTBASettingsFragment extends PreferenceFragment {
         // Create the list of preferences
         new CreateSubscriptionPanel(getActivity(), this, savedStateBundle, modelType).execute(modelKey);
 
-        // Remove padding from the list view
+        // Setup padding on the view. Padding is needed at the bottom to account for the FAB.
         if (getView() != null) {
-            View listView = getView().findViewById(android.R.id.list);
+            ListView listView = (ListView) getView().findViewById(android.R.id.list);
             if (listView != null) {
-                listView.setPadding(0, 0, 0, 0);
+                listView.setPadding(0, 0, 0, getResources().getDimensionPixelSize(R.dimen.fab_list_padding));
+                listView.setClipToPadding(false);
+                // Scrollbar gets janky with padding in a listview. Just hide it.
+                listView.setVerticalScrollBarEnabled(false);
             }
         }
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/mytba/MyTBASettingsFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/mytba/MyTBASettingsFragment.java
@@ -18,7 +18,6 @@ import android.preference.PreferenceGroup;
 import android.preference.PreferenceScreen;
 import android.util.Log;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.ListView;
 
 import java.util.ArrayList;

--- a/android/src/main/res/layout/buffer_preference.xml
+++ b/android/src/main/res/layout/buffer_preference.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="80dp"
-    android:orientation="vertical" />


### PR DESCRIPTION
**Summary:** Instead of using an empty `Preference` to pad the bottom of the myTBA settings list, this now applies actual padding to the bottom of the list. This avoids the case of a random divider appearing in the list where it shouldn't (see screenshots).

**Issues Reference:** N/A

**Test Plan:** N/A

**Screenshots:**

Old (note the lone divider):

![Imgur](http://i.imgur.com/163QWqkl.png)

New:

![Imgur](http://i.imgur.com/PjpdHRHl.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/752)
<!-- Reviewable:end -->
