### PR TITLE
Fix crash on ContributorsActivity load

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ContributorsActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ContributorsActivity.java
@@ -72,6 +72,7 @@ public class ContributorsActivity extends DatafeedActivity {
               .datafeedModule(application.getDatafeedModule())
               .binderModule(application.getBinderModule())
               .databaseWriterModule(application.getDatabaseWriterModule())
+              .authModule(application.getAuthModule())
               .subscriberModule(new SubscriberModule(this))
               .clickListenerModule(new ClickListenerModule(this))
               .build();


### PR DESCRIPTION
**Summary:** 
When I tried to open the contributors page in the settings tab, the app crashed and restarted. I experimented with this further and came to the conclusion that it was throwing an IllegalStateException because the AuthModule was not set. I believe that `ContributorsActivity.getComponent()` was not updated to reflect the changes in PR #884, causing the crash. When I added `.authModule(application.getAuthModule())` to the DaggerFragmentComponent builder in ContributorsActivity.java, it fixed the crash.

**Test Plan:**
Manual test.