### PR TITLE
Add auth module to imgur suggestion service and GCM message handler

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
@@ -97,17 +97,18 @@ public class GCMMessageHandler extends IntentService implements FollowsChecker {
     @Override
     public void onCreate() {
         super.onCreate();
-        getComponenet();
+        getComponent();
         mComponenet.inject(this);
     }
 
-    private void getComponenet() {
+    private void getComponent() {
         if (mComponenet == null) {
             TBAAndroid application = ((TBAAndroid) getApplication());
             mComponenet = DaggerNotificationComponent.builder()
                     .applicationComponent(application.getComponent())
                     .datafeedModule(application.getDatafeedModule())
                     .rendererModule(new RendererModule())
+                    .authModule(application.getAuthModule())
                     .build();
         }
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/imgur/ImgurSuggestionService.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/imgur/ImgurSuggestionService.java
@@ -199,6 +199,7 @@ public class ImgurSuggestionService extends IntentService {
                 .httpModule(application.getHttpModule())
                 .imgurModule(application.getImgurModule())
                 .tBAAndroidModule(application.getModule())
+                .authModule(application.getAuthModule())
                 .build();
     }
 


### PR DESCRIPTION
**Summary:** 
We weren't creating an `AuthModule` (see #884, also related #891) for the Imgur suggestion service and the GCM message handler components, so both were crashing.

This resolves both issues.

**Test Plan:** 
I'm not set up to test GCM notifications at the moment, but sending an FCM message from the Firebase console, or launching either of these services through other means all result in the same crash. After this fix, it does not crash.
