### PR TITLE
Get ConnectivityManager with an ApplicationContext

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/helpers/ConnectionDetector.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/helpers/ConnectionDetector.java
@@ -12,7 +12,8 @@ public final class ConnectionDetector {
 
     public static boolean isConnectedToInternet(Context context) {
         ConnectivityManager cm =
-                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+                (ConnectivityManager) context.getApplicationContext()
+                                             .getSystemService(Context.CONNECTIVITY_SERVICE);
 
         NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
         return activeNetwork != null && activeNetwork.isConnectedOrConnecting();


### PR DESCRIPTION
**Summary:** Android has a bug where the service is created the first time with the
passed Context. The suggested workaround was to use ApplicationContext

See https://code.google.com/p/android/issues/detail?id=198852

**Issues Reference:**

**Test Plan:** 

**Screenshots:**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-blue-alliance/the-blue-alliance-android/759)
<!-- Reviewable:end -->
