### PR TITLE
Auto-post releases to slack

### DIFF
--- a/scripts/do_release.py
+++ b/scripts/do_release.py
@@ -1,7 +1,10 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
+import configparser
+import json
 import time
+import requests
 import subprocess
 import sys
 import re
@@ -45,65 +48,67 @@ parser.add_argument("--skip-local-tests", action="store_true", default=False,
                     help="Don't run the test suite on the local machine")
 parser.add_argument("--skip-travis", action="store_true", default=False,
                     help="Don't wait for travis build to complete")
+parser.add_argument("--skip-slack-update", action="store_true", default=False,
+                    help="Don't post an update to the TBA slack")
 
 
 def check_clean_repo():
     try:
-        subprocess.check_output(["git", "diff-files", "--quiet", "--ignore-submodules"])
+        subprocess.check_output(["git", "diff-files", "--quiet", "--ignore-submodules"]).decode("utf-8")
     except CalledProcessError:
-        print "You have uncommitted changes in the repository. Commit them and try again"
+        print("You have uncommitted changes in the repository. Commit them and try again")
         sys.exit(1)
 
 
 def check_travis_tests(args):
     tag_name = "v{}".format(args.tag)
-    print "Checking travis build status at tag {}".format(tag_name)
+    print("Checking travis build status at tag {}".format(tag_name))
 
     status = "created"
     duration = ""
     while status == "created" or status == "started":
         try:
-            info = subprocess.check_output(["travis", "show", tag_name])
+            info = subprocess.check_output(["travis", "show", tag_name]).decode("utf-8")
         except CalledProcessError:
             try:
-                input("Error getting travis status. Press Enter to continue...")
+                eval("Error getting travis status. Press Enter to continue...")
             except SyntaxError:
                 pass
         regex = re.search(".*State:[ \t]+((\w)*)\n", info)
         status = regex.group(1)
         regex = re.search(".*Duration:[ \t]+(([\w\d ])*)", info)
         duration = regex.group(1) if regex else None
-        print "Build Status: {}, duration: {}".format(status, duration)
+        print("Build Status: {}, duration: {}".format(status, duration))
         if status == "passed" or status == "failed" or status == "errored":
             break
         time.sleep(30)
 
     if status == "failed" or status == "errored":
-        print "Errors with the travis build"
-        print info
+        print("Errors with the travis build")
+        print(info)
         if not args.dry_run:
             sys.exit(-1)
 
 
 def check_unittest_local(args):
-    print "Running project unit tests..."
+    print("Running project unit tests...")
     time.sleep(2)
     try:
         script_args = ["./gradlew", "testReleaseUnitTest"]
         if args.dry_run:
             script_args.append("-m")
         subprocess.check_call(script_args)
-        print "Unit tests passed!"
+        print("Unit tests passed!")
     except CalledProcessError:
-        print "Unit tests failed. Fix them before releasing"
+        print("Unit tests failed. Fix them before releasing")
         sys.exit(1)
 
 
 def update_whatsnew(args):
-    print "Updating whatsnew file ({}). Limit 500 characters".format(CHANGELOG_PATH)
+    print("Updating whatsnew file ({}). Limit 500 characters".format(CHANGELOG_PATH))
     time.sleep(2)
-    base_tag = subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"]).split()[0] if not args.base_tag else args.base_tag
-    commitlog = subprocess.check_output(["git", "shortlog", "{}..HEAD".format(base_tag), "--oneline", "--no-merges"])
+    base_tag = subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"]).split()[0].decode("utf-8") if not args.base_tag else args.base_tag
+    commitlog = subprocess.check_output(["git", "shortlog", "{}..HEAD".format(base_tag), "--oneline", "--no-merges"]).decode("utf-8")
     commitlog = '# '.join(('\n' + commitlog.lstrip()).splitlines(True))
 
     # Append commented commitlog to whatsnew file for ease of writing
@@ -112,7 +117,7 @@ def update_whatsnew(args):
             whatsnew.write(commitlog)
 
     if args.dry_run:
-        print "Would edit changelog file: {}".format(CHANGELOG_PATH)
+        print("Would edit changelog file: {}".format(CHANGELOG_PATH))
     else:
         subprocess.call(["vim", CHANGELOG_PATH])
 
@@ -121,16 +126,16 @@ def update_whatsnew(args):
         subprocess.call(["sed", "-i", "/^#/d", CHANGELOG_PATH])
 
     # Check character count
-    chars = subprocess.check_output(["wc", "-m", CHANGELOG_PATH])
+    chars = subprocess.check_output(["wc", "-m", CHANGELOG_PATH]).decode("utf-8")
     if int(chars.split()[0]) > 500:
-        print "Changelog too long. Must be limited to 500 characters"
+        print("Changelog too long. Must be limited to 500 characters")
         sys.exit(1)
 
     # Copy to in-app changelog
     if not args.dry_run:
         subprocess.call(["cp", CHANGELOG_PATH, INAPP_CHANGELOG])
     else:
-        print "Would move {} to {}".format(CHANGELOG_PATH, INAPP_CHANGELOG)
+        print("Would move {} to {}".format(CHANGELOG_PATH, INAPP_CHANGELOG))
 
     # Fix line breaks
     if not args.dry_run:
@@ -139,29 +144,29 @@ def update_whatsnew(args):
 
 
 def commit_whatsnew(dry_run):
-    print "Committing new changelog"
+    print("Committing new changelog")
     time.sleep(2)
     if not dry_run:
         subprocess.call(["git", "add", INAPP_CHANGELOG, CHANGELOG_PATH])
 
         try:
-            subprocess.check_output(["git", "commit", "-m", "Version {} Whatsnew".format(args.tag)])
+            subprocess.check_output(["git", "commit", "-m", "Version {} Whatsnew".format(args.tag)]).decode("utf-8")
         except CalledProcessError:
