### PR TITLE
Improve team@event summary when event hasn't started

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/combiners/TeamAtEventSummaryCombiner.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/combiners/TeamAtEventSummaryCombiner.java
@@ -1,0 +1,14 @@
+package com.thebluealliance.androidclient.datafeed.combiners;
+
+import com.thebluealliance.androidclient.models.Event;
+import com.thebluealliance.androidclient.models.TeamAtEventStatus;
+import com.thebluealliance.androidclient.subscribers.TeamAtEventSummarySubscriber;
+
+import rx.functions.Func2;
+
+public class TeamAtEventSummaryCombiner implements Func2<TeamAtEventStatus, Event, TeamAtEventSummarySubscriber.Model> {
+    @Override
+    public TeamAtEventSummarySubscriber.Model call(TeamAtEventStatus teamAtEventStatus, Event event) {
+        return new TeamAtEventSummarySubscriber.Model(teamAtEventStatus, event);
+    }
+}

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/teamAtEvent/TeamAtEventSummaryFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/teamAtEvent/TeamAtEventSummaryFragment.java
@@ -7,11 +7,11 @@ import android.view.View;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.accounts.AccountController;
 import com.thebluealliance.androidclient.binders.RecyclerViewBinder;
+import com.thebluealliance.androidclient.datafeed.combiners.TeamAtEventSummaryCombiner;
 import com.thebluealliance.androidclient.fragments.RecyclerViewFragment;
 import com.thebluealliance.androidclient.itemviews.LabelValueItemView;
 import com.thebluealliance.androidclient.itemviews.LabeledMatchItemView;
 import com.thebluealliance.androidclient.models.NoDataViewParams;
-import com.thebluealliance.androidclient.models.TeamAtEventStatus;
 import com.thebluealliance.androidclient.subscribers.TeamAtEventSummarySubscriber;
 import com.thebluealliance.androidclient.viewmodels.LabelValueViewModel;
 import com.thebluealliance.androidclient.viewmodels.LabeledMatchViewModel;
@@ -21,7 +21,7 @@ import javax.inject.Inject;
 import io.nlopez.smartadapters.SmartAdapter;
 import rx.Observable;
 
