### PR TITLE
Migrate users from legacy auth to Firebase

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -248,6 +248,12 @@
         <service
             android:name=".imgur.ImgurSuggestionService"
             android:exported="false" />
+        <service
+                android:name=".auth.firebase.MigrateLegacyUserToFirebase"
+                android:exported="false" />
+        <service
+                android:name=".mytba.MyTbaRegistrationService"
+                android:exported="false" />
     </application>
 
 </manifest>

--- a/android/src/main/java/com/google/firebase/auth/GoogleAuthCredentialWrapper.java
+++ b/android/src/main/java/com/google/firebase/auth/GoogleAuthCredentialWrapper.java
@@ -1,0 +1,13 @@
+package com.google.firebase.auth;
+
+import android.support.annotation.Nullable;
+
+/**
+ * A wrapper for {@link GoogleAuthCredential}, because the original class doesn't have a
+ * public constructor
+ */
+public class GoogleAuthCredentialWrapper extends GoogleAuthCredential {
+    public GoogleAuthCredentialWrapper(@Nullable String idToken, @Nullable String accessToken) {
+        super(idToken, accessToken);
+    }
+}

--- a/android/src/main/java/com/thebluealliance/androidclient/auth/AuthProvider.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/auth/AuthProvider.java
@@ -32,4 +32,5 @@ public interface AuthProvider {
 
     Observable<? extends User> userFromSignInResult(int requestCode, int resultCode, Intent data);
 
+    Observable<? extends User> signInLegacyUser();
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/auth/firebase/MigrateLegacyUserToFirebase.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/auth/firebase/MigrateLegacyUserToFirebase.java
@@ -1,0 +1,55 @@
+package com.thebluealliance.androidclient.auth.firebase;
+
+import com.thebluealliance.androidclient.Constants;
+import com.thebluealliance.androidclient.TBAAndroid;
+import com.thebluealliance.androidclient.auth.AuthProvider;
+import com.thebluealliance.androidclient.auth.User;
+import com.thebluealliance.androidclient.di.components.DaggerMyTbaComponent;
+import com.thebluealliance.androidclient.di.components.MyTbaComponent;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.util.Log;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+public class MigrateLegacyUserToFirebase extends IntentService {
+
+    @Inject @Named("firebase_auth") AuthProvider mAuthProvider;
+
+    /**
+     * Creates an IntentService.  Invoked by your subclass's constructor.
+     */
+    public MigrateLegacyUserToFirebase() {
+        super("migrate-legacy-user");
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        getComponenet().inject(this);
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        Log.d(Constants.LOG_TAG, "Trying to migrate legacy auth to Firebase");
+        User user = mAuthProvider.signInLegacyUser().toBlocking().first();
+
+        if (user != null) {
+            Log.d(Constants.LOG_TAG, "Migrated user");
+        } else {
+            Log.d(Constants.LOG_TAG, "Failed to migrate");
+        }
+    }
+
+    private MyTbaComponent getComponenet() {
+        TBAAndroid application = ((TBAAndroid) getApplication());
+        return DaggerMyTbaComponent.builder()
+                                   .applicationComponent(application.getComponent())
+                                   .gceModule(application.getGceModule())
+                                   .authModule(application.getAuthModule())
+                                   .gcmModule(application.getGcmModule())
+                                   .build();
+    }
+}

--- a/android/src/main/java/com/thebluealliance/androidclient/auth/google/GoogleAuthProvider.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/auth/google/GoogleAuthProvider.java
@@ -5,6 +5,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.auth.api.signin.GoogleSignInResult;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.common.api.OptionalPendingResult;
 import com.google.firebase.auth.AuthCredential;
 
 import com.thebluealliance.androidclient.Constants;
@@ -16,6 +17,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
 import android.util.Log;
 
 import javax.inject.Inject;
@@ -85,6 +87,19 @@ public class GoogleAuthProvider implements AuthProvider,
             mCurrentUser = new GoogleSignInUser(result.getSignInAccount());
         }
         return Observable.just(mCurrentUser);
+    }
+
+    @WorkerThread
+    public Observable<GoogleSignInUser> signInLegacyUser() {
+        onStart();
+        OptionalPendingResult<GoogleSignInResult> optionalResult = Auth.GoogleSignInApi
+                .silentSignIn(mGoogleApiClient);
+        GoogleSignInResult result = optionalResult.await();
+        onStop();
+        if (result.isSuccess()) {
+            return Observable.just(new GoogleSignInUser(result.getSignInAccount()));
+        }
+        return Observable.empty();
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/di/components/MyTbaComponent.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/di/components/MyTbaComponent.java
@@ -5,6 +5,7 @@ import com.thebluealliance.androidclient.activities.MyTBASettingsActivity;
 import com.thebluealliance.androidclient.activities.settings.MyTBAModelSettingsActivity;
 import com.thebluealliance.androidclient.activities.settings.SettingsActivity;
 import com.thebluealliance.androidclient.auth.AuthModule;
+import com.thebluealliance.androidclient.auth.firebase.MigrateLegacyUserToFirebase;
 import com.thebluealliance.androidclient.database.writers.DatabaseWriterModule;
 import com.thebluealliance.androidclient.datafeed.gce.GceModule;
 import com.thebluealliance.androidclient.fragments.NavigationDrawerFragment;
@@ -35,4 +36,5 @@ public interface MyTbaComponent {
     void inject(MyTBASettingsActivity myTBASettingsActivity);
     void inject(UpdateUserModelSettingsTaskFragment updateUserModelSettingsTaskFragment);
     void inject(MyTBAModelSettingsActivity myTBAModelSettingsActivity);
+    void inject(MigrateLegacyUserToFirebase migrateLegacyUserToFirebase);
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/NavigationDrawerFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/NavigationDrawerFragment.java
@@ -8,6 +8,7 @@ import com.thebluealliance.androidclient.accounts.AccountController;
 import com.thebluealliance.androidclient.adapters.NavigationDrawerAdapter;
 import com.thebluealliance.androidclient.auth.AuthProvider;
 import com.thebluealliance.androidclient.auth.User;
+import com.thebluealliance.androidclient.auth.firebase.MigrateLegacyUserToFirebase;
 import com.thebluealliance.androidclient.di.components.HasMyTbaComponent;
 import com.thebluealliance.androidclient.listitems.DividerListItem;
 import com.thebluealliance.androidclient.listitems.ListItem;
@@ -16,6 +17,7 @@ import com.thebluealliance.androidclient.listitems.SpacerListItem;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
@@ -192,6 +194,10 @@ public class NavigationDrawerFragment extends Fragment {
                 }
             } else {
                 Log.w(Constants.LOG_TAG, "No current user found");
+                // If myTBA /should/ be enabled, but we don't have a registered Firebase user,
+                // then we're probably upgrading from a pre-firebase version. Try and migrate
+                Activity activity = getActivity();
+                activity.startService(new Intent(activity, MigrateLegacyUserToFirebase.class));
             }
         }
 


### PR DESCRIPTION
**Summary:** When a user upgrades to the newest version of the app (with an existing Google auth token), we'll recover and register for Firebase in the background

**Test Plan:** Downgraded to b26c91d015365c0008712f177c251bae738585b6 and then upgraded the app, verified my account appeared in the Firebase console

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/758)
<!-- Reviewable:end -->
