### PR TITLE
Speed up FAB circular reveal to 350ms

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/MyTBASettingsActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/MyTBASettingsActivity.java
@@ -76,7 +76,7 @@ public abstract class MyTBASettingsActivity extends DatafeedActivity implements 
     private AnimatorSet mRunningPanelAnimation;
 
     // In milliseconds
-    private static final int ANIMATION_DURATION = 500;
+    private static final int ANIMATION_DURATION = 350;
     private static final int FAB_ANIMATION_DURATION = 250;
     private static final int FAB_COLOR_ANIMATION_DURATION = 250;
 


### PR DESCRIPTION
**Summary:** 
#864 is right- our FAB animation was a bit too slow. This speeds it up a bit, making it a much more enjoyable experience.

**Issues Reference:** 
#864 

**Test Plan:** 
N/A

**Screenshots:**
![fab](https://user-images.githubusercontent.com/3267925/54631663-760b5400-4a4a-11e9-9113-60b5f993dcf9.gif)
