### PR TITLE
[SQLite] Use quotes when matching team keys in JSON strings

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/database/tables/AwardsTable.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/tables/AwardsTable.java
@@ -46,7 +46,7 @@ public class AwardsTable extends ModelTable<Award> {
 
     public List<Award> getTeamAtEventAwards(String teamKey, String eventKey) {
         Cursor cursor = mDb.rawQuery("SELECT * FROM `" + Database.TABLE_AWARDS + "` WHERE `" + EVENTKEY
-          + "` = ? AND `" + WINNERS + "` LIKE '%" + teamKey + "," + "%'", new String[]{eventKey});
+          + "` = ? AND `" + WINNERS + "` LIKE '%\"" + teamKey + "\"%'", new String[]{eventKey});
         List<Award> models = new ArrayList<>(cursor == null ? 0 : cursor.getCount());
         if (cursor == null || !cursor.moveToFirst()) {
             return models;

--- a/android/src/main/java/com/thebluealliance/androidclient/database/tables/MatchesTable.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/tables/MatchesTable.java
@@ -46,7 +46,7 @@ public class MatchesTable extends ModelTable<Match> {
 
     public List<Match> getTeamAtEventMatches(String teamKey, String eventKey) {
         Cursor cursor = mDb.rawQuery("SELECT * FROM `" + Database.TABLE_MATCHES + "` WHERE `" + EVENT
-          + "` = ? AND `" + ALLIANCES + "` LIKE '%" + teamKey + "," + "%'", new String[]{eventKey});
+          + "` = ? AND `" + ALLIANCES + "` LIKE '%\"" + teamKey + "\"%'", new String[]{eventKey});
         List<Match> models = new ArrayList<>(cursor == null ? 0 : cursor.getCount());
         if (cursor == null || !cursor.moveToFirst()) {
             return models;


### PR DESCRIPTION
**Summary:** The previous LIKE statement never actually worked. Because the JSON strings we were searching looked like `...["frc111","frc254","frc1114"]...`, matching against something like `frc111,` didn't actually work because of the quotes. This PR matches against `"frc111"` instead. This also avoids `frc111` inadvertently matching `frc1114`.

**Issues Reference:** N/A

**Test Plan:** We really should find a way to test queries, because this has been broken for a long time and I only caught it because I happened to take a close look at this. That's beyond the scope of this PR, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/754)
<!-- Reviewable:end -->
