### PR TITLE
Added Match Breakdown Table for 2018

### DIFF
--- a/android/src/androidTest/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018Test.java
+++ b/android/src/androidTest/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018Test.java
@@ -54,14 +54,14 @@ public class MatchBreakdownView2018Test {
         FrameLayout matchView = (FrameLayout) view.findViewById(R.id.match_breakdown);
         assertEquals(1, matchView.getChildCount());
         assertTrue(matchView.getChildAt(0) instanceof MatchBreakdownView2018);
-        MatchBreakdownView2018 view2017 = (MatchBreakdownView2018) matchView.getChildAt(0);
+        MatchBreakdownView2018 view2018 = (MatchBreakdownView2018) matchView.getChildAt(0);
         MatchType matchType = MatchType.fromKey(match.getKey());
-        view2017.initWithData(matchType, match.getWinningAlliance(), match.getAlliances(),
+        view2018.initWithData(matchType, match.getWinningAlliance(), match.getAlliances(),
                 mGson.fromJson(match.getScoreBreakdown(),JsonObject.class));
-        view2017.setVisibility(View.VISIBLE);
+        view2018.setVisibility(View.VISIBLE);
 
         // hide progress bar
         view.findViewById(R.id.progress).setVisibility(View.GONE);
-        return view2017;
+        return view2018;
     }
 }

--- a/android/src/androidTest/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018Test.java
+++ b/android/src/androidTest/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018Test.java
@@ -1,0 +1,67 @@
+package com.thebluealliance.androidclient.views.breakdowns;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import com.facebook.testing.screenshot.Screenshot;
+import com.facebook.testing.screenshot.ViewHelpers;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.datafeed.HttpModule;
+import com.thebluealliance.androidclient.models.Match;
+import com.thebluealliance.androidclient.testing.ModelMaker;
+import com.thebluealliance.androidclient.types.MatchType;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class MatchBreakdownView2018Test {
+
+    private static final int WIDTH_DP = 400;
+    private Gson mGson;
+
+    @Before
+    public void setUp() {
+        mGson = HttpModule.getGson();
+    }
+
+    @Test
+    public void testRenderQualMatch() throws Exception {
+        View view = getView("2018week0_qm1");
+        ViewHelpers.setupView(view)
+                .setExactWidthDp(WIDTH_DP)
+                .layout();
+
+        Screenshot.snap(view)
+                .record();
+    }
+
+
+    private MatchBreakdownView2018 getView(String matchJsonFile) {
+        Match match = ModelMaker.getModel(Match.class, matchJsonFile);
+        LayoutInflater inflater = LayoutInflater.from(InstrumentationRegistry.getTargetContext());
+        View view = inflater.inflate(R.layout.fragment_match_breakdown, null, false);
+
+        FrameLayout matchView = (FrameLayout) view.findViewById(R.id.match_breakdown);
+        assertEquals(1, matchView.getChildCount());
+        assertTrue(matchView.getChildAt(0) instanceof MatchBreakdownView2018);
+        MatchBreakdownView2018 view2017 = (MatchBreakdownView2018) matchView.getChildAt(0);
+        MatchType matchType = MatchType.fromKey(match.getKey());
+        view2017.initWithData(matchType, match.getWinningAlliance(), match.getAlliances(),
+                mGson.fromJson(match.getScoreBreakdown(),JsonObject.class));
+        view2017.setVisibility(View.VISIBLE);
+
+        // hide progress bar
+        view.findViewById(R.id.progress).setVisibility(View.GONE);
+        return view2017;
+    }
+}

--- a/android/src/androidTest/resources/2018week0_qm1.json
+++ b/android/src/androidTest/resources/2018week0_qm1.json
@@ -1,0 +1,120 @@
+{
+  "actual_time": 1518901106,
+  "alliances": {
+    "blue": {
+      "dq_team_keys": [],
+      "score": 267,
+      "surrogate_team_keys": [],
+      "team_keys": [
+        "frc78",
+        "frc5813",
+        "frc5459"
+      ]
+    },
+    "red": {
+      "dq_team_keys": [],
+      "score": 267,
+      "surrogate_team_keys": [],
+      "team_keys": [
+        "frc238",
+        "frc5687",
+        "frc3323"
+      ]
+    }
+  },
+  "comp_level": "f",
+  "event_key": "2018week0",
+  "key": "2018week0_f1m1",
+  "match_number": 1,
+  "post_result_time": 1518901301,
+  "predicted_time": 1518901029,
+  "score_breakdown": {
+    "blue": {
+      "adjustPoints": 0,
+      "autoOwnershipPoints": 20,
+      "autoPoints": 30,
+      "autoQuestRankingPoint": false,
+      "autoRobot1": "AutoRun",
+      "autoRobot2": "AutoRun",
+      "autoRobot3": "None",
+      "autoRunPoints": 10,
+      "autoScaleOwnershipSec": 0,
+      "autoSwitchAtZero": true,
+      "autoSwitchOwnershipSec": 10,
+      "endgamePoints": 65,
+      "endgameRobot1": "Levitate",
+      "endgameRobot2": "Climbing",
+      "endgameRobot3": "Parking",
+      "faceTheBossRankingPoint": false,
+      "foulCount": 1,
+      "foulPoints": 0,
+      "rp": 0,
+      "tba_rpEarned": null,
+      "techFoulCount": 0,
+      "teleopOwnershipPoints": 152,
+      "teleopPoints": 237,
+      "teleopScaleBoostSec": 0,
+      "teleopScaleForceSec": 0,
+      "teleopScaleOwnershipSec": 6,
+      "teleopSwitchBoostSec": 10,
+      "teleopSwitchForceSec": 0,
+      "teleopSwitchOwnershipSec": 136,
+      "totalPoints": 267,
+      "vaultBoostPlayed": 0,
+      "vaultBoostTotal": 1,
+      "vaultForcePlayed": 0,
+      "vaultForceTotal": 0,
+      "vaultLevitatePlayed": 3,
+      "vaultLevitateTotal": 3,
+      "vaultPoints": 20
+    },
+    "red": {
+      "adjustPoints": 0,
+      "autoOwnershipPoints": 0,
+      "autoPoints": 10,
+      "autoQuestRankingPoint": false,
+      "autoRobot1": "AutoRun",
+      "autoRobot2": "AutoRun",
+      "autoRobot3": "None",
+      "autoRunPoints": 10,
+      "autoScaleOwnershipSec": 0,
+      "autoSwitchAtZero": false,
+      "autoSwitchOwnershipSec": 0,
+      "endgamePoints": 40,
+      "endgameRobot1": "Levitate",
+      "endgameRobot2": "Parking",
+      "endgameRobot3": "Parking",
+      "faceTheBossRankingPoint": false,
+      "foulCount": 0,
+      "foulPoints": 5,
+      "rp": 0,
+      "tba_rpEarned": null,
+      "techFoulCount": 0,
+      "teleopOwnershipPoints": 187,
+      "teleopPoints": 252,
+      "teleopScaleBoostSec": 0,
+      "teleopScaleForceSec": 0,
+      "teleopScaleOwnershipSec": 81,
+      "teleopSwitchBoostSec": 0,
+      "teleopSwitchForceSec": 10,
+      "teleopSwitchOwnershipSec": 106,
+      "totalPoints": 267,
+      "vaultBoostPlayed": 0,
+      "vaultBoostTotal": 0,
+      "vaultForcePlayed": 1,
+      "vaultForceTotal": 2,
+      "vaultLevitatePlayed": 2,
+      "vaultLevitateTotal": 3,
+      "vaultPoints": 25
+    }
+  },
+  "set_number": 1,
+  "time": 1518899400,
+  "videos": [
+    {
+      "key": "8hYdD7qnuKo",
+      "type": "youtube"
+    }
+  ],
+  "winning_alliance": ""
+}

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/MatchBreakdownBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/MatchBreakdownBinder.java
@@ -1,7 +1,11 @@
 package com.thebluealliance.androidclient.binders;
 
