### PR TITLE
Optional google-secrets.json

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/auth/firebase/MigrateLegacyUserToFirebase.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/auth/firebase/MigrateLegacyUserToFirebase.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.androidclient.auth.firebase;
 
 import com.thebluealliance.androidclient.TBAAndroid;
+import com.thebluealliance.androidclient.TbaLogger;
 import com.thebluealliance.androidclient.auth.AuthProvider;
 import com.thebluealliance.androidclient.auth.User;
 import com.thebluealliance.androidclient.di.components.DaggerMyTbaComponent;
@@ -8,7 +9,6 @@ import com.thebluealliance.androidclient.di.components.MyTbaComponent;
 
 import android.app.IntentService;
 import android.content.Intent;
-import com.thebluealliance.androidclient.TbaLogger;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -33,7 +33,7 @@ public class MigrateLegacyUserToFirebase extends IntentService {
     @Override
     protected void onHandleIntent(Intent intent) {
         TbaLogger.d("Trying to migrate legacy auth to Firebase");
-        User user = mAuthProvider.signInLegacyUser().toBlocking().first();
+        User user = mAuthProvider.signInLegacyUser().toBlocking().firstOrDefault(null);
 
         if (user != null) {
             TbaLogger.d("Migrated user");


### PR DESCRIPTION
**Summary:** Currently the app insta-crashes without the `google-secrets.json` file required by Firebase Authentication. This is because the library throws an exception when it can't find the file. This PR make it optional by catching the exception within DI and `FirebaseAuth` being `@Nullable` (enforced by Dagger)

**Test Plan:** Dagger enforces compile-time validity

