### PR TITLE
Fix some offseason events not showing up

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/APICache.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/APICache.java
@@ -203,6 +203,7 @@ public class APICache {
         return Observable.create((observer) -> {
             try {
                 Calendar cal = Calendar.getInstance();
+                cal.clear();
                 cal.set(year, month, 1);
                 String start = Long.toString(cal.getTimeInMillis());
                 cal.add(Calendar.MONTH, 1);
@@ -210,9 +211,9 @@ public class APICache {
                 String end = Long.toString(cal.getTimeInMillis());
 
                 String where = String.format(
-                  "%1$s >= ? AND %2$s < ?",
+                  "%1$s >= ? AND %2$s <= ?",
                   EventsTable.START,
-                  EventsTable.END);
+                  EventsTable.START);
                 List<Event> events = mDb.getEventsTable()
                   .getForQuery(null, where, new String[]{start, end});
                 observer.onNext(events);


### PR DESCRIPTION
**Summary:** 
The logic for fetching events within a given month was funky in a few ways:
 * It only kept events that were completely within the month (`monthStart <= eventStart && eventEnd < eventEnd`)
 * This also actually would have excluded events ending on the last day of the month
 * Both the month start and the month end were calculated with the correct year, month, and day, but using the current device time. This effectively meant that unless you were getting the events at precisely midnight, you wouldn't see any events starting on the first of the month. 

This new logic uses the correct time, and only checks that the event's start date lies within the month. If an event starts in July and ends in August, it is bucketed as a July event.

**Issues Reference:** 
Fixes #870 

**Test Plan:** 
Unfortunately the APICache (particularly with the database) isn't particularly well set up for unit tests, but I'd like to get there eventually.

For manual testing, September 2018 contains events on September 1st (Battleship Blast Day 1) and September 30th (2018 CORI Invitational) that serve as good start/end logic checks within the month.
July 2018 contains an event (RCC aka Region China Champions) that straddles the July - August boundary.

Battleship Blast Day 1 and RCC previously did not show up, and now do.