-import com.google.gson.JsonObject;
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.ProgressBar;
 
+import com.google.gson.JsonObject;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.TbaLogger;
 import com.thebluealliance.androidclient.types.MatchType;
@@ -9,12 +13,8 @@ import com.thebluealliance.androidclient.views.breakdowns.AbstractMatchBreakdown
 import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2015;
 import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2016;
 import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2017;
+import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2018;
 import com.thebluealliance.api.model.IMatchAlliancesContainer;
-
-import android.support.annotation.Nullable;
-import android.view.View;
-import android.widget.FrameLayout;
-import android.widget.ProgressBar;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
@@ -45,6 +45,9 @@ public class MatchBreakdownBinder extends AbstractDataBinder<MatchBreakdownBinde
                 break;
             case 2017:
                 breakdownView = new MatchBreakdownView2017(mActivity);
+                break;
+            case 2018:
+                breakdownView = new MatchBreakdownView2018(mActivity);
                 break;
             default:
                 breakdownView = null;

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchBreakdownSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchBreakdownSubscriber.java
@@ -2,7 +2,6 @@ package com.thebluealliance.androidclient.subscribers;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-
 import com.thebluealliance.androidclient.TbaLogger;
 import com.thebluealliance.androidclient.binders.MatchBreakdownBinder;
 import com.thebluealliance.androidclient.config.AppConfig;
@@ -17,6 +16,7 @@ import javax.inject.Inject;
 public class MatchBreakdownSubscriber extends BaseAPISubscriber<Match, MatchBreakdownBinder.Model> {
 
     public static final String SHOW_2017_KEY = "show_2017_breakdowns";
+    public static final String SHOW_2018_KEY = "show_2018_breakdowns";
 
     private final Gson mGson;
     private final AppConfig mConfig;
@@ -41,6 +41,10 @@ public class MatchBreakdownSubscriber extends BaseAPISubscriber<Match, MatchBrea
             case 2017:
                 shouldShowBreakdown = mConfig.getBoolean(SHOW_2017_KEY);
                 TbaLogger.i("Showing 2017 breakdowns? " + shouldShowBreakdown);
+                break;
+            case 2018:
+                shouldShowBreakdown = mConfig.getBoolean(SHOW_2018_KEY);
+                TbaLogger.i("Showing 2018 breakdowns? " + shouldShowBreakdown);
                 break;
         }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
@@ -35,6 +35,12 @@ public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
     @Bind(R.id.breakdown_red3)                              TextView red3;
     @Bind(R.id.breakdown_blue3)                             TextView blue3;
 
+    @Bind(R.id.breakdown2018_red_auto_run_robot_1)          ImageView redAutoRunRobot1;
+    @Bind(R.id.breakdown2018_blue_auto_run_robot_1)         ImageView blueAutoRunRobot1;
+    @Bind(R.id.breakdown2018_red_auto_run_robot_2)          ImageView redAutoRunRobot2;
+    @Bind(R.id.breakdown2018_blue_auto_run_robot_2)         ImageView blueAutoRunRobot2;
+    @Bind(R.id.breakdown2018_red_auto_run_robot_3)          ImageView redAutoRunRobot3;
+    @Bind(R.id.breakdown2018_blue_auto_run_robot_3)         ImageView blueAutoRunRobot3;
     @Bind(R.id.breakdown2018_red_auto_run_points)           TextView redAutoRunPoints;
     @Bind(R.id.breakdown2018_blue_auto_run_points)          TextView blueAutoRunPoints;
     @Bind(R.id.breakdown2018_red_auto_scale_seconds)        TextView redAutoScaleSeconds;
@@ -134,6 +140,14 @@ public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
         blue2.setText(teamNumberFromKey(blueTeams.get(1)));
         blue3.setText(teamNumberFromKey(blueTeams.get(2)));
 
+        /* Auto Run */
+        redAutoRunRobot1.setBackgroundResource(getAutoRunResource(getIntDefault(redData, "autoRobot1")));
+        blueAutoRunRobot1.setBackgroundResource(getAutoRunResource(getIntDefault(blueData, "autoRobot1")));
+        redAutoRunRobot2.setBackgroundResource(getAutoRunResource(getIntDefault(redData, "autoRobot2")));
+        blueAutoRunRobot2.setBackgroundResource(getAutoRunResource(getIntDefault(blueData, "autoRobot2")));
+        redAutoRunRobot3.setBackgroundResource(getAutoRunResource(getIntDefault(redData, "autoRobot3")));
+        blueAutoRunRobot3.setBackgroundResource(getAutoRunResource(getIntDefault(blueData, "autoRobot3")));
+
         /* Auto Run Points */
         redAutoRunPoints.setText(getIntDefault(redData, "autoRunPoints"));
         blueAutoRunPoints.setText(getIntDefault(blueData, "autoRunPoints"));
