### PR TITLE
Fix #856: red vault data shown in blue vault fields

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
@@ -182,11 +182,11 @@ public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
 
         /* Teleop Cubes Played */
         redVaultForceCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultForceTotal"), getIntDefault(redData, "vaultForcePlayed")));
-        blueVaultForceCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultForceTotal"), getIntDefault(redData, "vaultForcePlayed")));
+        blueVaultForceCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(blueData, "vaultForceTotal"), getIntDefault(blueData, "vaultForcePlayed")));
         redVaultLevitateCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultLevitateTotal"), getIntDefault(redData, "vaultLevitatePlayed")));
-        blueVaultLevitateCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultLevitateTotal"), getIntDefault(redData, "vaultLevitatePlayed")));
+        blueVaultLevitateCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(blueData, "vaultLevitateTotal"), getIntDefault(blueData, "vaultLevitatePlayed")));
         redVaultBoostCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultBoostTotal"), getIntDefault(redData, "vaultBoostPlayed")));
-        blueVaultBoostCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(redData, "vaultBoostTotal"), getIntDefault(redData, "vaultBoostPlayed")));
+        blueVaultBoostCubes.setText(res.getString(R.string.breakdown2018_cubes_total_played, getIntDefault(blueData, "vaultBoostTotal"), getIntDefault(blueData, "vaultBoostPlayed")));
 
         /* Teleop Vault Points */
         redVaultPoints.setText(getIntDefault(redData, "vaultPoints"));


### PR DESCRIPTION
This OUGHT to fix the bug but the Breakdown tab says
“No match breakdown found”. Maybe that has to do with the EventBus messages?