-public class TeamAtEventSummaryFragment extends RecyclerViewFragment<TeamAtEventStatus, TeamAtEventSummarySubscriber, RecyclerViewBinder> {
+public class TeamAtEventSummaryFragment extends RecyclerViewFragment<TeamAtEventSummarySubscriber.Model, TeamAtEventSummarySubscriber, RecyclerViewBinder> {
 
     public static final String TEAM_KEY = "team", EVENT_KEY = "event";
 
@@ -70,8 +70,11 @@ public class TeamAtEventSummaryFragment extends RecyclerViewFragment<TeamAtEvent
     }
 
     @Override
-    protected Observable<TeamAtEventStatus> getObservable(String cacheHeader) {
-        return mDatafeed.fetchTeamAtEventStatus(mTeamKey, mEventKey, cacheHeader);
+    protected Observable<TeamAtEventSummarySubscriber.Model> getObservable(String cacheHeader) {
+        return Observable.zip(
+                mDatafeed.fetchTeamAtEventStatus(mTeamKey, mEventKey, cacheHeader),
+                mDatafeed.fetchEvent(mEventKey, cacheHeader),
+                new TeamAtEventSummaryCombiner());
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/SubscriberModule.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/SubscriberModule.java
@@ -105,14 +105,12 @@ public class SubscriberModule {
 
     @Provides
     public TeamAtEventSummarySubscriber provideTeamAtEventSummarySubscriber(MatchRenderer renderer,
-                                                                            Database db,
                                                                             AppConfig config,
                                                                             EventBus bus) {
         return new TeamAtEventSummarySubscriber(mActivity.getApplicationContext(),
                                                 config,
                                                 bus,
-                                                renderer,
-                                                db.getEventsTable());
+                                                renderer);
     }
 
     @Provides

--- a/android/src/main/res/values/strings_team_at_event.xml
+++ b/android/src/main/res/values/strings_team_at_event.xml
@@ -24,6 +24,7 @@
     <string name="team_at_event_qual_record">Qual Record</string>
     <string name="team_at_event_alliance">Alliance</string>
     <string name="team_at_event_status">Team Status</string>
+    <string name="team_at_event_future_event">Event not yet started</string>
 
     <!-- possible statuses -->
     <string name="playing_in_quals">Playing in the qualification matches</string>

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/TeamAtEventSummarySubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/TeamAtEventSummarySubscriberTest.java
@@ -4,7 +4,6 @@ import android.content.Context;
 
 import com.thebluealliance.androidclient.DefaultTestRunner;
 import com.thebluealliance.androidclient.config.AppConfig;
-import com.thebluealliance.androidclient.database.tables.EventsTable;
 import com.thebluealliance.androidclient.datafeed.framework.DatafeedTestDriver;
 import com.thebluealliance.androidclient.datafeed.framework.ModelMaker;
 import com.thebluealliance.androidclient.eventbus.EventAwardsEvent;
@@ -32,12 +31,11 @@ public class TeamAtEventSummarySubscriberTest {
     @Mock EventMatchesEvent mMatchesEvent;
     @Mock EventAwardsEvent mAwardsEvent;
     @Mock MatchRenderer mMatchRenderer;
-    @Mock EventsTable mEventsTable;
     @Mock AppConfig mAppConfig;
     @Mock EventBus mEventBus;
 
     TeamAtEventSummarySubscriber mSubscriber;
-    TeamAtEventStatus mData;
+    TeamAtEventStatus mStatus;
 
     @Before
     public void setUp() {
@@ -45,9 +43,10 @@ public class TeamAtEventSummarySubscriberTest {
         mContext = mock(Context.class, RETURNS_DEEP_STUBS);
         when(mContext.getResources().getString(anyInt())).thenReturn("");
         mSubscriber = new TeamAtEventSummarySubscriber(mContext, mAppConfig, mEventBus,
-                                                       mMatchRenderer, mEventsTable);
+                                                       mMatchRenderer);
         mSubscriber.setTeamAndEventKeys("frc1519", "2015necmp");
-        mData = ModelMaker.getModel(TeamAtEventStatus.class, "frc1519_2015necmp_status");
+        mEvent = ModelMaker.getModel(Event.class, "2015necmp");
+        mStatus = ModelMaker.getModel(TeamAtEventStatus.class, "frc1519_2015necmp_status");
     }
 
     @Test
@@ -59,6 +58,11 @@ public class TeamAtEventSummarySubscriberTest {
     public void testSimpleParsing()  {
         mSubscriber.onEventMatchesLoaded(mMatchesEvent);
         mSubscriber.onEventAwardsLoaded(mAwardsEvent);
-        DatafeedTestDriver.testSimpleParsing(mSubscriber, mData);
+        DatafeedTestDriver.testSimpleParsing(mSubscriber,  new TeamAtEventSummarySubscriber.Model(mStatus, mEvent));
+    }
+
+    @Test
+    public void testUnplayedEvent() {
+        DatafeedTestDriver.testSimpleParsing(mSubscriber,  new TeamAtEventSummarySubscriber.Model(null, mEvent));
     }
 }


### PR DESCRIPTION
**Summary:** 
When an event hasn't started yet, show something more useful than a totally blank screen in the team@event summary view

**Issues Reference:** 
fixes https://github.com/the-blue-alliance/the-blue-alliance-android/issues/886

**Test Plan:** 
local

**Screenshots:**
![device-2019-02-18-144141](https://user-images.githubusercontent.com/2754863/52973264-76e99100-338b-11e9-86b1-acf56c8b5bd9.png)