-            print "Unable to commit new changelog"
+            print("Unable to commit new changelog")
             sys.exit(1)
     else:
-        print "Would commit changelog"
+        print("Would commit changelog")
 
     # Write shortlog to file
-    base_tag = subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"]).split()[0]
-    shortlog = subprocess.check_output(["git", "shortlog", "{}..HEAD".format(base_tag), "--no-merges", "--oneline"])
+    base_tag = subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"]).split()[0].decode("utf-8")
+    shortlog = subprocess.check_output(["git", "shortlog", "{}..HEAD".format(base_tag), "--no-merges", "--oneline"]).decode("utf-8")
 
     if not dry_run:
         with open(SHORTLOG_PATH, "w") as logfile:
             logfile.write(shortlog)
     else:
-        print "Would write shortlog to file: {}".format(SHORTLOG_PATH)
-        print "Shortlog contents:\n{}".format(shortlog)
+        print("Would write shortlog to file: {}".format(SHORTLOG_PATH))
+        print("Shortlog contents:\n{}".format(shortlog))
 
 
 def create_tag(args):
@@ -175,10 +180,10 @@ def create_tag(args):
 
 
 def validate_build(dry_run):
-    print "Installing build, ensure a device is plugged in with USB Debugging enabled"
+    print("Installing build, ensure a device is plugged in with USB Debugging enabled")
     subprocess.call(["adb", "devices"])
     try:
-        input("Press Enter to continue...")
+        eval("Press Enter to continue...")
     except SyntaxError:
         pass
     time.sleep(5)
@@ -190,22 +195,22 @@ def validate_build(dry_run):
     if not dry_run:
         subprocess.call(["adb", "shell", "am", "start", "-n", "com.thebluealliance.androidclient/com.thebluealliance.androidclient.activities.LaunchActivity"])
     else:
-        print "Would start launch activity"
+        print("Would start launch activity")
     try:
-        input("Press Enter to continue the release, or ^C to quit")
+        eval("Press Enter to continue the release, or ^C to quit")
     except SyntaxError:
         pass
 
 
 def build_apk(args):
     # Check out repo at specified tag and build
-    old_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
-    print "Leaving {}, checking out tag v{}".format(old_branch, args.tag)
+    old_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).decode("utf-8").strip()
+    print("Leaving {}, checking out tag v{}".format(old_branch, args.tag))
     time.sleep(2)
     if not args.dry_run:
         subprocess.call(["git", "checkout", "v{}".format(args.tag)])
 
-    print "Uploading the app to Google Play..."
+    print("Uploading the app to Google Play...")
     time.sleep(2)
 
     # Don't rebuild the app, because we've built it already
@@ -216,20 +221,20 @@ def build_apk(args):
         script_args.append("-x")
         script_args.append("assembleRelease")
     subprocess.call(script_args)
-    print "Returning to {}".format(old_branch)
+    print("Returning to {}".format(old_branch))
     if not args.dry_run:
         subprocess.call(["git", "checkout", old_branch])
 
 
 def push_repo(dry_run):
-    print "Pushing updates to GitHub"
+    print("Pushing updates to GitHub")
     time.sleep(2)
 
     if not dry_run:
         subprocess.call(["git", "push", "upstream"])
         subprocess.call(["git", "push", "--tags", "upstream"])
     else:
-        print "Would push repo and tags to upstream"
+        print("Would push repo and tags to upstream")
 
 
 def create_release(args):
@@ -241,7 +246,46 @@ def create_release(args):
     if not args.dry_run:
         subprocess.call(script_args)
     else:
-        print "Would call {}".format(subprocess.list2cmdline(script_args))
+        print("Would call {}".format(subprocess.list2cmdline(script_args)))
+
+def post_to_slack(args):
+    with open('local.properties', 'r') as f:
+        config_string = '[main]\n' + f.read()
+    config = configparser.ConfigParser()
+    config.read_string(config_string)
+    slack_url = config['main']['slack_update_url']
+    if not slack_url:
+        print("Can't find slack url to update, bailing")
+        return
+
+    base_tag = subprocess.check_output(["git", "describe", "HEAD~1", "--tags", "--abbrev=0"]).split()[0].decode("utf-8") if not args.base_tag else args.base_tag
+    print(f"Base tag: {base_tag}")
+    commitlog = subprocess.check_output(["git", "shortlog", f"{base_tag}..HEAD", "--oneline", "--no-merges"]).decode("utf-8").strip()
+    message_body = """
+Shipping android v{version} to Google Play.
+```
+{shortlog}
+```
+https://github.com/the-blue-alliance/the-blue-alliance-android/releases/tag/v{version}
+""".format(version=args.tag, shortlog=commitlog)
+    slack_data = {
+        "text": message_body,
+        "username": "release-bot",
+        "icon_emoji": ":tba:",
+    }
+    if not args.dry_run:
+        response = requests.post(
+    	    slack_url, data=json.dumps(slack_data),
+            headers={'Content-Type': 'application/json'}
+        )
+        if response.status_code != 200:
+            raise ValueError(
+                'Request to slack returned an error %s, the response is:\n%s'
+                % (response.status_code, response.text)
+            )
+    else:
+        print("Would have posted {} to slack".format(json.dumps(slack_data)))
+
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -261,3 +305,5 @@ if __name__ == "__main__":
         check_travis_tests(args)
     build_apk(args)
     create_release(args)
+    if not args.skip_slack_updates:
+        post_to_slack(args)


### PR DESCRIPTION
Post to slack with the version, shortlog, and link to release. Saves me from doing it manually :)

Except this also moves the release script to python 3, which probably breaks it somehow, and I'll find out next release...
