### PR TITLE
Updates API of model objects to have more consistent method names

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/SearchResultsActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/SearchResultsActivity.java
@@ -150,7 +150,7 @@ public class SearchResultsActivity extends NavigationDrawerActivity implements S
                 if (team == null) {
                     // Don't display models that don't exist anymore and delete them from search indexes
                     team = new Team();
-                    team.setTeamKey(key);
+                    team.setKey(key);
                     Database.getInstance(this).getTeamsTable().deleteSearchIndex(team);
                     continue;
                 }
@@ -197,7 +197,7 @@ public class SearchResultsActivity extends NavigationDrawerActivity implements S
                 if (event == null) {
                     // Don't display models that don't exist anymore and delete them from search indexes
                     event = new Event();
-                    event.setEventKey(key);
+                    event.setKey(key);
                     Database.getInstance(this).getEventsTable().deleteSearchIndex(event);
                     continue;
                 }

--- a/android/src/main/java/com/thebluealliance/androidclient/comparators/EventSortByTypeAndDateComparator.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/comparators/EventSortByTypeAndDateComparator.java
@@ -19,7 +19,7 @@ public class EventSortByTypeAndDateComparator implements Comparator<Event> {
                 if (districtSort == 0) {
                     int eventSort = event.getStartDate().compareTo(event2.getStartDate());
                     if (eventSort == 0) {
-                        return event.getEventShortName().compareTo(event2.getEventShortName());
+                        return event.getShortName().compareTo(event2.getShortName());
                     } else {
                         return eventSort;
                     }

--- a/android/src/main/java/com/thebluealliance/androidclient/comparators/EventSortByTypeAndNameComparator.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/comparators/EventSortByTypeAndNameComparator.java
@@ -16,7 +16,7 @@ public class EventSortByTypeAndNameComparator implements Comparator<Event> {
         try {
             if (event.getEventType() == event2.getEventType()) {
                 int districtSort = ((Integer) event.getDistrictEnum()).compareTo(event2.getDistrictEnum());
-                int nameSort = event.getEventShortName().compareTo(event2.getEventShortName());
+                int nameSort = event.getShortName().compareTo(event2.getShortName());
                 if (districtSort == 0) {
                     return nameSort;
                 } else {

--- a/android/src/main/java/com/thebluealliance/androidclient/comparators/TeamSortByNumberComparator.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/comparators/TeamSortByNumberComparator.java
@@ -13,7 +13,7 @@ public class TeamSortByNumberComparator implements Comparator<Team> {
     @Override
     public int compare(Team team, Team team2) {
         try {
-            return team.getTeamNumber().compareTo(team2.getTeamNumber());
+            return team.getNumber().compareTo(team2.getNumber());
         } catch (BasicModel.FieldNotDefinedException e) {
             Log.e(Constants.LOG_TAG, "Can't compare teams with missing fields"
                     + Arrays.toString(e.getStackTrace()));

--- a/android/src/main/java/com/thebluealliance/androidclient/database/ModelInflater.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/ModelInflater.java
@@ -80,13 +80,13 @@ public final class ModelInflater {
         for (int i = 0; i < data.getColumnCount(); i++) {
             switch (data.getColumnName(i)) {
                 case EventsTable.KEY:
-                    event.setEventKey(data.getString(i));
+                    event.setKey(data.getString(i));
                     break;
                 case EventsTable.NAME:
-                    event.setEventName(data.getString(i));
+                    event.setName(data.getString(i));
                     break;
                 case EventsTable.SHORTNAME:
-                    event.setEventShortName(data.getString(i));
+                    event.setShortName(data.getString(i));
                     break;
                 case EventsTable.LOCATION:
                     event.setLocation(data.getString(i));
@@ -221,10 +221,10 @@ public final class ModelInflater {
         for (int i = 0; i < data.getColumnCount(); i++) {
             switch (data.getColumnName(i)) {
                 case TeamsTable.KEY:
-                    team.setTeamKey(data.getString(i));
+                    team.setKey(data.getString(i));
                     break;
                 case TeamsTable.NUMBER:
-                    team.setTeamNumber(data.getInt(i));
+                    team.setNumber(data.getInt(i));
                     break;
                 case TeamsTable.SHORTNAME:
                     team.setNickname(data.getString(i));

--- a/android/src/main/java/com/thebluealliance/androidclient/database/tables/EventsTable.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/tables/EventsTable.java
@@ -97,7 +97,7 @@ public class EventsTable extends ModelTable<Event> {
         try {
             cv.put(Database.SearchEvent.KEY, event.getKey());
             cv.put(Database.SearchEvent.TITLES, Utilities.getAsciiApproximationOfUnicode(event.getSearchTitles()));
-            cv.put(Database.SearchEvent.YEAR, event.getEventYear());
+            cv.put(Database.SearchEvent.YEAR, event.getYear());
             mDb.insert(Database.TABLE_SEARCH_EVENTS, null, cv);
 
         } catch (BasicModel.FieldNotDefinedException e) {
@@ -114,7 +114,7 @@ public class EventsTable extends ModelTable<Event> {
             ContentValues cv = new ContentValues();
             cv.put(Database.SearchEvent.KEY, event.getKey());
             cv.put(Database.SearchEvent.TITLES, Utilities.getAsciiApproximationOfUnicode(event.getSearchTitles()));
-            cv.put(Database.SearchEvent.YEAR, event.getEventYear());
+            cv.put(Database.SearchEvent.YEAR, event.getYear());
 
             mDb.update(Database.TABLE_SEARCH_EVENTS, cv, Database.SearchEvent.KEY + "=?", new String[]{event.getKey()});
         } catch (BasicModel.FieldNotDefinedException e) {

--- a/android/src/main/java/com/thebluealliance/androidclient/database/tables/TeamsTable.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/tables/TeamsTable.java
@@ -44,7 +44,7 @@ public class TeamsTable extends ModelTable<Team> {
         try {
             cv.put(Database.SearchTeam.KEY, team.getKey());
             cv.put(Database.SearchTeam.TITLES, Utilities.getAsciiApproximationOfUnicode(team.getSearchTitles()));
-            cv.put(Database.SearchTeam.NUMBER, team.getTeamNumber());
+            cv.put(Database.SearchTeam.NUMBER, team.getNumber());
             mDb.insert(Database.TABLE_SEARCH_TEAMS, null, cv);
         } catch (BasicModel.FieldNotDefinedException e) {
             Log.e(Constants.LOG_TAG, "Can't insert search team without the following fields:"
@@ -60,7 +60,7 @@ public class TeamsTable extends ModelTable<Team> {
             ContentValues cv = new ContentValues();
             cv.put(Database.SearchTeam.KEY, team.getKey());
             cv.put(Database.SearchTeam.TITLES, Utilities.getAsciiApproximationOfUnicode(team.getSearchTitles()));
-            cv.put(Database.SearchTeam.NUMBER, team.getTeamNumber());
+            cv.put(Database.SearchTeam.NUMBER, team.getNumber());
             mDb.update(Database.TABLE_SEARCH_TEAMS, cv, Database.SearchTeam.KEY + "=?", new String[]{team.getKey()});
         } catch (BasicModel.FieldNotDefinedException e) {
             Log.e(Constants.LOG_TAG, "Can't insert event search item without the following fields:"

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/deserializers/EventDeserializer.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/deserializers/EventDeserializer.java
@@ -31,11 +31,11 @@ public class EventDeserializer implements JsonDeserializer<Event> {
         final Event event = new Event();
 
         if (object.has("key")) {
-            event.setEventKey(object.get("key").getAsString());
+            event.setKey(object.get("key").getAsString());
         }
 
         if (object.has("name")) {
-            event.setEventName(object.get("name").getAsString());
+            event.setName(object.get("name").getAsString());
         }
 
         if (isNull(object.get("location"))) {
@@ -76,9 +76,9 @@ public class EventDeserializer implements JsonDeserializer<Event> {
         // "short_name" is not a required field in the API response.
         // If it is null, simply use the event name as the short name
         if (isNull(object.get("short_name"))) {
-            event.setEventShortName("");
+            event.setShortName("");
         } else {
-            event.setEventShortName(object.get("short_name").getAsString());
+            event.setShortName(object.get("short_name").getAsString());
         }
 
         if (!isNull(object.get("website"))) {

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/deserializers/TeamDeserializer.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/deserializers/TeamDeserializer.java
@@ -23,11 +23,11 @@ public class TeamDeserializer implements JsonDeserializer<Team> {
         // All the teams should have an associated key and team number,
         // but it doesn't hurt to check in the rare case something goes terribly wrong.
         if (!isNull(object.get("key"))) {
-            team.setTeamKey(object.get("key").getAsString());
+            team.setKey(object.get("key").getAsString());
         }
 
         if (!isNull(object.get("team_number"))) {
-            team.setTeamNumber(object.get("team_number").getAsInt());
+            team.setNumber(object.get("team_number").getAsInt());
         }
 
         // Some of the old teams don't have names and/or locations.

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/AllianceSelectionNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/AllianceSelectionNotification.java
@@ -64,7 +64,7 @@ public class AllianceSelectionNotification extends BaseNotification<AllianceSele
         Resources r = context.getResources();
         String eventName;
         try {
-            eventName = event.getEventShortName();
+            eventName = event.getShortName();
         } catch (BasicModel.FieldNotDefinedException e) {
             Log.e(getLogTag(), "Event data passed in this notification does not contain an event short name. Can't post notification");
             e.printStackTrace();
@@ -128,7 +128,7 @@ public class AllianceSelectionNotification extends BaseNotification<AllianceSele
 
         String titleString, shortName, shortCode;
         try {
-            shortName = event.getEventShortName();
+            shortName = event.getShortName();
             shortCode = EventHelper.getShortCodeForEventKey(event.getKey()).toUpperCase();
             titleString = c.getString(R.string.gameday_ticker_event_title_format, shortName, shortCode);
         } catch (BasicModel.FieldNotDefinedException e) {
@@ -146,7 +146,7 @@ public class AllianceSelectionNotification extends BaseNotification<AllianceSele
     public AllianceSelectionNotificationViewModel renderToViewModel(Context context, @Nullable Void aVoid) {
         String titleString;
         try {
-            titleString = getNotificationCardHeader(context, event.getEventShortName(), event.getKey());
+            titleString = getNotificationCardHeader(context, event.getShortName(), event.getKey());
         } catch (BasicModel.FieldNotDefinedException e) {
             titleString = eventKey;
         }

--- a/android/src/main/java/com/thebluealliance/androidclient/helpers/EventHelper.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/helpers/EventHelper.java
@@ -121,7 +121,7 @@ public final class EventHelper {
                  * Week 1 is actually Week 0.5, everything else is one less
                  * See http://www.usfirst.org/roboticsprograms/frc/blog-The-Palmetto-Regional
                  */
-                if (e.getEventYear() == 2016) {
+                if (e.getYear() == 2016) {
                     int week = e.getCompetitionWeek();
                     if (week == 1) {
                         return String.format(FLOAT_REGIONAL_LABEL, 0.5);
@@ -250,7 +250,7 @@ public final class EventHelper {
         String lastHeader = null, currentHeader = null;
         for (Event event : events) {
             try {
-                currentHeader = weekLabelFromNum(event.getEventYear(), event.getCompetitionWeek());
+                currentHeader = weekLabelFromNum(event.getYear(), event.getCompetitionWeek());
                 if (!currentHeader.equals(lastHeader)) {
                     output.add(new ListSectionHeaderViewModel(currentHeader + " Events"));
                 }

--- a/android/src/main/java/com/thebluealliance/androidclient/helpers/EventTeamHelper.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/helpers/EventTeamHelper.java
@@ -15,7 +15,7 @@ public final class EventTeamHelper {
     public static EventTeam fromEvent(String teamKey, Event in) throws BasicModel.FieldNotDefinedException {
         EventTeam eventTeam = new EventTeam();
         eventTeam.setEventKey(in.getKey());
-        eventTeam.setYear(in.getEventYear());
+        eventTeam.setYear(in.getYear());
         eventTeam.setCompWeek(in.getCompetitionWeek());
         eventTeam.setTeamKey(teamKey);
         eventTeam.setKey(EventTeamHelper.generateKey(in.getKey(), teamKey));

--- a/android/src/main/java/com/thebluealliance/androidclient/listitems/EventListElement.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/listitems/EventListElement.java
@@ -27,10 +27,10 @@ public class EventListElement extends ListElement implements Serializable {
     public EventListElement(Event event) throws BasicModel.FieldNotDefinedException {
         super(event.getKey());
         eventKey = "";
-        eventName = event.getEventName();
+        eventName = event.getName();
         eventDates = event.getDateString();
         eventLocation = event.getLocation();
-        eventYear = event.getEventYear();
+        eventYear = event.getYear();
         this.showMyTba = false;
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/listitems/TeamListElement.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/listitems/TeamListElement.java
@@ -23,7 +23,7 @@ public class TeamListElement extends ListElement {
 
     public TeamListElement(Team team) throws BasicModel.FieldNotDefinedException {
         super(team.getKey());
-        mTeamNumber = team.getTeamNumber();
+        mTeamNumber = team.getNumber();
         mTeamName = team.getNickname();
         mTeamLocation = team.getLocation();
         mShowLinkToTeamDetails = false;

--- a/android/src/main/java/com/thebluealliance/androidclient/models/Event.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/models/Event.java
@@ -87,7 +87,7 @@ public class Event extends BasicModel<Event> implements ViewModelRenderer<EventV
         return "";
     }
 
-    public int getEventYear() throws FieldNotDefinedException {
+    public int getYear() throws FieldNotDefinedException {
         if (fields.containsKey(EventsTable.YEAR) && fields.get(EventsTable.YEAR) instanceof Integer) {
             return (Integer) fields.get(EventsTable.YEAR);
         } else {
@@ -177,36 +177,37 @@ public class Event extends BasicModel<Event> implements ViewModelRenderer<EventV
         return getKey().replaceAll("[0-9]", "");
     }
 
-    public void setEventKey(String eventKey) {
-        if (!EventHelper.validateEventKey(eventKey))
-            throw new IllegalArgumentException("Invalid event key: " + eventKey + " Should be format <year><event>, like 2014cthar");
-        fields.put(EventsTable.KEY, eventKey);
-        fields.put(EventsTable.YEAR, Integer.parseInt(eventKey.substring(0, 4)));
+    public void setKey(String key) {
+        if (!EventHelper.validateEventKey(key)) {
+            throw new IllegalArgumentException("Invalid event key: " + key + " Should be format <year><event>, like 2014cthar");
+        }
+        fields.put(EventsTable.KEY, key);
+        fields.put(EventsTable.YEAR, Integer.parseInt(key.substring(0, 4)));
     }
 
-    public String getEventName() throws FieldNotDefinedException {
+    public String getName() throws FieldNotDefinedException {
         if (fields.containsKey(EventsTable.NAME) && fields.get(EventsTable.NAME) instanceof String) {
             return (String) fields.get(EventsTable.NAME);
         }
         throw new FieldNotDefinedException("Field Database.Events.NAME is not defined");
     }
 
-    public void setEventName(String eventName) {
-        fields.put(EventsTable.NAME, eventName);
+    public void setName(String name) {
+        fields.put(EventsTable.NAME, name);
     }
 
-    public String getEventShortName() throws FieldNotDefinedException {
+    public String getShortName() throws FieldNotDefinedException {
         if (fields.containsKey(EventsTable.SHORTNAME) && fields.get(EventsTable.SHORTNAME) instanceof String) {
             String shortName = (String) fields.get(EventsTable.SHORTNAME);
             if (shortName != null && !shortName.isEmpty()) {
                 return shortName;
             }
         }
-        return getEventName();
+        return getName();
     }
 
-    public void setEventShortName(String eventShortName) {
-        fields.put(EventsTable.SHORTNAME, eventShortName);
+    public void setShortName(String shortName) {
+        fields.put(EventsTable.SHORTNAME, shortName);
     }
 
     public String getLocation() throws FieldNotDefinedException {
@@ -467,13 +468,13 @@ public class Event extends BasicModel<Event> implements ViewModelRenderer<EventV
     }
 
     public String getSearchTitles() throws FieldNotDefinedException {
-        return getKey() + "," + getEventYear() + " " + getEventName() + "," + getEventYear() + " " + getEventShortName() + "," + getYearAgnosticEventKey() + " " + getEventYear();
+        return getKey() + "," + getYear() + " " + getName() + "," + getYear() + " " + getShortName() + "," + getYearAgnosticEventKey() + " " + getYear();
     }
 
     @Nullable @Override public EventViewModel renderToViewModel(Context context, @Nullable @RenderType Integer renderType) {
         EventViewModel model;
         try {
-            model = new EventViewModel(getKey(), getEventYear(), getEventShortName(), getDateString(), getLocation());
+            model = new EventViewModel(getKey(), getYear(), getShortName(), getDateString(), getLocation());
 
 
             switch (renderType) {

--- a/android/src/main/java/com/thebluealliance/androidclient/models/Team.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/models/Team.java
@@ -45,8 +45,8 @@ public class Team extends BasicModel<Team> implements ViewModelRenderer<TeamView
 
     public Team(String teamKey, int teamNumber, String nickname, String location) {
         this();
-        setTeamKey(teamKey);
-        setTeamNumber(teamNumber);
+        setKey(teamKey);
+        setNumber(teamNumber);
         setNickname(nickname);
         setLocation(location);
     }
@@ -81,8 +81,8 @@ public class Team extends BasicModel<Team> implements ViewModelRenderer<TeamView
         return "";
     }
 
-    public void setTeamKey(String teamKey) {
-        fields.put(TeamsTable.KEY, teamKey);
+    public void setKey(String key) {
+        fields.put(TeamsTable.KEY, key);
     }
 
     public String getNickname() {
@@ -108,15 +108,15 @@ public class Team extends BasicModel<Team> implements ViewModelRenderer<TeamView
         fields.put(TeamsTable.LOCATION, location);
     }
 
-    public Integer getTeamNumber() throws FieldNotDefinedException {
+    public Integer getNumber() throws FieldNotDefinedException {
         if (fields.containsKey(TeamsTable.NUMBER) && fields.get(TeamsTable.NUMBER) instanceof Integer) {
             return (Integer) fields.get(TeamsTable.NUMBER);
         }
         throw new FieldNotDefinedException("Field Database.Teams.NUMBER is not defined");
     }
 
-    public void setTeamNumber(int teamNumber) {
-        fields.put(TeamsTable.NUMBER, teamNumber);
+    public void setNumber(int number) {
+        fields.put(TeamsTable.NUMBER, number);
     }
 
     public void setYearsParticipated(JsonArray years) {
@@ -141,7 +141,7 @@ public class Team extends BasicModel<Team> implements ViewModelRenderer<TeamView
 
     public String getSearchTitles() {
         try {
-            return getKey() + "," + getNickname() + "," + getTeamNumber();
+            return getKey() + "," + getNickname() + "," + getNumber();
         } catch (FieldNotDefinedException e) {
             Log.w(Constants.LOG_TAG, "Missing fields for creating search titles\n"
                     + "Required: Database.Teams.KEY, Database.Teams.SHORTNAME, Database.Teams.NUMBER");
@@ -165,7 +165,7 @@ public class Team extends BasicModel<Team> implements ViewModelRenderer<TeamView
     public TeamViewModel renderToViewModel(Context context, @Nullable @RenderType Integer renderType) {
         try {
             int safeRenderType = renderType == null ? RENDER_BASIC : renderType;
-            TeamViewModel model = new TeamViewModel(getKey(), getTeamNumber(), getNickname(), getLocation());
+            TeamViewModel model = new TeamViewModel(getKey(), getNumber(), getNickname(), getLocation());
             model.setShowLinkToTeamDetails(false);
             model.setShowMyTbaDetails(false);
             switch (safeRenderType) {

--- a/android/src/main/java/com/thebluealliance/androidclient/renderers/EventRenderer.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/renderers/EventRenderer.java
@@ -51,8 +51,8 @@ public class EventRenderer implements ModelRenderer<Event, Boolean> {
         try {
             return new EventListElement(
               event.getKey(),
-              event.getEventYear(),
-              event.getEventShortName(),
+              event.getYear(),
+              event.getShortName(),
               event.getDateString(),
               event.getLocation(),
               safeMyTba);
@@ -71,7 +71,7 @@ public class EventRenderer implements ModelRenderer<Event, Boolean> {
             int i = 1;
             for (JsonElement webcast : event.getWebcasts()) {
                 try {
-                    webcasts.add(new WebcastListElement(event.getKey(), event.getEventShortName(), webcast.getAsJsonObject(), i));
+                    webcasts.add(new WebcastListElement(event.getKey(), event.getShortName(), webcast.getAsJsonObject(), i));
                     i++;
                 } catch (BasicModel.FieldNotDefinedException e) {
                     Log.w(Constants.LOG_TAG, "Missing fields for rendering event webcasts: KEY, SHORTNAME");

--- a/android/src/main/java/com/thebluealliance/androidclient/renderers/MyTbaModelRenderer.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/renderers/MyTbaModelRenderer.java
@@ -74,8 +74,8 @@ public class MyTbaModelRenderer implements ModelRenderer<Void, Void> {
                     }
                     text = String.format("%1$s @ %2$d %3$s",
                       eTeam.getNickname(),
-                      eEvent.getEventYear(),
-                      eEvent.getEventShortName());
+                      eEvent.getYear(),
+                      eEvent.getShortName());
                     return new ModelListElement(text, key, type);
                 case DISTRICT:
                     DistrictListElement element = mDistrictRenderer.renderFromKey(

--- a/android/src/main/java/com/thebluealliance/androidclient/renderers/TeamRenderer.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/renderers/TeamRenderer.java
@@ -52,7 +52,7 @@ public class TeamRenderer implements ModelRenderer<Team, Integer> {
         try {
             return new TeamListElement(
               team.getKey(),
-              team.getTeamNumber(),
+              team.getNumber(),
               team.getNickname(),
               team.getLocation(),
               safeRenderType == RENDER_DETAILS_BUTTON,

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriber.java
@@ -14,9 +14,9 @@ public class EventInfoSubscriber extends BaseAPISubscriber<Event, Model> {
     public void parseData() throws BasicModel.FieldNotDefinedException {
         mDataToBind = new Model();
         mDataToBind.eventKey = mAPIData.getKey();
-        mDataToBind.nameString = mAPIData.getEventName();
-        mDataToBind.actionBarTitle = mAPIData.getEventShortName();
-        mDataToBind.actionBarSubtitle = String.valueOf(mAPIData.getEventYear());
+        mDataToBind.nameString = mAPIData.getName();
+        mDataToBind.actionBarTitle = mAPIData.getShortName();
+        mDataToBind.actionBarSubtitle = String.valueOf(mAPIData.getYear());
         mDataToBind.venueString = mAPIData.getVenue();
         mDataToBind.locationString = mAPIData.getLocation();
         mDataToBind.eventWebsite = mAPIData.getWebsite();

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchInfoSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchInfoSubscriber.java
@@ -74,7 +74,7 @@ public class MatchInfoSubscriber extends BaseAPISubscriber<Model, List<ListItem>
             }
         }
 
-        updateActionBarTitle(mAPIData.event.getEventShortName());
+        updateActionBarTitle(mAPIData.event.getShortName());
     }
 
     @Override public boolean isDataValid() {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictBreakdownSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictBreakdownSubscriber.java
@@ -66,7 +66,7 @@ public class TeamAtDistrictBreakdownSubscriber
             Event event = mDb.getEventsTable().get(eventData.getKey());
             ListGroup eventGroup = new ListGroup(event == null
               ? eventData.getKey()
-              : event.getEventName());
+              : event.getName());
 
             DistrictPointBreakdown breakdown =
               mGson.fromJson(eventData.getValue(), DistrictPointBreakdown.class);

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictSummarySubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtDistrictSummarySubscriber.java
@@ -56,7 +56,7 @@ public class TeamAtDistrictSummarySubscriber
         if (mAPIData.hasField(DistrictTeamsTable.EVENT1_KEY)
                 && mAPIData.hasField(DistrictTeamsTable.EVENT1_POINTS)) {
             Event event1 = eventsTable.get(mAPIData.getEvent1Key());
-            String event1Name = event1 != null ? event1.getEventShortName() : mAPIData.getEvent1Key();
+            String event1Name = event1 != null ? event1.getShortName() : mAPIData.getEvent1Key();
             mDataToBind.add(new LabelValueDetailListItem(event1Name,
                     String.format(
                             mResources.getString(R.string.district_points_format), mAPIData.getEvent1Points()),
@@ -66,7 +66,7 @@ public class TeamAtDistrictSummarySubscriber
         if (mAPIData.hasField(DistrictTeamsTable.EVENT2_KEY)
                 && mAPIData.hasField(DistrictTeamsTable.EVENT2_POINTS)) {
             Event event2 = eventsTable.get(mAPIData.getEvent2Key());
-            String event2Name = event2 != null ? event2.getEventShortName() : mAPIData.getEvent2Key();
+            String event2Name = event2 != null ? event2.getShortName() : mAPIData.getEvent2Key();
             mDataToBind.add(new LabelValueDetailListItem(event2Name,
                     String.format(
                             mResources.getString(R.string.district_points_format), mAPIData.getEvent2Points()),
@@ -76,7 +76,7 @@ public class TeamAtDistrictSummarySubscriber
         if (mAPIData.hasField(DistrictTeamsTable.CMP_KEY)
                 && mAPIData.hasField(DistrictTeamsTable.CMP_POINTS)) {
             Event districtCmp = eventsTable.get(mAPIData.getCmpKey());
-            String cmpName = districtCmp != null ? districtCmp.getEventShortName() : mAPIData.getCmpKey();
+            String cmpName = districtCmp != null ? districtCmp.getShortName() : mAPIData.getCmpKey();
             mDataToBind.add(new LabelValueDetailListItem(cmpName,
                     String.format(
                             mResources.getString(R.string.district_points_format), mAPIData.getCmpPoints()),

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtEventSummarySubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamAtEventSummarySubscriber.java
@@ -84,11 +84,11 @@ public class TeamAtEventSummarySubscriber extends BaseAPISubscriber<Model, List<
                 String.format("%1$d - %2$d - %3$d", record[0], record[1], record[2]);
 
         Event event = mAPIData.event;
-        int year = event.getEventYear();
+        int year = event.getYear();
         boolean activeEvent = event.isHappeningNow();
         String actionBarTitle =
                 String.format(mResources.getString(R.string.team_actionbar_title), mTeamKey.substring(3));
-        String actionBarSubtitle = String.format("@ %1$d %2$s", year, event.getEventShortName());
+        String actionBarSubtitle = String.format("@ %1$d %2$s", year, event.getShortName());
         EventBus.getDefault().post(new ActionBarTitleEvent(actionBarTitle, actionBarSubtitle));
 
         if (activeEvent) {
@@ -164,7 +164,7 @@ public class TeamAtEventSummarySubscriber extends BaseAPISubscriber<Model, List<
 
         try {
             if (event.isChampsEvent()
-                    && event.getEventYear() == 2016
+                    && event.getYear() == 2016
                     && PitLocationHelper.shouldShowPitLocation(mContext, mTeamKey)) {
                 PitLocationHelper.TeamPitLocation location = PitLocationHelper.getPitLocation(mContext, mTeamKey);
                 if (location != null) {

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamInfoSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/TeamInfoSubscriber.java
@@ -17,7 +17,7 @@ public class TeamInfoSubscriber extends BaseAPISubscriber<Team, TeamInfoBinder.M
         mDataToBind.teamKey = mAPIData.getKey();
         mDataToBind.fullName = mAPIData.getFullName();
         mDataToBind.nickname = mAPIData.getNickname();
-        mDataToBind.teamNumber = mAPIData.getTeamNumber();
+        mDataToBind.teamNumber = mAPIData.getNumber();
         mDataToBind.location = mAPIData.getLocation();
         if (mAPIData.getParams().containsKey(TeamsTable.WEBSITE)) {
             mDataToBind.website = mAPIData.getWebsite();

--- a/android/src/test/java/com/thebluealliance/androidclient/datafeed/TBAApiTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/datafeed/TBAApiTest.java
@@ -39,8 +39,8 @@ public class TBAApiTest {
             assertEquals(event.getKey(), "2014ctgro");
             assertEquals(event.getStartDate(), new Date(114, 2, 8));
             assertEquals(event.getEndDate(), new Date(114, 2, 9));
-            assertEquals(event.getEventName(), "Groton District Event");
-            assertEquals(event.getEventShortName(), "Groton");
+            assertEquals(event.getName(), "Groton District Event");
+            assertEquals(event.getShortName(), "Groton");
             assertEquals(event.isOfficial(), true);
             assertEquals(event.getLocation(), "Groton, CT, USA");
             assertEquals(event.getEventType(), EventType.DISTRICT);
@@ -70,7 +70,7 @@ public class TBAApiTest {
             assertEquals(team.getWebsite(), "http://www.uberbots.org");
             assertEquals(team.getFullName(), "UTC Fire and Security & Avon High School");
             assertEquals(team.getLocation(), "Avon, CT, USA");
-            assertEquals((int) team.getTeamNumber(), 1124);
+            assertEquals((int) team.getNumber(), 1124);
             assertEquals(team.getKey(), "frc1124");
             assertEquals(team.getNickname(), "ÜberBots");
         } catch (BasicModel.FieldNotDefinedException e) {

--- a/android/src/test/java/com/thebluealliance/androidclient/helpers/EventHelperTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/helpers/EventHelperTest.java
@@ -364,7 +364,7 @@ public class EventHelperTest {
 
     private static Event mockRegularEvent(EventType type, int year, int week) throws BasicModel.FieldNotDefinedException {
         Event event = mockEventType(type);
-        when(event.getEventYear()).thenReturn(year);
+        when(event.getYear()).thenReturn(year);
         when(event.getCompetitionWeek()).thenReturn(week);
         return event;
     }

--- a/android/src/test/java/com/thebluealliance/androidclient/models/EventTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/models/EventTest.java
@@ -35,14 +35,14 @@ public class EventTest {
         assertEquals(mEvent.getWebsite(), "http://www.nefirst.org/");
         assertTrue(mEvent.isOfficial());
         assertEquals(mEvent.getCompetitionWeek(), 5);
-        assertEquals(mEvent.getEventName(), "NE District - Hartford Event");
-        assertEquals(mEvent.getEventShortName(), "Hartford");
+        assertEquals(mEvent.getName(), "NE District - Hartford Event");
+        assertEquals(mEvent.getShortName(), "Hartford");
         assertEquals(mEvent.getDistrictEnum(),
                      DistrictType.NEW_ENGLAND.ordinal());
         assertEquals(mEvent.getVenue(), "Hartford Public High School\n55 Forest Street\nHartford, CT 06105\nUSA");
         assertEquals(mEvent.getLocation(), "Hartford, CT, USA");
         assertEquals(mEvent.getYearAgnosticEventKey(), "cthar");
-        assertEquals(mEvent.getEventYear(), 2015);
+        assertEquals(mEvent.getYear(), 2015);
         assertEquals(mEvent.getEventType(),
                      EventType.DISTRICT);
         assertFalse(mEvent.getWebcasts().isJsonNull());

--- a/android/src/test/java/com/thebluealliance/androidclient/models/TeamTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/models/TeamTest.java
@@ -30,6 +30,6 @@ public class TeamTest {
         assertEquals("UberBots", mTeam.getNickname());
         assertEquals("http://www.uberbots.org", mTeam.getWebsite());
         assertEquals("Avon, Connecticut, USA", mTeam.getLocation());
-        assertEquals(1124, (int)mTeam.getTeamNumber());
+        assertEquals(1124, (int)mTeam.getNumber());
     }
 }

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/EventInfoSubscriberTest.java
@@ -42,9 +42,9 @@ public class EventInfoSubscriberTest extends TestCase {
         EventInfoBinder.Model data = DatafeedTestDriver.getParsedData(mSubscriber, mEvent);
 
         assertEquals(data.eventKey, mEvent.getKey());
-        assertEquals(data.nameString, mEvent.getEventName());
-        assertEquals(data.actionBarTitle, mEvent.getEventShortName());
-        assertEquals(data.actionBarSubtitle, String.valueOf(mEvent.getEventYear()));
+        assertEquals(data.nameString, mEvent.getName());
+        assertEquals(data.actionBarTitle, mEvent.getShortName());
+        assertEquals(data.actionBarSubtitle, String.valueOf(mEvent.getYear()));
         assertEquals(data.venueString, mEvent.getVenue());
         assertEquals(data.locationString, mEvent.getLocation());
         assertEquals(data.eventWebsite, mEvent.getWebsite());


### PR DESCRIPTION
**Summary:** I've been bugged for a long time by method names like `Event.getEventName()`. We know we're getting the *event* name because we're working with an `Event` object! This PR cleans things up by removing unneeded references to model type in get/set method names. This conveniently makes the internal model APIs more consistent. Zero change in functionality; this is all about aesthetics and consistency.

**Issues Reference:** N/A

**Test Plan:** N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/753)
<!-- Reviewable:end -->