@@ -230,6 +244,13 @@ public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
 
     private int getRankingPointResource(boolean achievedRankingPoint) {
         if (achievedRankingPoint)
+            return R.drawable.ic_check_black_24dp;
+        else
+            return R.drawable.ic_close_black_24dp;
+    }
+
+    private int getAutoRunResource(String autoRunAction) {
+        if (autoRunAction.equals("AutoRun"))
             return R.drawable.ic_check_black_24dp;
         else
             return R.drawable.ic_close_black_24dp;

--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
@@ -1,0 +1,239 @@
+package com.thebluealliance.androidclient.views.breakdowns;
+
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.support.v7.widget.GridLayout;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.google.gson.JsonObject;
+import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.types.MatchType;
+import com.thebluealliance.api.model.IMatchAlliancesContainer;
+
+import java.util.List;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+
+import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getBooleanDefault;
+import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getIntDefault;
+import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getIntDefaultValue;
+import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.teamNumberFromKey;
+
+public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
+    @Bind(R.id.breakdown2018_container)                     GridLayout breakdownContainer;
+
+    @Bind(R.id.breakdown_red1)                              TextView red1;
+    @Bind(R.id.breakdown_blue1)                             TextView blue1;
+    @Bind(R.id.breakdown_red2)                              TextView red2;
+    @Bind(R.id.breakdown_blue2)                             TextView blue2;
+    @Bind(R.id.breakdown_red3)                              TextView red3;
+    @Bind(R.id.breakdown_blue3)                             TextView blue3;
+
+    @Bind(R.id.breakdown2018_red_auto_run_points)           TextView redAutoRunPoints;
+    @Bind(R.id.breakdown2018_blue_auto_run_points)          TextView blueAutoRunPoints;
+    @Bind(R.id.breakdown2018_red_auto_scale_seconds)        TextView redAutoScaleSeconds;
+    @Bind(R.id.breakdown2018_blue_auto_scale_seconds)       TextView blueAutoScaleSeconds;
+    @Bind(R.id.breakdown2018_red_auto_switch_seconds)       TextView redAutoSwitchSeconds;
+    @Bind(R.id.breakdown2018_blue_auto_switch_seconds)      TextView blueAutoSwitchSeconds;
+    @Bind(R.id.breakdown2018_red_auto_ownership_points)     TextView redAutoOwnershipPoints;
+    @Bind(R.id.breakdown2018_blue_auto_ownership_points)    TextView blueAutoOwnershipPoints;
+    @Bind(R.id.breakdown_auto_total_red)                    TextView redAutoTotal;
+    @Bind(R.id.breakdown_auto_total_blue)                   TextView blueAutoTotal;
+
+    @Bind(R.id.breakdown2018_teleop_red_scale_seconds)      TextView redTeleopScaleSeconds;
+    @Bind(R.id.breakdown2018_teleop_blue_scale_seconds)     TextView blueTeleopScaleSeconds;
+    @Bind(R.id.breakdown2018_teleop_red_switch_seconds)     TextView redTeleopSwitchSeconds;
+    @Bind(R.id.breakdown2018_teleop_blue_switch_seconds)    TextView blueTeleopSwitchSeconds;
+    @Bind(R.id.breakdown2018_teleop_red_ownership_points)   TextView redTeleopOwnershipPoints;
+    @Bind(R.id.breakdown2018_teleop_blue_ownership_points)  TextView blueTeleopOwnershipPoints;
+
+    @Bind(R.id.breakdown2018_teleop_red_force_cubes)        TextView redTeleopForceCubes;
+    @Bind(R.id.breakdown2018_teleop_blue_force_cubes)       TextView blueTeleopForceCubes;
+    @Bind(R.id.breakdown2018_teleop_red_levitate_cubes)     TextView redTeleopLevitateCubes;
+    @Bind(R.id.breakdown2018_teleop_blue_levitate_cubes)    TextView blueTeleopLevitateCubes;
+    @Bind(R.id.breakdown2018_teleop_red_boost_cubes)        TextView redTeleopBoostCubes;
+    @Bind(R.id.breakdown2018_teleop_blue_boost_cubes)       TextView blueTeleopBoostCubes;
+    @Bind(R.id.breakdown2018_teleop_red_vault_points)       TextView redTeleopVaultPoints;
+    @Bind(R.id.breakdown2018_teleop_blue_vault_points)      TextView blueTeleopVaultPoints;
+
+    @Bind(R.id.breakdown2018_red_endgame_robot_1)           TextView redEndgameRobot1;
+    @Bind(R.id.breakdown2018_blue_endgame_robot_1)          TextView blueEndgameRobot1;
+    @Bind(R.id.breakdown2018_red_endgame_robot_2)           TextView redEndgameRobot2;
+    @Bind(R.id.breakdown2018_blue_endgame_robot_2)          TextView blueEndgameRobot2;
+    @Bind(R.id.breakdown2018_red_endgame_robot_3)           TextView redEndgameRobot3;
+    @Bind(R.id.breakdown2018_blue_endgame_robot_3)          TextView blueEndgameRobot3;
+    @Bind(R.id.breakdown2018_red_endgame_points)            TextView redEndgamePoints;
+    @Bind(R.id.breakdown2018_blue_endgame_points)           TextView blueEndgamePoints;
+
+    @Bind(R.id.breakdown_teleop_total_red)                  TextView redTeleopTotal;
+    @Bind(R.id.breakdown_teleop_total_blue)                 TextView blueTeleopTotal;
+
+    @Bind(R.id.breakdown2018_red_face_the_boss)             ImageView redFaceTheBoss;
+    @Bind(R.id.breakdown2018_blue_face_the_boss)            ImageView blueFaceTheBoss;
+    @Bind(R.id.breakdown2018_red_auto_quest)                ImageView redAutoQuest;
+    @Bind(R.id.breakdown2018_blue_auto_quest)               ImageView blueAutoQuest;
+
+    @Bind(R.id.breakdown_fouls_red)                         TextView foulsRed;
+    @Bind(R.id.breakdown_fouls_blue)                        TextView foulsBlue;
+    @Bind(R.id.breakdown_adjust_red)                        TextView adjustRed;
+    @Bind(R.id.breakdown_adjust_blue)                       TextView adjustBlue;
+    @Bind(R.id.breakdown_total_red)                         TextView totalRed;
+    @Bind(R.id.breakdown_total_blue)                        TextView totalBlue;
+    @Bind(R.id.breakdown_red_rp)                            TextView rpRed;
+    @Bind(R.id.breakdown_blue_rp)                           TextView rpBlue;
+    @Bind(R.id.breakdown_rp_header)                         TextView rpHeader;
+
+    public MatchBreakdownView2018(Context context) {
+        super(context);
+    }
+
+    public MatchBreakdownView2018(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public MatchBreakdownView2018(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Override
+    void init() {
+        LayoutInflater.from(getContext()).inflate(R.layout.match_breakdown_2018, this, true);
+        ButterKnife.bind(this);
+    }
+
+    @Override
+    public boolean initWithData(MatchType matchType, String winningAlliance, IMatchAlliancesContainer allianceData, JsonObject scoreData) {
+        if (scoreData == null || scoreData.entrySet().isEmpty()
+                || allianceData == null || allianceData.getRed() == null || allianceData.getBlue() == null) {
+            breakdownContainer.setVisibility(GONE);
+            return false;
+        }
+
+        /* Resources */
+        Resources res = getResources();
+
+        /* Alliance data */
+        List<String> redTeams = allianceData.getRed().getTeamKeys();
+        List<String> blueTeams = allianceData.getBlue().getTeamKeys();
+        JsonObject redData = scoreData.get("red").getAsJsonObject();
+        JsonObject blueData = scoreData.get("blue").getAsJsonObject();
+
+        /* Red Teams */
+        red1.setText(teamNumberFromKey(redTeams.get(0)));
+        red2.setText(teamNumberFromKey(redTeams.get(1)));
+        red3.setText(teamNumberFromKey(redTeams.get(2)));
+
+        /* Blue Teams */
+        blue1.setText(teamNumberFromKey(blueTeams.get(0)));
+        blue2.setText(teamNumberFromKey(blueTeams.get(1)));
+        blue3.setText(teamNumberFromKey(blueTeams.get(2)));
+
+        /* Auto Run Points */
+        redAutoRunPoints.setText(getIntDefault(redData, "autoRunPoints"));
+        blueAutoRunPoints.setText(getIntDefault(blueData, "autoRunPoints"));
+
+        /* Auto Scale Ownership Seconds */
+        redAutoScaleSeconds.setText(getIntDefault(redData, "autoScaleOwnershipSec"));
+        blueAutoScaleSeconds.setText(getIntDefault(blueData, "autoScaleOwnershipSec"));
+
+        /* Auto Switch Ownership Seconds */
+        redAutoSwitchSeconds.setText(getIntDefault(redData, "autoSwitchOwnershipSec"));
+        blueAutoSwitchSeconds.setText(getIntDefault(blueData, "autoSwitchOwnershipSec"));
+
+        /* Auto Ownership Points */
+        redAutoOwnershipPoints.setText(getIntDefault(redData, "autoOwnershipPoints"));
+        blueAutoOwnershipPoints.setText(getIntDefault(blueData, "autoOwnershipPoints"));
+
+        /* Auto Total Points */
+        redAutoTotal.setText(getIntDefault(redData, "autoPoints"));
+        blueAutoTotal.setText(getIntDefault(blueData, "autoPoints"));
+
+        /* Teleop Switch Ownership Seconds */
+        redTeleopSwitchSeconds.setText(res.getString(R.string.breakdown2018_scale_switch_boost_points, getIntDefault(redData, "teleopSwitchOwnershipSec"), getIntDefault(redData, "teleopSwitchBoostSec")));
+        blueTeleopSwitchSeconds.setText(res.getString(R.string.breakdown2018_scale_switch_boost_points, getIntDefault(blueData, "teleopSwitchOwnershipSec"), getIntDefault(blueData, "teleopSwitchBoostSec")));
+
+        /* Teleop Scale Ownership Seconds */
+        redTeleopScaleSeconds.setText(res.getString(R.string.breakdown2018_scale_switch_boost_points, getIntDefault(redData, "teleopScaleOwnershipSec"), getIntDefault(redData, "teleopScaleBoostSec")));
+        blueTeleopScaleSeconds.setText(res.getString(R.string.breakdown2018_scale_switch_boost_points, getIntDefault(blueData, "teleopScaleOwnershipSec"), getIntDefault(blueData, "teleopScaleBoostSec")));
+
+        /* Teleop Ownership Points */
+        redTeleopOwnershipPoints.setText(getIntDefault(redData, "teleopOwnershipPoints"));
+        blueTeleopOwnershipPoints.setText(getIntDefault(blueData, "teleopOwnershipPoints"));
+
+        /* Teleop Cubes Played */
+        redTeleopForceCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultForceTotal"), getIntDefault(redData, "vaultForcePlayed")));
+        blueTeleopForceCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultForceTotal"), getIntDefault(redData, "vaultForcePlayed")));
+        redTeleopLevitateCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultLevitateTotal"), getIntDefault(redData, "vaultLevitatePlayed")));
+        blueTeleopLevitateCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultLevitateTotal"), getIntDefault(redData, "vaultLevitatePlayed")));
+        redTeleopBoostCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultBoostTotal"), getIntDefault(redData, "vaultBoostPlayed")));
+        blueTeleopBoostCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultBoostTotal"), getIntDefault(redData, "vaultBoostPlayed")));
+
+        /* Teleop Vault Points */
+        redTeleopVaultPoints.setText(getIntDefault(redData, "vaultPoints"));
+        blueTeleopVaultPoints.setText(getIntDefault(blueData, "vaultPoints"));
+
+        /* Endgame */
+        redEndgameRobot1.setText(getIntDefault(redData, "endgameRobot1"));
+        blueEndgameRobot1.setText(getIntDefault(blueData, "endgameRobot1"));
+        redEndgameRobot2.setText(getIntDefault(redData, "endgameRobot2"));
+        blueEndgameRobot2.setText(getIntDefault(blueData, "endgameRobot2"));
+        redEndgameRobot3.setText(getIntDefault(redData, "endgameRobot3"));
+        blueEndgameRobot3.setText(getIntDefault(blueData, "endgameRobot3"));
+
+        /* Endgame Points */
+        redEndgamePoints.setText(getIntDefault(redData, "endgamePoints"));
+        blueEndgamePoints.setText(getIntDefault(blueData, "endgamePoints"));
+
+        /* Teleop Total Points */
+        redTeleopTotal.setText(getIntDefault(redData, "teleopPoints"));
+        blueTeleopTotal.setText(getIntDefault(blueData, "teleopPoints"));
+
+        /* Auto Quest */
+        redAutoQuest.setBackgroundResource(getRankingPointResource(getBooleanDefault(redData, "autoQuestRankingPoint")));
+        blueAutoQuest.setBackgroundResource(getRankingPointResource(getBooleanDefault(blueData, "autoQuestRankingPoint")));
+
+        /* Face the Boss */
+        redFaceTheBoss.setBackgroundResource(getRankingPointResource(getBooleanDefault(redData, "faceTheBossRankingPoint")));
+        blueFaceTheBoss.setBackgroundResource(getRankingPointResource(getBooleanDefault(blueData, "faceTheBossRankingPoint")));
+
+        /* Fouls */
+        foulsRed.setText(res.getString(R.string.breakdown_foul_format_add, getIntDefaultValue(redData, "foulPoints")));
+        foulsBlue.setText(res.getString(R.string.breakdown_foul_format_add, getIntDefaultValue(blueData, "foulPoints")));
+
+        /* Adjustment points */
+        adjustRed.setText(getIntDefault(redData, "adjustPoints"));
+        adjustBlue.setText(getIntDefault(blueData, "adjustPoints"));
+
+        /* Total Points */
+        totalRed.setText(getIntDefault(redData, "totalPoints"));
+        totalBlue.setText(getIntDefault(blueData, "totalPoints"));
+
+        /* Show RPs earned, if needed */
+        boolean showRp = !redData.get("tba_rpEarned").isJsonNull() && !blueData.get("tba_rpEarned").isJsonNull();
+
+        if (showRp) {
+            rpRed.setText(res.getString(R.string.breakdown_total_rp, getIntDefaultValue(redData, "tba_rpEarned")));
+            rpBlue.setText(res.getString(R.string.breakdown_total_rp, getIntDefaultValue(blueData, "tba_rpEarned")));
+        } else {
+            rpRed.setVisibility(GONE);
+            rpBlue.setVisibility(GONE);
+            rpHeader.setVisibility(GONE);
+        }
+
+        breakdownContainer.setVisibility(View.VISIBLE);
+        return true;
+    }
+
+    private int getRankingPointResource(boolean achievedRankingPoint) {
+        if (achievedRankingPoint)
+            return R.drawable.ic_check_black_24dp;
+        else
+            return R.drawable.ic_close_black_24dp;
+    } // End of method
+}

--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
@@ -53,23 +53,23 @@ public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
     @Bind(R.id.breakdown2018_teleop_red_ownership_points)   TextView redTeleopOwnershipPoints;
     @Bind(R.id.breakdown2018_teleop_blue_ownership_points)  TextView blueTeleopOwnershipPoints;
 
-    @Bind(R.id.breakdown2018_teleop_red_force_cubes)        TextView redTeleopForceCubes;
-    @Bind(R.id.breakdown2018_teleop_blue_force_cubes)       TextView blueTeleopForceCubes;
-    @Bind(R.id.breakdown2018_teleop_red_levitate_cubes)     TextView redTeleopLevitateCubes;
-    @Bind(R.id.breakdown2018_teleop_blue_levitate_cubes)    TextView blueTeleopLevitateCubes;
-    @Bind(R.id.breakdown2018_teleop_red_boost_cubes)        TextView redTeleopBoostCubes;
-    @Bind(R.id.breakdown2018_teleop_blue_boost_cubes)       TextView blueTeleopBoostCubes;
-    @Bind(R.id.breakdown2018_teleop_red_vault_points)       TextView redTeleopVaultPoints;
-    @Bind(R.id.breakdown2018_teleop_blue_vault_points)      TextView blueTeleopVaultPoints;
+    @Bind(R.id.breakdown2018_vault_red_force_cubes)         TextView redVaultForceCubes;
+    @Bind(R.id.breakdown2018_vault_blue_force_cubes)        TextView blueVaultForceCubes;
+    @Bind(R.id.breakdown2018_vault_red_levitate_cubes)      TextView redVaultLevitateCubes;
+    @Bind(R.id.breakdown2018_vault_blue_levitate_cubes)     TextView blueVaultLevitateCubes;
+    @Bind(R.id.breakdown2018_vault_red_boost_cubes)         TextView redVaultBoostCubes;
+    @Bind(R.id.breakdown2018_vault_blue_boost_cubes)        TextView blueVaultBoostCubes;
+    @Bind(R.id.breakdown2018_vault_red_total)               TextView redVaultPoints;
+    @Bind(R.id.breakdown2018_vault_blue_total)              TextView blueVaultPoints;
 
-    @Bind(R.id.breakdown2018_red_endgame_robot_1)           TextView redEndgameRobot1;
-    @Bind(R.id.breakdown2018_blue_endgame_robot_1)          TextView blueEndgameRobot1;
-    @Bind(R.id.breakdown2018_red_endgame_robot_2)           TextView redEndgameRobot2;
-    @Bind(R.id.breakdown2018_blue_endgame_robot_2)          TextView blueEndgameRobot2;
-    @Bind(R.id.breakdown2018_red_endgame_robot_3)           TextView redEndgameRobot3;
-    @Bind(R.id.breakdown2018_blue_endgame_robot_3)          TextView blueEndgameRobot3;
-    @Bind(R.id.breakdown2018_red_endgame_points)            TextView redEndgamePoints;
-    @Bind(R.id.breakdown2018_blue_endgame_points)           TextView blueEndgamePoints;
+    @Bind(R.id.breakdown2018_endgame_red_robot_1)           TextView redEndgameRobot1;
+    @Bind(R.id.breakdown2018_endgame_blue_robot_1)          TextView blueEndgameRobot1;
+    @Bind(R.id.breakdown2018_endgame_red_robot_2)           TextView redEndgameRobot2;
+    @Bind(R.id.breakdown2018_endgame_blue_robot_2)          TextView blueEndgameRobot2;
+    @Bind(R.id.breakdown2018_endgame_red_robot_3)           TextView redEndgameRobot3;
+    @Bind(R.id.breakdown2018_endgame_blue_robot_3)          TextView blueEndgameRobot3;
+    @Bind(R.id.breakdown2018_endgame_red_total)             TextView redEndgamePoints;
+    @Bind(R.id.breakdown2018_endgame_blue_total)            TextView blueEndgamePoints;
 
     @Bind(R.id.breakdown_teleop_total_red)                  TextView redTeleopTotal;
     @Bind(R.id.breakdown_teleop_total_blue)                 TextView blueTeleopTotal;
@@ -167,16 +167,16 @@ public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
         blueTeleopOwnershipPoints.setText(getIntDefault(blueData, "teleopOwnershipPoints"));
 
         /* Teleop Cubes Played */
-        redTeleopForceCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultForceTotal"), getIntDefault(redData, "vaultForcePlayed")));
-        blueTeleopForceCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultForceTotal"), getIntDefault(redData, "vaultForcePlayed")));
-        redTeleopLevitateCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultLevitateTotal"), getIntDefault(redData, "vaultLevitatePlayed")));
-        blueTeleopLevitateCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultLevitateTotal"), getIntDefault(redData, "vaultLevitatePlayed")));
-        redTeleopBoostCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultBoostTotal"), getIntDefault(redData, "vaultBoostPlayed")));
-        blueTeleopBoostCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultBoostTotal"), getIntDefault(redData, "vaultBoostPlayed")));
+        redVaultForceCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultForceTotal"), getIntDefault(redData, "vaultForcePlayed")));
+        blueVaultForceCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultForceTotal"), getIntDefault(redData, "vaultForcePlayed")));
+        redVaultLevitateCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultLevitateTotal"), getIntDefault(redData, "vaultLevitatePlayed")));
+        blueVaultLevitateCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultLevitateTotal"), getIntDefault(redData, "vaultLevitatePlayed")));
+        redVaultBoostCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultBoostTotal"), getIntDefault(redData, "vaultBoostPlayed")));
+        blueVaultBoostCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultBoostTotal"), getIntDefault(redData, "vaultBoostPlayed")));
 
         /* Teleop Vault Points */
-        redTeleopVaultPoints.setText(getIntDefault(redData, "vaultPoints"));
-        blueTeleopVaultPoints.setText(getIntDefault(blueData, "vaultPoints"));
+        redVaultPoints.setText(getIntDefault(redData, "vaultPoints"));
+        blueVaultPoints.setText(getIntDefault(blueData, "vaultPoints"));
 
         /* Endgame */
         redEndgameRobot1.setText(getIntDefault(redData, "endgameRobot1"));
@@ -215,11 +215,9 @@ public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
         totalBlue.setText(getIntDefault(blueData, "totalPoints"));
 
         /* Show RPs earned, if needed */
-        boolean showRp = !redData.get("tba_rpEarned").isJsonNull() && !blueData.get("tba_rpEarned").isJsonNull();
-
-        if (showRp) {
-            rpRed.setText(res.getString(R.string.breakdown_total_rp, getIntDefaultValue(redData, "tba_rpEarned")));
-            rpBlue.setText(res.getString(R.string.breakdown_total_rp, getIntDefaultValue(blueData, "tba_rpEarned")));
+        if (!matchType.isPlayoff() ) {
+            rpRed.setText(res.getString(R.string.breakdown_total_rp, getIntDefaultValue(redData, "rp")));
+            rpBlue.setText(res.getString(R.string.breakdown_total_rp, getIntDefaultValue(blueData, "rp")));
         } else {
             rpRed.setVisibility(GONE);
             rpBlue.setVisibility(GONE);
@@ -235,5 +233,5 @@ public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
             return R.drawable.ic_check_black_24dp;
         else
             return R.drawable.ic_close_black_24dp;
-    } // End of method
+    }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
@@ -215,7 +215,7 @@ public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
         totalBlue.setText(getIntDefault(blueData, "totalPoints"));
 
         /* Show RPs earned, if needed */
-        if (!matchType.isPlayoff() ) {
+        if (!matchType.isPlayoff()) {
             rpRed.setText(res.getString(R.string.breakdown_total_rp, getIntDefaultValue(redData, "rp")));
             rpBlue.setText(res.getString(R.string.breakdown_total_rp, getIntDefaultValue(blueData, "rp")));
         } else {

--- a/android/src/main/res/layout/match_breakdown_2018.xml
+++ b/android/src/main/res/layout/match_breakdown_2018.xml
@@ -152,105 +152,105 @@
 
         <!-- Teleop Force Cubes -->
         <TextView
-            android:id="@+id/breakdown2018_teleop_red_force_cubes"
+            android:id="@+id/breakdown2018_vault_red_force_cubes"
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
-            android:text="@string/breakdown2018_teleop_force_cubes"
+            android:text="@string/breakdown2018_vault_force_cubes"
             style="@style/breakdown_category" />
         <TextView
-            android:id="@+id/breakdown2018_teleop_blue_force_cubes"
+            android:id="@+id/breakdown2018_vault_blue_force_cubes"
             style="@style/breakdown_blueItem"
             tools:text="80"/>
 
         <!-- Teleop Levitate Cubes -->
         <TextView
-            android:id="@+id/breakdown2018_teleop_red_levitate_cubes"
+            android:id="@+id/breakdown2018_vault_red_levitate_cubes"
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
-            android:text="@string/breakdown2018_teleop_levitate_cubes"
+            android:text="@string/breakdown2018_vault_levitate_cubes"
             style="@style/breakdown_category" />
         <TextView
-            android:id="@+id/breakdown2018_teleop_blue_levitate_cubes"
+            android:id="@+id/breakdown2018_vault_blue_levitate_cubes"
             style="@style/breakdown_blueItem"
             tools:text="80"/>
 
         <!-- Teleop Boost Cubes -->
         <TextView
-            android:id="@+id/breakdown2018_teleop_red_boost_cubes"
+            android:id="@+id/breakdown2018_vault_red_boost_cubes"
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
-            android:text="@string/breakdown2018_teleop_boost_cubes"
+            android:text="@string/breakdown2018_vault_boost_cubes"
             style="@style/breakdown_category" />
         <TextView
-            android:id="@+id/breakdown2018_teleop_blue_boost_cubes"
+            android:id="@+id/breakdown2018_vault_blue_boost_cubes"
             style="@style/breakdown_blueItem"
             tools:text="80"/>
 
         <!-- Teleop Vault Points -->
         <TextView
-            android:id="@+id/breakdown2018_teleop_red_vault_points"
+            android:id="@+id/breakdown2018_vault_red_total"
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
-            android:text="@string/breakdown2018_teleop_vault_points"
+            android:text="@string/breakdown2018_vault_points"
             style="@style/breakdown_categorySubtotal" />
         <TextView
-            android:id="@+id/breakdown2018_teleop_blue_vault_points"
+            android:id="@+id/breakdown2018_vault_blue_total"
             style="@style/breakdown_blueItem"
             tools:text="80"/>
 
         <!-- Robot 1 Endgame -->
         <TextView
-            android:id="@+id/breakdown2018_red_endgame_robot_1"
+            android:id="@+id/breakdown2018_endgame_red_robot_1"
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
             android:text="@string/breakdown2018_teleop_robot_1_endgame"
             style="@style/breakdown_category" />
         <TextView
-            android:id="@+id/breakdown2018_blue_endgame_robot_1"
+            android:id="@+id/breakdown2018_endgame_blue_robot_1"
             style="@style/breakdown_blueItem"
             tools:text="80"/>
 
         <!-- Robot 2 Endgame  -->
         <TextView
-            android:id="@+id/breakdown2018_red_endgame_robot_2"
+            android:id="@+id/breakdown2018_endgame_red_robot_2"
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
             android:text="@string/breakdown2018_teleop_robot_2_endgame"
             style="@style/breakdown_category" />
         <TextView
-            android:id="@+id/breakdown2018_blue_endgame_robot_2"
+            android:id="@+id/breakdown2018_endgame_blue_robot_2"
             style="@style/breakdown_blueItem"
             tools:text="80"/>
 
         <!-- Robot 3 Endgame -->
         <TextView
-            android:id="@+id/breakdown2018_red_endgame_robot_3"
+            android:id="@+id/breakdown2018_endgame_red_robot_3"
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
             android:text="@string/breakdown2018_teleop_robot_3_endgame"
             style="@style/breakdown_category" />
         <TextView
-            android:id="@+id/breakdown2018_blue_endgame_robot_3"
+            android:id="@+id/breakdown2018_endgame_blue_robot_3"
             style="@style/breakdown_blueItem"
             tools:text="80"/>
 
         <!-- Park/Climb Points -->
         <TextView
-            android:id="@+id/breakdown2018_red_endgame_points"
+            android:id="@+id/breakdown2018_endgame_red_total"
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
             android:text="@string/breakdown2018_teleop_park_climb_points"
             style="@style/breakdown_categorySubtotal" />
         <TextView
-            android:id="@+id/breakdown2018_blue_endgame_points"
+            android:id="@+id/breakdown2018_endgame_blue_total"
             style="@style/breakdown_blueItem"
             tools:text="80"/>
 

--- a/android/src/main/res/layout/match_breakdown_2018.xml
+++ b/android/src/main/res/layout/match_breakdown_2018.xml
@@ -13,7 +13,7 @@
         android:paddingBottom="8dp"
         android:background="@color/column_header_gray"
         app:columnCount="3"
-        app:rowCount="26"
+        app:rowCount="29"
         app:alignmentMode="alignBounds" >
 
         <!-- Teams -->
@@ -47,6 +47,74 @@
             tools:text="Blue 3"/>
 
         <!-- Auto Run -->
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2018_red_auto_run_robot_1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_clear_black_24dp"
+                tools:background="@drawable/ic_done_black_24dp"/>
+        </LinearLayout>
+        <TextView
+            android:text="@string/breakdown2018_auto_run_robot_1"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2018_blue_auto_run_robot_1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:background="@drawable/ic_done_black_24dp"/>
+        </LinearLayout>
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2018_red_auto_run_robot_2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_clear_black_24dp"
+                tools:background="@drawable/ic_done_black_24dp"/>
+        </LinearLayout>
+        <TextView
+            android:text="@string/breakdown2018_auto_run_robot_2"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2018_blue_auto_run_robot_2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:background="@drawable/ic_done_black_24dp"/>
+        </LinearLayout>
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2018_red_auto_run_robot_3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_clear_black_24dp"
+                tools:background="@drawable/ic_done_black_24dp"/>
+        </LinearLayout>
+        <TextView
+            android:text="@string/breakdown2018_auto_run_robot_3"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2018_blue_auto_run_robot_3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:background="@drawable/ic_done_black_24dp"/>
+        </LinearLayout>
+
+        <!-- Auto Run Points -->
         <TextView
             android:id="@+id/breakdown2018_red_auto_run_points"
             style="@style/breakdown_redItem"
@@ -208,7 +276,7 @@
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
-            android:text="@string/breakdown2018_teleop_robot_1_endgame"
+            android:text="@string/breakdown2018_endgame_robot_1"
             style="@style/breakdown_category" />
         <TextView
             android:id="@+id/breakdown2018_endgame_blue_robot_1"
@@ -221,7 +289,7 @@
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
-            android:text="@string/breakdown2018_teleop_robot_2_endgame"
+            android:text="@string/breakdown2018_endgame_robot_2"
             style="@style/breakdown_category" />
         <TextView
             android:id="@+id/breakdown2018_endgame_blue_robot_2"
@@ -234,7 +302,7 @@
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
-            android:text="@string/breakdown2018_teleop_robot_3_endgame"
+            android:text="@string/breakdown2018_endgame_robot_3"
             style="@style/breakdown_category" />
         <TextView
             android:id="@+id/breakdown2018_endgame_blue_robot_3"
@@ -247,7 +315,7 @@
             style="@style/breakdown_redItem"
             tools:text="40"/>
         <TextView
-            android:text="@string/breakdown2018_teleop_park_climb_points"
+            android:text="@string/breakdown2018_endgame_park_climb_points"
             style="@style/breakdown_categorySubtotal" />
         <TextView
             android:id="@+id/breakdown2018_endgame_blue_total"

--- a/android/src/main/res/layout/match_breakdown_2018.xml
+++ b/android/src/main/res/layout/match_breakdown_2018.xml
@@ -1,0 +1,372 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+    <android.support.v7.widget.GridLayout
+        app:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/breakdown2018_container"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:background="@color/column_header_gray"
+        app:columnCount="3"
+        app:rowCount="26"
+        app:alignmentMode="alignBounds" >
+
+        <!-- Teams -->
+        <TextView
+            android:id="@+id/breakdown_red1"
+            style="@style/breakdown_redItemSmall"
+            tools:text="Red 1"/>
+        <TextView
+            android:text="@string/breakdown_teams"
+            style="@style/breakdown_categorySubtotal"
+            app:layout_rowSpan="3" />
+        <TextView
+            android:id="@+id/breakdown_blue1"
+            style="@style/breakdown_blueItemSmall"
+            tools:text="Blue 1"/>
+        <TextView
+            android:id="@+id/breakdown_red2"
+            style="@style/breakdown_redItemSmall"
+            tools:text="Red 2"/>
+        <TextView
+            android:id="@+id/breakdown_blue2"
+            style="@style/breakdown_blueItemSmall"
+            tools:text="Blue 2"/>
+        <TextView
+            android:id="@+id/breakdown_red3"
+            style="@style/breakdown_redItemSmall"
+            tools:text="Red 3"/>
+        <TextView
+            android:id="@+id/breakdown_blue3"
+            style="@style/breakdown_blueItemSmall"
+            tools:text="Blue 3"/>
+
+        <!-- Auto Run -->
+        <TextView
+            android:id="@+id/breakdown2018_red_auto_run_points"
+            style="@style/breakdown_redItem"
+            tools:text="0"/>
+        <TextView
+            android:text="@string/breakdown2018_auto_run_points"
+            style="@style/breakdown_categorySubtotal" />
+        <TextView
+            android:id="@+id/breakdown2018_blue_auto_run_points"
+            style="@style/breakdown_blueItem"
+            tools:text="5"/>
+
+        <!-- Auto Scale -->
+        <TextView
+            android:id="@+id/breakdown2018_red_auto_scale_seconds"
+            style="@style/breakdown_redItem"
+            tools:text="0"/>
+        <TextView
+            android:text="@string/breakdown2018_auto_scale_seconds"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2018_blue_auto_scale_seconds"
+            style="@style/breakdown_blueItem"
+            tools:text="0"/>
+
+        <!-- Auto Switch -->
+        <TextView
+            android:id="@+id/breakdown2018_red_auto_switch_seconds"
+            style="@style/breakdown_redItem"
+            tools:text="0"/>
+        <TextView
+            android:text="@string/breakdown2018_auto_switch_seconds"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2018_blue_auto_switch_seconds"
+            style="@style/breakdown_blueItem"
+            tools:text="0"/>
+
+        <!-- Auto Ownership -->
+        <TextView
+            android:id="@+id/breakdown2018_red_auto_ownership_points"
+            style="@style/breakdown_redItem"
+            tools:text="0"/>
+        <TextView
+            android:text="@string/breakdown2018_ownership_points"
+            style="@style/breakdown_categorySubtotal" />
+        <TextView
+            android:id="@+id/breakdown2018_blue_auto_ownership_points"
+            style="@style/breakdown_blueItem"
+            tools:text="0"/>
+
+        <!-- Auto Total -->
+        <TextView
+            android:id="@+id/breakdown_auto_total_red"
+            style="@style/breakdown_redTotal"
+            tools:text="60"/>
+        <TextView
+            android:text="@string/breakdown_auto_total"
+            style="@style/breakdown_categoryTotal" />
+        <TextView
+            android:id="@+id/breakdown_auto_total_blue"
+            style="@style/breakdown_blueTotal"
+            tools:text="5"/>
+
+        <!-- Teleop Scale -->
+        <TextView
+            android:id="@+id/breakdown2018_teleop_red_scale_seconds"
+            style="@style/breakdown_redItem"
+            tools:text="0"/>
+        <TextView
+            android:text="@string/breakdown2018_teleop_scale_boost"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2018_teleop_blue_scale_seconds"
+            style="@style/breakdown_blueItem"
+            tools:text="0"/>
+
+        <!-- Teleop Switch -->
+        <TextView
+            android:id="@+id/breakdown2018_teleop_red_switch_seconds"
+            style="@style/breakdown_redItem"
+            tools:text="0"/>
+        <TextView
+            android:text="@string/breakdown2018_teleop_switch_boost"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2018_teleop_blue_switch_seconds"
+            style="@style/breakdown_blueItem"
+            tools:text="0"/>
+
+        <!-- Teleop Ownership -->
+        <TextView
+            android:id="@+id/breakdown2018_teleop_red_ownership_points"
+            style="@style/breakdown_redItem"
+            tools:text="0"/>
+        <TextView
+            android:text="@string/breakdown2018_ownership_points"
+            style="@style/breakdown_categorySubtotal" />
+        <TextView
+            android:id="@+id/breakdown2018_teleop_blue_ownership_points"
+            style="@style/breakdown_blueItem"
+            tools:text="0"/>
+
+        <!-- Teleop Force Cubes -->
+        <TextView
+            android:id="@+id/breakdown2018_teleop_red_force_cubes"
+            style="@style/breakdown_redItem"
+            tools:text="40"/>
+        <TextView
+            android:text="@string/breakdown2018_teleop_force_cubes"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2018_teleop_blue_force_cubes"
+            style="@style/breakdown_blueItem"
+            tools:text="80"/>
+
+        <!-- Teleop Levitate Cubes -->
+        <TextView
+            android:id="@+id/breakdown2018_teleop_red_levitate_cubes"
+            style="@style/breakdown_redItem"
+            tools:text="40"/>
+        <TextView
+            android:text="@string/breakdown2018_teleop_levitate_cubes"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2018_teleop_blue_levitate_cubes"
+            style="@style/breakdown_blueItem"
+            tools:text="80"/>
+
+        <!-- Teleop Boost Cubes -->
+        <TextView
+            android:id="@+id/breakdown2018_teleop_red_boost_cubes"
+            style="@style/breakdown_redItem"
+            tools:text="40"/>
+        <TextView
+            android:text="@string/breakdown2018_teleop_boost_cubes"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2018_teleop_blue_boost_cubes"
+            style="@style/breakdown_blueItem"
+            tools:text="80"/>
+
+        <!-- Teleop Vault Points -->
+        <TextView
+            android:id="@+id/breakdown2018_teleop_red_vault_points"
+            style="@style/breakdown_redItem"
+            tools:text="40"/>
+        <TextView
+            android:text="@string/breakdown2018_teleop_vault_points"
+            style="@style/breakdown_categorySubtotal" />
+        <TextView
+            android:id="@+id/breakdown2018_teleop_blue_vault_points"
+            style="@style/breakdown_blueItem"
+            tools:text="80"/>
+
+        <!-- Robot 1 Endgame -->
+        <TextView
+            android:id="@+id/breakdown2018_red_endgame_robot_1"
+            style="@style/breakdown_redItem"
+            tools:text="40"/>
+        <TextView
+            android:text="@string/breakdown2018_teleop_robot_1_endgame"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2018_blue_endgame_robot_1"
+            style="@style/breakdown_blueItem"
+            tools:text="80"/>
+
+        <!-- Robot 2 Endgame  -->
+        <TextView
+            android:id="@+id/breakdown2018_red_endgame_robot_2"
+            style="@style/breakdown_redItem"
+            tools:text="40"/>
+        <TextView
+            android:text="@string/breakdown2018_teleop_robot_2_endgame"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2018_blue_endgame_robot_2"
+            style="@style/breakdown_blueItem"
+            tools:text="80"/>
+
+        <!-- Robot 3 Endgame -->
+        <TextView
+            android:id="@+id/breakdown2018_red_endgame_robot_3"
+            style="@style/breakdown_redItem"
+            tools:text="40"/>
+        <TextView
+            android:text="@string/breakdown2018_teleop_robot_3_endgame"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2018_blue_endgame_robot_3"
+            style="@style/breakdown_blueItem"
+            tools:text="80"/>
+
+        <!-- Park/Climb Points -->
+        <TextView
+            android:id="@+id/breakdown2018_red_endgame_points"
+            style="@style/breakdown_redItem"
+            tools:text="40"/>
+        <TextView
+            android:text="@string/breakdown2018_teleop_park_climb_points"
+            style="@style/breakdown_categorySubtotal" />
+        <TextView
+            android:id="@+id/breakdown2018_blue_endgame_points"
+            style="@style/breakdown_blueItem"
+            tools:text="80"/>
+
+        <!-- Teleop Total -->
+        <TextView
+            android:id="@+id/breakdown_teleop_total_red"
+            style="@style/breakdown_redTotal"
+            tools:text="40"/>
+        <TextView
+            android:text="@string/breakdown_teleop_total"
+            style="@style/breakdown_categoryTotal" />
+        <TextView
+            android:id="@+id/breakdown_teleop_total_blue"
+            style="@style/breakdown_blueTotal"
+            tools:text="80"/>
+
+        <!-- Auto Quest -->
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2018_red_auto_quest"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_clear_black_24dp"
+                tools:background="@drawable/ic_done_black_24dp"/>
+        </LinearLayout>
+        <TextView
+            android:text="@string/breakdown2018_auto_quest"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2018_blue_auto_quest"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_clear_black_24dp"
+                tools:background="@drawable/ic_done_black_24dp"/>
+        </LinearLayout>
+
+        <!-- Face the Boss -->
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2018_red_face_the_boss"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_clear_black_24dp"
+                tools:background="@drawable/ic_done_black_24dp"/>
+        </LinearLayout>
+        <TextView
+            android:text="@string/breakdown2018_face_the_boss"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2018_blue_face_the_boss"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:background="@drawable/ic_done_black_24dp"/>
+        </LinearLayout>
+
+        <!-- Fouls -->
+        <TextView
+            android:id="@+id/breakdown_fouls_red"
+            style="@style/breakdown_redItem"
+            tools:text="+ 0"/>
+        <TextView
+            android:text="@string/breakdown_foul"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown_fouls_blue"
+            style="@style/breakdown_blueItem"
+            tools:text="+ 5"/>
+
+        <!-- Adjustments -->
+        <TextView
+            android:id="@+id/breakdown_adjust_red"
+            style="@style/breakdown_redItem"
+            tools:text="0"/>
+        <TextView
+            android:text="@string/breakdown_adjust"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown_adjust_blue"
+            style="@style/breakdown_blueItem"
+            tools:text="0"/>
+
+        <!-- Total -->
+        <TextView
+            android:id="@+id/breakdown_total_red"
+            style="@style/breakdown_redTotal"
+            tools:text="100"/>
+        <TextView
+            android:text="@string/breakdown_total"
+            style="@style/breakdown_categoryTotal" />
+        <TextView
+            android:id="@+id/breakdown_total_blue"
+            style="@style/breakdown_blueTotal"
+            tools:text="90"/>
+
+        <!-- Ranking Points -->
+        <TextView
+            android:id="@+id/breakdown_red_rp"
+            style="@style/breakdown_redTotal"
+            tools:text="2"/>
+        <TextView
+            android:text="@string/breakdown_rp"
+            android:id="@+id/breakdown_rp_header"
+            style="@style/breakdown_categorySubtotal" />
+        <TextView
+            android:id="@+id/breakdown_blue_rp"
+            style="@style/breakdown_blueTotal"
+            tools:text="0"/>
+    </android.support.v7.widget.GridLayout>
+</ScrollView>

--- a/android/src/main/res/values-v21/strings_2018_breakdown.xml
+++ b/android/src/main/res/values-v21/strings_2018_breakdown.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="breakdown2018_auto_run_robot_1">Robot 1 Auto Run</string>
+    <string name="breakdown2018_auto_run_robot_2">Robot 2 Auto Run</string>
+    <string name="breakdown2018_auto_run_robot_3">Robot 3 Auto Run</string>
     <string name="breakdown2018_auto_run_points">Auto Run Points</string>
     <string name="breakdown2018_auto_scale_seconds">Scale Ownership (seconds)</string>
     <string name="breakdown2018_auto_switch_seconds">Switch Ownership (seconds)</string>
+
     <string name="breakdown2018_teleop_scale_boost">Scale Ownership + Boost (seconds)</string>
     <string name="breakdown2018_teleop_switch_boost">Switch Ownership + Boost (seconds)</string>
+
     <string name="breakdown2018_vault_force_cubes">Force Cubes Total (Played)</string>
     <string name="breakdown2018_vault_levitate_cubes">Levitate Cubes Total (Played)</string>
     <string name="breakdown2018_vault_boost_cubes">Boost Cubes Total (Played)</string>
     <string name="breakdown2018_vault_points">Total Vault Points</string>
-    <string name="breakdown2018_teleop_robot_1_endgame">Robot 1 Endgame</string>
-    <string name="breakdown2018_teleop_robot_2_endgame">Robot 2 Endgame</string>
-    <string name="breakdown2018_teleop_robot_3_endgame">Robot 3 Endgame</string>
-    <string name="breakdown2018_teleop_park_climb_points">Park/Climb Points</string>
+
+    <string name="breakdown2018_endgame_robot_1">Robot 1 Endgame</string>
+    <string name="breakdown2018_endgame_robot_2">Robot 2 Endgame</string>
+    <string name="breakdown2018_endgame_robot_3">Robot 3 Endgame</string>
+    <string name="breakdown2018_endgame_park_climb_points">Park/Climb Points</string>
+
     <string name="breakdown2018_ownership_points">Ownership Points</string>
 
     <string name="breakdown2018_face_the_boss">Face The Boss</string>

--- a/android/src/main/res/values-v21/strings_2018_breakdown.xml
+++ b/android/src/main/res/values-v21/strings_2018_breakdown.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="breakdown2018_auto_run_points">Auto Run Points</string>
+    <string name="breakdown2018_auto_scale_seconds">Scale Ownership (seconds)</string>
+    <string name="breakdown2018_auto_switch_seconds">Switch Ownership (seconds)</string>
+    <string name="breakdown2018_teleop_scale_boost">Scale Ownership + Boost (seconds)</string>
+    <string name="breakdown2018_teleop_switch_boost">Switch Ownership + Boost (seconds)</string>
+    <string name="breakdown2018_teleop_force_cubes">Force Cubes Total (Played)</string>
+    <string name="breakdown2018_teleop_levitate_cubes">Levitate Cubes Total (Played)</string>
+    <string name="breakdown2018_teleop_boost_cubes">Boost Cubes Total (Played)</string>
+    <string name="breakdown2018_teleop_vault_points">Total Vault Points</string>
+    <string name="breakdown2018_teleop_robot_1_endgame">Robot 1 Endgame</string>
+    <string name="breakdown2018_teleop_robot_2_endgame">Robot 2 Endgame</string>
+    <string name="breakdown2018_teleop_robot_3_endgame">Robot 3 Endgame</string>
+    <string name="breakdown2018_teleop_park_climb_points">Park/Climb Points</string>
+    <string name="breakdown2018_ownership_points">Ownership Points</string>
+
+    <string name="breakdown2018_face_the_boss">Face The Boss</string>
+    <string name="breakdown2018_auto_quest">Auto Quest</string>
+
+    <string name="breakdown2018_scale_switch_boost_points">%1$s + %2$s</string>
+    <string name="breakdown2018_cubes_total_played"> %1$s (%2$s)</string>
+</resources>

--- a/android/src/main/res/values-v21/strings_2018_breakdown.xml
+++ b/android/src/main/res/values-v21/strings_2018_breakdown.xml
@@ -5,10 +5,10 @@
     <string name="breakdown2018_auto_switch_seconds">Switch Ownership (seconds)</string>
     <string name="breakdown2018_teleop_scale_boost">Scale Ownership + Boost (seconds)</string>
     <string name="breakdown2018_teleop_switch_boost">Switch Ownership + Boost (seconds)</string>
-    <string name="breakdown2018_teleop_force_cubes">Force Cubes Total (Played)</string>
-    <string name="breakdown2018_teleop_levitate_cubes">Levitate Cubes Total (Played)</string>
-    <string name="breakdown2018_teleop_boost_cubes">Boost Cubes Total (Played)</string>
-    <string name="breakdown2018_teleop_vault_points">Total Vault Points</string>
+    <string name="breakdown2018_vault_force_cubes">Force Cubes Total (Played)</string>
+    <string name="breakdown2018_vault_levitate_cubes">Levitate Cubes Total (Played)</string>
+    <string name="breakdown2018_vault_boost_cubes">Boost Cubes Total (Played)</string>
+    <string name="breakdown2018_vault_points">Total Vault Points</string>
     <string name="breakdown2018_teleop_robot_1_endgame">Robot 1 Endgame</string>
     <string name="breakdown2018_teleop_robot_2_endgame">Robot 2 Endgame</string>
     <string name="breakdown2018_teleop_robot_3_endgame">Robot 3 Endgame</string>


### PR DESCRIPTION
**Summary:** 
Adds the match breakdown table for FRC POWER UP matches.

**Issues Reference:** 
Closes: #846 

**Test Plan:** 
- Created unit test for match breakdown using local data
- Tested the breakdown on debug application, checking for layout inconsistencies, crashes, and leaks
- Compared data with official match data for accuracy

**Screenshots:**
<img src="https://user-images.githubusercontent.com/17170253/36646376-ca6bb2ec-1a44-11e8-8c10-b7ef93c568d8.png" width="35%" height="35%"> <img src="https://user-images.githubusercontent.com/17170253/36646414-2860498a-1a45-11e8-9605-665ca5de965b.png" width="35%" height="35%">


