### PR TITLE
simplify the preference code and fix 2 minor bugs

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/settings/NotificationSettingsActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/settings/NotificationSettingsActivity.java
@@ -1,17 +1,13 @@
 package com.thebluealliance.androidclient.activities.settings;
 
-import com.thebluealliance.androidclient.R;
-import com.thebluealliance.androidclient.Utilities;
-
 import android.app.Fragment;
 import android.os.Build;
 import android.os.Bundle;
-import android.preference.CheckBoxPreference;
-import android.preference.Preference;
 import android.preference.PreferenceFragment;
-import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
+
+import com.thebluealliance.androidclient.R;
 
 public class NotificationSettingsActivity extends AppCompatActivity {
 
@@ -32,55 +28,12 @@ public class NotificationSettingsActivity extends AppCompatActivity {
 
     public static class NotificationSettingsFragment extends PreferenceFragment {
 
-        private static Preference notificationTone;
-        private static Preference notificationVibrate;
-        private static CheckBoxPreference notificationLedEnabled;
-        private static Preference notificationLedColor;
-        private static @Nullable Preference notificationHeadsup;
-
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             addPreferencesFromResource(R.xml.notification_preferences);
             if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
                 addPreferencesFromResource(R.xml.notification_preferences_lollipop);
-            }
-
-            notificationTone = findPreference("notification_tone");
-            notificationVibrate = findPreference("notification_vibrate");
-            notificationHeadsup = null;
-            if (Utilities.hasLApis()) {
-                notificationHeadsup = findPreference("notification_headsup");
-            }
-            notificationLedEnabled = (CheckBoxPreference) findPreference("notification_led_enabled");
-            notificationLedColor = findPreference("notification_led_color");
-
-            CheckBoxPreference enableNotifications = (CheckBoxPreference) findPreference("enable_notifications");
-            boolean currentlyEnabled = enableNotifications.isChecked();
-            setPreferencesEnabled(currentlyEnabled);
-
-            enableNotifications.setOnPreferenceChangeListener((preference, newValue) -> {
-                boolean enabled = (Boolean) newValue;
-                setPreferencesEnabled(enabled);
-                return true;
-            });
-
-            notificationLedColor.setEnabled(notificationLedEnabled.isChecked());
-
-            notificationLedEnabled.setOnPreferenceChangeListener((preference, newValue) -> {
-                boolean enabled = (Boolean) newValue;
-                notificationLedColor.setEnabled(enabled);
-                return true;
-            });
-        }
-
-        private void setPreferencesEnabled(boolean enabled) {
-            notificationTone.setEnabled(enabled);
-            notificationVibrate.setEnabled(enabled);
-            notificationLedEnabled.setEnabled(enabled);
-            notificationLedColor.setEnabled(enabled);
-            if (notificationHeadsup != null) {
-                notificationHeadsup.setEnabled(enabled);
             }
         }
 

--- a/android/src/main/res/xml/notification_preferences.xml
+++ b/android/src/main/res/xml/notification_preferences.xml
@@ -10,20 +10,24 @@
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="notification_tone"
+            android:dependency="enable_notifications"
             android:title="@string/pref_notification_tone" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="notification_vibrate"
+            android:dependency="enable_notifications"
             android:title="@string/pref_notification_vibrate" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="notification_led_enabled"
+            android:dependency="enable_notifications"
             android:summary="@string/pref_notification_led_enabled_summary"
             android:title="@string/pref_notification_led_enabled" />
         <com.thebluealliance.spectrum.SpectrumPreference
             android:defaultValue="@color/md_indigo_500"
             android:key="notification_led_color"
-            android:title="Notification LED Color"
+            android:dependency="notification_led_enabled"
+            android:title="@string/pref_notification_led_color"
             android:negativeButtonText="@string/cancel"
             app:spectrum_colors="@array/led_colors" />
     </PreferenceCategory>

--- a/android/src/main/res/xml/notification_preferences_lollipop.xml
+++ b/android/src/main/res/xml/notification_preferences_lollipop.xml
@@ -5,6 +5,7 @@
         <SwitchPreference
             android:defaultValue="true"
             android:key="notification_headsup"
+            android:dependency="enable_notifications"
             android:title="@string/pref_notification_headsup" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
**Summary:** 

I'm punting on the notification-sound-picker for lack of a way to make the standard dialog include the app's resources. There are more useful things to do than implement a custom sound picker.

But a tiny code improvement came out of the investigation: 
• The android:dependency preference attribute handles an if-enabled
dependency, obviating a bunch of code. It even handles the LED Color
dependency on both LED Enabled and Notifications Enabled (not that
the docs say so), fixing the handling of that dual dependency.

• android:title="Notification LED Color" wasn’t using its string
resource.

**Issues Reference:** 

**Test Plan:** 
Tested in the emulator.

To reproduce the bug in the old code:

1. Open Settings.
2. Tap "Notification Settings".
3. Check "Enable Notifications" if it was unchecked.
4. Uncheck "Flash Notification LED" and notice that "Notification LED Color" is now disabled.
5. Uncheck "Enable Notifications".
6. Check "Enable Notifications".

--> Notice that "Notification LED Color" is now enabled even though "Flash Notification LED" is disabled.

**Screenshots:** 
