### PR TITLE
Add all notifications to default channel

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/TBAAndroid.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/TBAAndroid.java
@@ -1,5 +1,8 @@
 package com.thebluealliance.androidclient;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.os.Build;
 import android.support.multidex.MultiDexApplication;
 
 import com.facebook.stetho.Stetho;
@@ -24,6 +27,8 @@ import com.thebluealliance.androidclient.gcm.GcmModule;
 import com.thebluealliance.androidclient.imgur.ImgurModule;
 
 import javax.inject.Inject;
+
+import static com.thebluealliance.androidclient.gcm.notifications.BaseNotification.NOTIFICATION_CHANNEL;
 
 public class TBAAndroid extends MultiDexApplication {
 
@@ -84,6 +89,21 @@ public class TBAAndroid extends MultiDexApplication {
 
                             .build());
         }
+
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = getString(R.string.notification_channel_name);
+            String description = getString(R.string.notification_channel_description);
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL, name, importance);
+            channel.setDescription(description);
+            // Register the channel with the system; you can't change the importance
+            // or other notification behaviors after this
+            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+        }
+
     }
 
     void disableStetho() {

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/BaseNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/BaseNotification.java
@@ -29,6 +29,8 @@ import java.util.Date;
 
 public abstract class BaseNotification<VIEWMODEL> extends ListElement implements ViewModelRenderer<VIEWMODEL, Void> {
 
+    public static String NOTIFICATION_CHANNEL = "mytba_notification";
+
     String messageData;
     String messageType;
     Gson gson;
@@ -128,7 +130,8 @@ public abstract class BaseNotification<VIEWMODEL> extends ListElement implements
                 .setGroup(GCMMessageHandler.GROUP_KEY)
                 .setDeleteIntent(onDismiss)
                 .setAutoCancel(true)
-                .extend(wearableExtender);
+                .extend(wearableExtender)
+                .setChannelId(NOTIFICATION_CHANNEL);
     }
 
     /**

--- a/android/src/main/res/values/strings_notification.xml
+++ b/android/src/main/res/values/strings_notification.xml
@@ -3,6 +3,8 @@
 
     <!-- General strings -->
     <string name="notifications">Notifications</string>
+    <string name="notification_channel_name">myTBA</string>
+    <string name="notification_channel_description">Notifications triggered by your myTBA subscriptions</string>
     <string name="and">and</string>
     <!-- Used to show when new notifications appeared offscreen. Example: "5 new" -->
     <string name="new_notifications">"%1$s new"</string>


### PR DESCRIPTION
**Summary:** 
> Starting in Android 8.0 (API level 26), all notifications must be assigned to a channel.

So this means that notifications won't show for users on 8.0. This sets everything to a `mytba` channel

**Test Plan:** 
(my phone with 8.0, notifications triggered from script in the repo)
![device-2019-02-28-212017](https://user-images.githubusercontent.com/2754863/53612143-32d26980-3b9f-11e9-822f-d39110ef760d.png)

