### PR TITLE
Fix for opening team links with leading zeros

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/Utilities.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/Utilities.java
@@ -157,10 +157,13 @@ public final class Utilities {
                     break;
                 case "team":
                     if (indexExists(urlParts, 1) && TeamHelper.validateTeamKey("frc" + urlParts.get(1))) {
+                        // Some sources (such as ChiefDelphi) will include leading 0s in the team #
+                        // The API doesn't accept those and we shouldn't display those, so strip them
+                        String teamNumber = urlParts.get(1).replaceFirst ("^0+", "");
                         if (indexExists(urlParts, 2) && urlParts.get(2).matches("\\d\\d\\d\\d")) {
-                            intent = ViewTeamActivity.newInstance(c, "frc" + urlParts.get(1), Integer.parseInt(urlParts.get(2)));
+                            intent = ViewTeamActivity.newInstance(c, "frc" + teamNumber, Integer.parseInt(urlParts.get(2)));
                         } else {
-                            intent = ViewTeamActivity.newInstance(c, "frc" + urlParts.get(1));
+                            intent = ViewTeamActivity.newInstance(c, "frc" + teamNumber);
                         }
                     }
                     break;

--- a/android/src/test/java/com/thebluealliance/androidclient/UtilitiesTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/UtilitiesTest.java
@@ -1,0 +1,74 @@
+package com.thebluealliance.androidclient;
+
+import com.thebluealliance.androidclient.activities.ViewTeamActivity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.robolectric.RuntimeEnvironment;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(DefaultTestRunner.class)
+public class UtilitiesTest {
+
+    @Mock private Context context;
+
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.application.getApplicationContext();
+    }
+
+    @Test
+    public void teamIntent_noTeamNumber() {
+        Uri uri = Uri.parse("http://www.thebluealliance.com/team");
+        Intent intent = Utilities.getIntentForTBAUrl(context, uri);
+
+        assertNull(intent);
+    }
+
+    @Test
+    public void teamIntent_invalidTeamNumber() {
+        Uri uri = Uri.parse("http://www.thebluealliance.com/team/a230");
+        Intent intent = Utilities.getIntentForTBAUrl(context, uri);
+
+        assertNull(intent);
+    }
+
+    @Test
+    public void teamIntent_teamNumber() {
+        Uri uri = Uri.parse("http://www.thebluealliance.com/team/230");
+        Intent intent = Utilities.getIntentForTBAUrl(context, uri);
+
+        assertNotNull(intent);
+        assertEquals("frc230", intent.getStringExtra(ViewTeamActivity.EXTRA_TEAM_KEY));
+    }
+
+    @Test
+    public void teamIntent_leadingZerosInTeamNumber() {
+        Uri uri = Uri.parse("http://www.thebluealliance.com/team/0030");
+        Intent intent = Utilities.getIntentForTBAUrl(context, uri);
+
+        assertNotNull(intent);
+        assertEquals("frc30", intent.getStringExtra(ViewTeamActivity.EXTRA_TEAM_KEY));
+    }
+
+    @Test
+    public void teamIntent_teamNumberAndYear() {
+        Uri uri = Uri.parse("http://www.thebluealliance.com/team/230/2009");
+        Intent intent = Utilities.getIntentForTBAUrl(context, uri);
+
+        assertNotNull(intent);
+        assertEquals("frc230", intent.getStringExtra(ViewTeamActivity.EXTRA_TEAM_KEY));
+        assertEquals(2009, intent.getIntExtra(ViewTeamActivity.TEAM_YEAR, 0));
+    }
+
+}


### PR DESCRIPTION
**Summary:** 
As reported in #841, team links with leading zeros (like those Chief Delphi provides for teams with < 4 digit team numbers) open up a blank page. TBA Web handles such links by stripping out the leading zeros, so this does this same.

**Issues Reference:** 
#841 

**Test Plan:** 
Added unit tests for team link parsing.

**Screenshots:**
