### PR TITLE
Add Facebook SDK support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -328,6 +328,11 @@ dependencies {
     debugProguardCompile "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}"
     releaseCompile "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}"
     testCompile "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}"
+
+    // Facebook SDKs
+    compile ('com.facebook.android:facebook-android-sdk:[4,5)'){
+        exclude group:"com.android.support"
+    }
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -259,6 +259,26 @@
         <service
                 android:name=".mytba.MyTbaRegistrationService"
                 android:exported="false" />
+
+        <!-- Facebook SDK Configuration -->
+        <meta-data android:name="com.facebook.sdk.ApplicationId"
+            android:value="@string/facebook_app_id"/>
+
+        <activity android:name="com.facebook.FacebookActivity"
+            android:configChanges=
+                "keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+            android:label="@string/app_name" />
+        <activity
+            android:name="com.facebook.CustomTabActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="@string/fb_login_protocol_scheme" />
+            </intent-filter>
+        </activity>
+
     </application>
 
 </manifest>

--- a/android/src/main/java/com/thebluealliance/androidclient/TBAAndroid.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/TBAAndroid.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.androidclient;
 
 import com.facebook.stetho.Stetho;
+import com.facebook.FacebookSdk;
 import com.squareup.leakcanary.LeakCanary;
 import com.thebluealliance.androidclient.accounts.AccountModule;
 import com.thebluealliance.androidclient.auth.AuthModule;

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -189,4 +189,8 @@
     <string name="event_type_other">Other Events</string>
     <string name="week_events_header">%1$s Events</string>
     <string name="district_events_header">%1$s District Events</string>
+
+    <!-- Facebook SDK Things -->
+    <string name="facebook_app_id">117484816504</string>
+    <string name="fb_login_protocol_scheme">fb117484816504</string>
 </resources>


### PR DESCRIPTION
**Summary:** Adds the Facebook SDK through Gradle and initializes it. Because of some conflicts with our version of the android compatibility library, I added one "exclude group:"com.android.support"" which shouldn't affect functionality.

**Issues Reference:** n/a

**Test Plan:** Compiled and ran in emulator running Google Play Services.

**Screenshots:** n/a