### PR TITLE
Use a FileProvider for media suggestions

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -260,6 +260,17 @@
         <service
                 android:name=".mytba.MyTbaRegistrationService"
                 android:exported="false" />
+
+        <!-- FileProvider for capturing team media -->
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/android/src/main/res/xml/file_paths.xml
+++ b/android/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="tba_media" path="The Blue Alliance/"/>
+</paths>
+


### PR DESCRIPTION
**Summary:** 
Resolves issue #894 by adding a FileProvider to make our picture capture compatible with Android 24+.

This also moves us from using the public Pictures directory with a "The Blue Alliance" subdirectory to just a "The Blue Alliance" directory within the external storage directory.

**Issues Reference:** 
#894 

**Test Plan:** 
Tested up to the final confirmation step on a couple devices, including those running 5.0, 9.0, and 8.0.

**Screenshots:**
N/A