```
03-16 01:03:24.615 7439-7439/com.thebluealliance.androidclient.development D/android.view.View: Match key clicked: 2018azfl_qm2
03-16 01:03:24.615 7439-7439/com.thebluealliance.androidclient.development W/GAv4: Discarding hit. Missing tracking id parameter: cd=com.thebluealliance.androidclient.activities.ViewEventActivity,a=661243983,sf=100.0,t=event,av=4.3.0+dirty,el=,ea=2018azfl_qm2,an=The Blue Alliance Debug,aid=4.3.0+dirty,tid=,ec=match_click
03-16 01:03:24.621 7439-7931/com.thebluealliance.androidclient.development V/FA: Activity paused, time: 3861058
03-16 01:03:24.627 7439-7439/com.thebluealliance.androidclient.development V/FA: onActivityCreated
03-16 01:03:24.635 7439-7439/com.thebluealliance.androidclient.development I/AppCompatViewInflater: app:theme is now deprecated. Please move to using android:theme instead.
03-16 01:03:24.637 7439-7439/com.thebluealliance.androidclient.development I/AppCompatViewInflater: app:theme is now deprecated. Please move to using android:theme instead.
03-16 01:03:24.644 7439-7439/com.thebluealliance.androidclient.development W/GAv4: Discarding hit. Missing tracking id parameter: cd=com.thebluealliance.androidclient.activities.ViewMatchActivity,a=1998468115,sf=100.0,t=screenview,av=4.3.0+dirty,an=The Blue Alliance Debug,aid=4.3.0+dirty
03-16 01:03:24.645 7439-7439/com.thebluealliance.androidclient.development W/GAv4: Discarding hit. Missing tracking id parameter: cd=com.thebluealliance.androidclient.activities.ViewMatchActivity,a=15517766,sf=100.0,t=screenview,av=4.3.0+dirty,an=The Blue Alliance Debug,aid=4.3.0+dirty,tid=
03-16 01:03:24.645 7439-7439/com.thebluealliance.androidclient.development W/GAv4: Discarding hit. Missing tracking id parameter: cd=com.thebluealliance.androidclient.activities.ViewMatchActivity,a=661243983,sf=100.0,t=screenview,av=4.3.0+dirty,an=The Blue Alliance Debug,aid=4.3.0+dirty,tid=
03-16 01:03:24.648 7439-7931/com.thebluealliance.androidclient.development V/FA: Activity resumed, time: 3861085
03-16 01:03:24.658 7439-7439/com.thebluealliance.androidclient.development D/com.thebluealliance.androidclient.datafeed.DatafeedModule_ProvideTBARetrofitFactory: Using TBA Host: https://www.thebluealliance.com/
03-16 01:03:24.663 7439-7961/com.thebluealliance.androidclient.development D/okhttp3.internal.http.RealInterceptorChain: FETCHING https://www.thebluealliance.com/api/v3/match/2018azfl_qm2
03-16 01:03:24.666 7439-7520/com.thebluealliance.androidclient.development I/com.thebluealliance.androidclient.subscribers.BaseAPISubscriber: Showing 2018 breakdowns? false
03-16 01:03:24.666 7439-7520/com.thebluealliance.androidclient.development W/GAv4: Discarding hit. Missing tracking id parameter: cd=com.thebluealliance.androidclient.activities.ViewMatchActivity,a=661243983,sf=100.0,utt=2983,t=timing,av=4.3.0+dirty,utc=load_timing,utv=MatchBreakdownSubscriber,utl=matchBreakdown_2018azfl_qm2,an=The Blue Alliance Debug,aid=4.3.0+dirty,tid=
03-16 01:03:24.719 7439-7439/com.thebluealliance.androidclient.development W/View: requestLayout() improperly called by android.widget.ListView{5318abb VFED.VC.. ......ID 0,590-1050,2392 #7f0f0105 app:id/left_drawer} during layout: running second layout pass
03-16 01:03:24.722 7439-7439/com.thebluealliance.androidclient.development D/com.thebluealliance.androidclient.background.mytba.CreateSubscriptionPanel: getting notifications for: MATCH
03-16 01:03:24.730 7439-7507/com.thebluealliance.androidclient.development D/EGL_emulation: eglMakeCurrent: 0xa42fc5a0: ver 3 0 (tinfo 0x93a83740)
03-16 01:03:24.744 7439-7507/com.thebluealliance.androidclient.development I/chatty: uid=10088(u0_a88) RenderThread identical 2 lines
03-16 01:03:24.748 7439-7507/com.thebluealliance.androidclient.development D/EGL_emulation: eglMakeCurrent: 0xa42fc5a0: ver 3 0 (tinfo 0x93a83740)
03-16 01:03:24.758 7439-7507/com.thebluealliance.androidclient.development D/EGL_emulation: eglMakeCurrent: 0xa42fc5a0: ver 3 0 (tinfo 0x93a83740)
03-16 01:03:24.809 7439-7507/com.thebluealliance.androidclient.development I/chatty: uid=10088(u0_a88) RenderThread identical 1 line
03-16 01:03:24.815 7439-7507/com.thebluealliance.androidclient.development D/EGL_emulation: eglMakeCurrent: 0xa42fc5a0: ver 3 0 (tinfo 0x93a83740)
03-16 01:03:24.816 7439-7507/com.thebluealliance.androidclient.development D/OpenGLRenderer: endAllActiveAnimators on 0x8e19ea80 (RippleDrawable) with handle 0x9406c060
03-16 01:03:24.823 7439-7507/com.thebluealliance.androidclient.development D/EGL_emulation: eglMakeCurrent: 0xa42fc5a0: ver 3 0 (tinfo 0x93a83740)
03-16 01:03:25.246 7439-7505/com.thebluealliance.androidclient.development D/EventBus: No subscribers registered for event class com.thebluealliance.androidclient.subscribers.MatchInfoSubscriber$Model
03-16 01:03:25.246 7439-7505/com.thebluealliance.androidclient.development D/EventBus: No subscribers registered for event class org.greenrobot.eventbus.NoSubscriberEvent
03-16 01:03:25.246 7439-7961/com.thebluealliance.androidclient.development D/okhttp3.internal.http.RealInterceptorChain: FETCHING https://www.thebluealliance.com/api/v3/event/2018azfl
03-16 01:03:25.247 7439-7439/com.thebluealliance.androidclient.development D/com.thebluealliance.androidclient.subscribers.BaseAPISubscriber: BINDING DATA
03-16 01:03:25.247 7439-7439/com.thebluealliance.androidclient.development D/com.thebluealliance.androidclient.subscribers.BaseAPISubscriber: BINDING COMPLETE; ELAPSED TIME: 0ms
03-16 01:03:25.249 7439-7505/com.thebluealliance.androidclient.development D/EventBus: No subscribers registered for event class com.thebluealliance.androidclient.subscribers.MatchInfoSubscriber$Model
03-16 01:03:25.249 7439-7505/com.thebluealliance.androidclient.development D/EventBus: No subscribers registered for event class org.greenrobot.eventbus.NoSubscriberEvent
03-16 01:03:25.249 7439-7505/com.thebluealliance.androidclient.development W/GAv4: Discarding hit. Missing tracking id parameter: cd=com.thebluealliance.androidclient.activities.ViewMatchActivity,a=661243983,sf=100.0,utt=587257,t=timing,av=4.3.0+dirty,utc=load_timing,utv=MatchInfoSubscriber,utl=matchInfo_2018azfl_qm2,an=The Blue Alliance Debug,aid=4.3.0+dirty,tid=
03-16 01:03:25.279 7439-7439/com.thebluealliance.androidclient.development D/com.thebluealliance.androidclient.subscribers.BaseAPISubscriber: BINDING DATA
03-16 01:03:25.279 7439-7439/com.thebluealliance.androidclient.development D/com.thebluealliance.androidclient.subscribers.BaseAPISubscriber: BINDING COMPLETE; ELAPSED TIME: 0ms
```

How to run the tests? Trying to run MatchBreakdownView2018Test as
an Android Instrumented Test failed before I changed any code:

```
java.lang.AssertionError: expected:<1> but was:<0>
at org.junit.Assert.fail(Assert.java:88)
at org.junit.Assert.failNotEquals(Assert.java:834)
at org.junit.Assert.assertEquals(Assert.java:645)
at org.junit.Assert.assertEquals(Assert.java:631)
at com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2018Test.getView(MatchBreakdownView2018Test.java:55)
at com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2018Test.testRenderQualMatch(MatchBreakdownView2018Test.java:39)
at java.lang.reflect.Method.invoke(Native Method)
at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
at org.junit.runners.Suite.runChild(Suite.java:128)
at org.junit.runners.Suite.runChild(Suite.java:27)
at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:59)
at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:262)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2074)
```

… and testRenderQualMatch() looks like it just records a snapshot.
Does that do a regression test against a previous snapshot?
There’s nothing obvious in there to check values.

**Summary:** 
Fix some copy-paste-os on the 2018 match breakdown screen.

**Issues Reference:** 
#856 

**Test Plan:** 
This OUGHT to fix the bug but the Breakdown tab says “No match breakdown found”, and no joy from the androidTest.

**Screenshots:**
