### PR TITLE
Fix Travis Return Code Filter

### DIFF
--- a/scripts/travis-worker.sh
+++ b/scripts/travis-worker.sh
@@ -5,12 +5,11 @@
 
 filter_code () {
     # Allow a return code of 137, we'll whitelist robolectric OOMs
-    RET=$?
-    if test "$RET" = "137" ; then
+    if test "$1" = "137" ; then
         echo "Allowing gradle return code 137. Probably a Robolectric OOM bug :("
-    elif test "$RET" != "0" ; then
-        echo "Error with job, exited with code $RET"
-        exit $RET
+    elif test "$1" != "0" ; then
+        echo "Error with job, exited with code $1"
+        exit $1
     fi
 }
 
@@ -19,19 +18,19 @@ case "$1" in
     "UNIT")
         echo "Running project unit tests"
         ./gradlew testProdDebugProguardUnitTest --stacktrace
-        filter_code
+        filter_code $?
         ;;
 
     "COVERAGE")
         echo "Generating project code coverage"
         ./gradlew jacocoTestReport coveralls
-        filter_code
+        filter_code $?
         ;;
 
     "CHECKSTYLE")
         echo "Running project checkstyle"
         ./gradlew androidCheckstyle
-        filter_code
+        filter_code $?
         ;;
 
     *)


### PR DESCRIPTION
**Summary:** When travis fails with exit code 137, we should just allow, since it's not an actual failure, just a side effect of memory issues.

**Issues Reference:** N/A

**Test Plan:** Intermittent, so it hopefully works...

**Screenshots:** N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/755)
<!-- Reviewable:end -->
