### PR TITLE
Keep team numbers on a single line

### DIFF
--- a/android/src/main/res/layout/list_item_team.xml
+++ b/android/src/main/res/layout/list_item_team.xml
@@ -12,7 +12,7 @@
 
     <TextView
         android:id="@+id/team_number"
-        android:layout_width="72dp"
+        android:layout_width="80dp"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:padding="16dp"

--- a/android/src/main/res/layout/list_item_team.xml
+++ b/android/src/main/res/layout/list_item_team.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
@@ -13,10 +15,14 @@
         android:layout_width="72dp"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
-        android:paddingLeft="16dp"
-        android:text="254"
+        android:padding="16dp"
         android:textSize="20sp"
-        android:textStyle="bold" />
+        android:textStyle="bold"
+        android:maxLines="1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="14sp"
+        app:autoSizeMaxTextSize="20sp"
+        tools:text="254" />
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -36,17 +42,17 @@
             android:ellipsize="end"
             android:maxLines="1"
             android:singleLine="true"
-            android:text="Teh Chezy Pofs"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            tools:text="Teh Chezy Pofs" />
 
         <TextView
             android:id="@+id/team_location"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:ellipsize="end"
-            android:text="San Jose, CA"
             android:textColor="@color/secondary_text_color"
-            android:textSize="14sp" />
+            android:textSize="14sp"
+            tools:text="San Jose, CA" />
     </LinearLayout>
 
     <ImageView


### PR DESCRIPTION
**Summary:** 
Two pronged approach to keeping team numbers on a single line:
 * First, support auto sizing the text to fit the available space. We will support shrinking down to a minimum of 14sp, and a max of 20sp (the default size).
 * Second, increase the space available for the team number in the first place to 80dp from 72dp. This should prevent the text from resizing for the majority of devices anyway, so the autosizing becomes a backup. This comes at a cost of 8dp for the team name, but the number is probably more important anyway, and the vast majority of team names should still fit reasonably well.

*Theoretically* you could make a device where the team number will now be truncated, but it would have to be a very wonky device.

As an added bonus, I also moved some hardcoded `android:text` values used for the layout preview to `tools:text`, and added a right padding to team numbers for better symmetry when the team number is 4 digits.

**Issues Reference:** 
Resolves #901 

**Test Plan:** 
Tested with 2, 3, 4, and 5 digit team numbers on a few different devices to see what we would get.

**Screenshots:**

Here's what it looks like when everything fits fine:
<img src="https://user-images.githubusercontent.com/3267925/54456641-3af8e000-472d-11e9-94df-9e3afd3fa37a.png" width=250 />


Here's what we get if 4 digit team numbers need to scale down a hair to fit:
<img src="https://user-images.githubusercontent.com/3267925/54456650-4946fc00-472d-11e9-9f79-5f8a00d50283.png" width=250 />
