### PR TITLE
Target API 23

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -105,7 +105,7 @@ android {
     defaultConfig {
         applicationId "com.thebluealliance.androidclient"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode versionNum
         versionName version.toString()
         multiDexEnabled true
@@ -280,6 +280,8 @@ dependencies {
     compile 'com.wada811:android-material-design-colors:3.0.0'
     compile 'com.thebluealliance:spectrum:0.6.0'
     compile 'javax.annotation:javax.annotation-api:1.2'
+    compile "com.github.hotchemi:permissionsdispatcher:${permissionDispatcherVersion}"
+    apt "com.github.hotchemi:permissionsdispatcher-processor:${permissionDispatcherVersion}"
 
     // testing
     testCompile "org.robolectric:robolectric:${robolectricVersion}"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -14,10 +14,15 @@
     <uses-permission android:name="com.thebluealliance.androidclient.permission.C2D_MESSAGE" />
 
     <!-- Device Accounts -->
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
+
+    <!-- This is not needed with android 6.0 (API 23) anymore, since we only need this to
+         interact with our own Authenticator to create a TBA system account
+         https://developer.android.com/reference/android/Manifest.permission.html#GET_ACCOUNTS -->
+    <uses-permission android:name="android.permission.GET_ACCOUNTS"
+                     android:maxSdkVersion="22"/>
 
     <!-- Used so we can save images taken with the camera -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
@@ -23,6 +23,7 @@ import com.thebluealliance.androidclient.subscribers.YearsParticipatedDropdownSu
 import com.thebluealliance.androidclient.types.ModelType;
 import com.thebluealliance.androidclient.views.SlidingTabs;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
@@ -30,10 +31,13 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
+import android.support.annotation.RequiresPermission;
 import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
 import android.support.v4.view.ViewCompat;
@@ -46,6 +50,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ListAdapter;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,8 +61,18 @@ import javax.inject.Inject;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
+import permissions.dispatcher.NeedsPermission;
+import permissions.dispatcher.OnNeverAskAgain;
+import permissions.dispatcher.OnPermissionDenied;
+import permissions.dispatcher.OnShowRationale;
+import permissions.dispatcher.PermissionRequest;
+import permissions.dispatcher.RuntimePermissions;
 import rx.schedulers.Schedulers;
 
+import static android.content.pm.PackageManager.PERMISSION_DENIED;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+
+@RuntimePermissions
 public class ViewTeamActivity extends MyTBASettingsActivity implements
         ViewPager.OnPageChangeListener,
         View.OnClickListener,
@@ -206,6 +221,12 @@ public class ViewTeamActivity extends MyTBASettingsActivity implements
         if (mCurrentPhotoUri != null) {
             outState.putString(CURRENT_PHOTO_URI, mCurrentPhotoUri);
         }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        ViewTeamActivityPermissionsDispatcher.onRequestPermissionsResult(this, requestCode, grantResults);
     }
 
     @Override
@@ -369,7 +390,7 @@ public class ViewTeamActivity extends MyTBASettingsActivity implements
                             .setAdapter(adapter, (dialog, position) -> {
                                 switch (position) {
                                     case 0: // take picture
-                                        takePicture();
+                                        ViewTeamActivityPermissionsDispatcher.takePictureWithCheck(this);
                                         dialog.cancel();
                                         break;
                                     case 1: // select from gallery
@@ -400,7 +421,15 @@ public class ViewTeamActivity extends MyTBASettingsActivity implements
         }
     }
 
-    private void takePicture() {
+    @RequiresPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    @NeedsPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    void takePicture() {
+        if (!checkHasStoragePermission()) {
+            TbaLogger.e("Permission WRITE_EXTERNAL_STORAGE not granted");
+            showSnackbar(R.string.error_taking_picture);
+            return;
+        }
+
         Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         // Ensure that there's a camera activity to handle the intent
         if (takePictureIntent.resolveActivity(getPackageManager()) != null) {
@@ -411,15 +440,31 @@ public class ViewTeamActivity extends MyTBASettingsActivity implements
             } catch (IOException ex) {
                 // Error occurred while creating the File
                 // TODO handle this
-                ex.printStackTrace();
+                TbaLogger.e("Unable to create image file", ex);
                 showSnackbar(R.string.error_taking_picture);
             }
             // Continue only if the File was successfully created
             if (photoFile != null) {
                 takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(photoFile));
                 startActivityForResult(takePictureIntent, TAKE_PICTURE_REQUEST);
+            } else {
+                TbaLogger.w("Unable to open file for photo");
+                showSnackbar(R.string.error_taking_picture);
             }
+        } else {
+            TbaLogger.w("Unable to resolve ");
+            showSnackbar(R.string.error_taking_picture);
         }
+    }
+
+    @OnShowRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    void showRationaleForStorage(final PermissionRequest request) {
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.camera_permission_title)
+                .setMessage(R.string.camera_permission_rationale)
+                .setPositiveButton(R.string.allow, (dialog, button) -> request.proceed())
+                .setNegativeButton(R.string.deny, (dialog, button) -> request.cancel())
+                .show();
     }
 
     @Override
@@ -441,13 +486,14 @@ public class ViewTeamActivity extends MyTBASettingsActivity implements
         }
     }
 
