### PR TITLE
Add Media tab to Team at Event

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/adapters/TeamAtEventFragmentPagerAdapter.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/adapters/TeamAtEventFragmentPagerAdapter.java
@@ -6,19 +6,26 @@ import android.support.v4.app.FragmentPagerAdapter;
 
 import com.thebluealliance.androidclient.fragments.event.EventAwardsFragment;
 import com.thebluealliance.androidclient.fragments.event.EventMatchesFragment;
+import com.thebluealliance.androidclient.fragments.team.TeamMediaFragment;
 import com.thebluealliance.androidclient.fragments.teamAtEvent.TeamAtEventStatsFragment;
 import com.thebluealliance.androidclient.fragments.teamAtEvent.TeamAtEventSummaryFragment;
+import com.thebluealliance.androidclient.helpers.EventHelper;
 
 public class TeamAtEventFragmentPagerAdapter extends FragmentPagerAdapter {
 
-    public static final String[] TITLES = {"Summary", "Matches", "Stats", "Awards"};
+    public static final String[] TITLES = {"Summary", "Matches", "Media", "Stats", "Awards"};
+    public static final int TAB_SUMMARY = 0,
+            TAB_MATCHES = 1,
+            TAB_MEDIA = 2,
+            TAB_STATS = 3,
+            TAB_AWARDS = 4;
 
-    private String teamKey, eventKey;
+    private String mTeamKey, mEventKey;
 
     public TeamAtEventFragmentPagerAdapter(FragmentManager fm, String teamKey, String eventKey) {
         super(fm);
-        this.teamKey = teamKey;
-        this.eventKey = eventKey;
+        mTeamKey = teamKey;
+        mEventKey = eventKey;
     }
 
     @Override
@@ -27,29 +34,26 @@ public class TeamAtEventFragmentPagerAdapter extends FragmentPagerAdapter {
     }
 
     @Override
-    public Fragment getItem(int position) {
-        Fragment fragment;
-        switch (position) {
-            default:
-            case 0: //summary
-                fragment = TeamAtEventSummaryFragment.newInstance(teamKey, eventKey);
-                break;
-            case 1:
-                //matches
-                fragment = EventMatchesFragment.newInstance(eventKey, teamKey);
-                break;
-            case 2: //stats
-                fragment = TeamAtEventStatsFragment.newInstance(teamKey, eventKey);
-                break;
-            case 3: //awards
-                fragment = EventAwardsFragment.newInstance(eventKey, teamKey);
-                break;
-        }
-        return fragment;
-    }
-
-    @Override
     public int getCount() {
         return TITLES.length;
     }
+
+    @Override
+    public Fragment getItem(int position) {
+        switch (position) {
+            case TAB_SUMMARY:
+                return TeamAtEventSummaryFragment.newInstance(mTeamKey, mEventKey);
+            case TAB_MATCHES:
+                return EventMatchesFragment.newInstance(mEventKey, mTeamKey);
+            case TAB_MEDIA:
+                return TeamMediaFragment.newInstance(mTeamKey, EventHelper.getYear(mEventKey));
+            case TAB_STATS:
+                return TeamAtEventStatsFragment.newInstance(mTeamKey, mEventKey);
+            case TAB_AWARDS:
+                return EventAwardsFragment.newInstance(mEventKey, mTeamKey);
+            default:
+                return new Fragment();
+        }
+    }
+
 }


### PR DESCRIPTION
**Summary:** 

Adds Media to the TeamAtEvent pages

* Add a TeamMediaFragment to the items of TeamAtEventFragmentPagerAdapter
* Refactor the TeamAtEventFragmentPagerAdapter slightly to match the style of ViewTeamFragmentPagerAdapter, which is a simpler style

**Issues Reference:** 

Per #863, we know people use the Team @ Event pages much more than Team pages, so we should make sure the most useful information is displayed there. Indexing robot photos is a unique feature of TBA, so this adds the Media tab to the Team @ Event views.

**Test Plan:** 

Look at Team 254 @ Arizona 2018 . Observe a Media tab that matches the Team 254 2018 Media tab renders, although no media renders.

I am not sure why no media is rendering locally, either for imgur photos or for youtube videos. I tested with Team 254's 2018 data, which has 2 imgur, 1 instagram, and 1 youtube media. https://www.thebluealliance.com/team/254/2018 . These media also fail to render in master on the the Team Media tab, so the problem seems unrelated to my changes.

31 tests fail, and I am not sure whether they are related to these changes.

**Screenshots:**

Team 254 Media:
![screenshot_1546354674](https://user-images.githubusercontent.com/57101/50574017-1e474000-0dad-11e9-9951-1bdc86751d07.png)

Before:
![screenshot_1546354862](https://user-images.githubusercontent.com/57101/50574012-125b7e00-0dad-11e9-9a1d-0b890b4be2be.png)

After: 
![screenshot_1546354664](https://user-images.githubusercontent.com/57101/50574016-19828c00-0dad-11e9-9cec-167a46057965.png)