+    @RequiresPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
     private File createImageFile() throws IOException {
         // Create an image file name
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "JPEG_" + timeStamp + "_";
         File storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
         storageDir = new File(storageDir, "The Blue Alliance");
-        storageDir.mkdir();
+        storageDir.mkdirs();
         File image = File.createTempFile(
                 imageFileName,  /* prefix */
                 ".jpg",         /* suffix */
@@ -456,6 +502,16 @@ public class ViewTeamActivity extends MyTBASettingsActivity implements
 
         mCurrentPhotoUri = "file:" + image.getAbsolutePath();
         return image;
+    }
+
+    private boolean checkHasStoragePermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return PERMISSION_GRANTED == checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        } else {
+            // No runtime permissions before API 23, so everything is "granted" as it's declared
+            // in the app Manifest
+            return true;
+        }
     }
 
     private void markMediaSnackbarAsDismissed() {

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
@@ -50,7 +50,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ListAdapter;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,14 +61,11 @@ import javax.inject.Inject;
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import permissions.dispatcher.NeedsPermission;
-import permissions.dispatcher.OnNeverAskAgain;
-import permissions.dispatcher.OnPermissionDenied;
 import permissions.dispatcher.OnShowRationale;
 import permissions.dispatcher.PermissionRequest;
 import permissions.dispatcher.RuntimePermissions;
 import rx.schedulers.Schedulers;
 
-import static android.content.pm.PackageManager.PERMISSION_DENIED;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
 @RuntimePermissions

--- a/android/src/main/java/com/thebluealliance/androidclient/auth/AuthModule.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/auth/AuthModule.java
@@ -34,7 +34,7 @@ public class AuthModule {
             /* When there is no google-secrets.json file found, the library throws an exception
              * here which causes insta-crashes for us. Silently recover here...
              */
-            TbaLogger.w("Unable to find google-secrets.json, disabling login");
+            TbaLogger.e("Unable to find google-secrets.json, disabling login");
             return null;
         }
     }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -82,6 +82,10 @@
     <string name="view_team_cd">View photos on Chief Delphi</string>
     <string name="error_loading_image">Error loading image</string>
     <string name="error_taking_picture">Error taking picture</string>
+    <string name="camera_permission_title">Allow access to external storage</string>
+    <string name="camera_permission_rationale">Granting this permission allows the app to save your media suggestions to local storage so they can be uploaded to The Blue Alliance.</string>
+    <string name="allow">Allow</string>
+    <string name="deny">Deny</string>
 
     <!-- View Match Details -->
     <string name="teams">Teams</string>

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ allprojects {
         daggerVersion = '2.7'
         leakCanaryVersion = '1.5'
         robolectricVersion = '3.1.3'
+        permissionDispatcherVersion = '2.2.0'
 
         travisBuild = System.getenv("TRAVIS") == "true"
         // allows for -Dpre-dex=false to be set


### PR DESCRIPTION
**Summary:** 
 - Adds runtime permission checks for WRITE_EXTERNAL_STORAGE in saving
   team media suggestions
 - Only request GET_ACCOUNTS for SDK <= 22 (it is not required for our
   use case in 23+)
 - Add a permissions dispatch library to make some of the runtime logic
   simpler
 - Do runtime checks for taking team media photos
 - Target API 23

**Issues Reference:**  Closes #678

**Test Plan:** Ran fresh installs with this build on my phone (running 23+) and verifying the suggestion flow still worked. 

@nwalters512 Can you take a look and make sure this seems sane?
