### PR TITLE
Match awards sorting to web's sorting

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/comparators/AwardSortComparator.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/comparators/AwardSortComparator.java
@@ -1,0 +1,41 @@
+package com.thebluealliance.androidclient.comparators;
+
+import com.thebluealliance.androidclient.models.Award;
+
+import java.util.Comparator;
+
+public class AwardSortComparator implements Comparator<Award> {
+
+    private static final int ORDER_UNDEFINED = Integer.MAX_VALUE;
+
+    @Override
+    public int compare(Award award1, Award award2) {
+        int priority1 = getAwardOrder(award1);
+        int priority2 = getAwardOrder(award2);
+
+        if (priority1 == ORDER_UNDEFINED && priority2 == ORDER_UNDEFINED) {
+            return award1.getName().compareTo(award2.getName());
+        } else {
+            return priority1 - priority2;
+        }
+    }
+
+    /**
+     * Get the priority order for a given award.
+     * If there is not particular priority for the award, returns {@link #ORDER_UNDEFINED}.
+     */
+    private int getAwardOrder(Award award) {
+        switch (award.getAwardType()) {
+            case 0: return 0; // Chairman's
+            case 6: return 1; // Founder's
+            case 9: return 2; // Engineering Inspiration
+            case 10: return 3; // Rookie All Star
+            case 3: return 4; // Woodie Flowers
+            case 5: return 5; // Volunteer of the Year
+            case 4: return 6; // Dean's List
+            case 1: return 7; // Winner
+            case 2: return 8; // Finalist
+            default: return ORDER_UNDEFINED;
+        }
+    }
+}

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/AwardsListSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/AwardsListSubscriber.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.androidclient.subscribers;
 
 import com.thebluealliance.androidclient.Utilities;
+import com.thebluealliance.androidclient.comparators.AwardSortComparator;
 import com.thebluealliance.androidclient.database.Database;
 import com.thebluealliance.androidclient.eventbus.EventAwardsEvent;
 import com.thebluealliance.androidclient.listitems.ListItem;
@@ -13,10 +14,13 @@ import com.thebluealliance.api.model.IAwardRecipient;
 import org.greenrobot.eventbus.EventBus;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 public class AwardsListSubscriber extends BaseAPISubscriber<List<Award>, List<ListItem>> {
+
+    private static final AwardSortComparator AWARD_COMPARATOR = new AwardSortComparator();
 
     private String mTeamKey;
     private Database mDb;
@@ -37,8 +41,10 @@ public class AwardsListSubscriber extends BaseAPISubscriber<List<Award>, List<Li
     public void parseData()  {
         mDataToBind.clear();
         Map<String, Team> teams = Utilities.getMapForPlatform(String.class, Team.class);
-        for (int i = 0; i < mAPIData.size(); i++) {
-            Award award = mAPIData.get(i);
+        ArrayList<Award> sortedAwards = new ArrayList<>(mAPIData);
+        Collections.sort(sortedAwards, AWARD_COMPARATOR);
+        for (int i = 0; i < sortedAwards.size(); i++) {
+            Award award = sortedAwards.get(i);
             if (award.getRecipientList() == null) continue;
             for (IAwardRecipient winner : award.getRecipientList()) {
                 if (winner != null && winner.getTeamKey() != null){

--- a/android/src/test/java/com/thebluealliance/androidclient/comparators/AwardSortComparatorTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/comparators/AwardSortComparatorTest.java
@@ -1,0 +1,70 @@
+package com.thebluealliance.androidclient.comparators;
+
+import com.thebluealliance.androidclient.DefaultTestRunner;
+import com.thebluealliance.androidclient.models.Award;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(DefaultTestRunner.class)
+public class AwardSortComparatorTest {
+
+    @Test
+    public void testPrioritizedAwards() {
+        // Make sure all the prioritized awards are in the correct order.
+        // We will add them in reverse order, and verify we get the correct order out.
+        List<Award> awards = new ArrayList<>();
+        awards.add(mockAward(2, ""));
+        awards.add(mockAward(1, ""));
+        awards.add(mockAward(4, ""));
+        awards.add(mockAward(5, ""));
+        awards.add(mockAward(3, ""));
+        awards.add(mockAward(10, ""));
+        awards.add(mockAward(9, ""));
+        awards.add(mockAward(6, ""));
+        awards.add(mockAward(0, ""));
+
+        Collections.sort(awards, new AwardSortComparator());
+
+        assertEquals(0, (int) awards.get(0).getAwardType());
+        assertEquals(6, (int) awards.get(1).getAwardType());
+        assertEquals(9, (int) awards.get(2).getAwardType());
+        assertEquals(10, (int) awards.get(3).getAwardType());
+        assertEquals(3, (int) awards.get(4).getAwardType());
+        assertEquals(5, (int) awards.get(5).getAwardType());
+        assertEquals(4, (int) awards.get(6).getAwardType());
+        assertEquals(1, (int) awards.get(7).getAwardType());
+        assertEquals(2, (int) awards.get(8).getAwardType());
+    }
+
+    @Test
+    public void testUnprioritizedAwards() {
+        // Make sure all the prioritized awards come before unprioritized awards, and all
+        // awards without a priority are sorted alphabetically
+        List<Award> awards = new ArrayList<>();
+        awards.add(mockAward(99, "Zebra"));
+        awards.add(mockAward(2, "Middle"));
+        awards.add(mockAward(99, "Apple"));
+
+        Collections.sort(awards, new AwardSortComparator());
+
+        assertEquals("Middle", awards.get(0).getName());
+        assertEquals("Apple", awards.get(0).getName());
+        assertEquals("Zebra", awards.get(0).getName());
+    }
+
+    private Award mockAward(int awardType, String name) {
+        Award award = Mockito.mock(Award.class);
+        award.setAwardType(awardType);
+        return award;
+    }
+
+}

--- a/android/src/test/java/com/thebluealliance/androidclient/comparators/AwardSortComparatorTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/comparators/AwardSortComparatorTest.java
@@ -57,13 +57,14 @@ public class AwardSortComparatorTest {
         Collections.sort(awards, new AwardSortComparator());
 
         assertEquals("Middle", awards.get(0).getName());
-        assertEquals("Apple", awards.get(0).getName());
-        assertEquals("Zebra", awards.get(0).getName());
+        assertEquals("Apple", awards.get(1).getName());
+        assertEquals("Zebra", awards.get(2).getName());
     }
 
     private Award mockAward(int awardType, String name) {
         Award award = Mockito.mock(Award.class);
-        award.setAwardType(awardType);
+        Mockito.when(award.getAwardType()).thenReturn(awardType);
+        Mockito.when(award.getName()).thenReturn(name);
         return award;
     }
 

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/AwardsListSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/AwardsListSubscriberTest.java
@@ -16,7 +16,6 @@ import org.greenrobot.eventbus.EventBus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -24,6 +23,7 @@ import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -69,13 +69,7 @@ public class AwardsListSubscriberTest {
         assertTrue(mSubscriber.shouldPostToEventBus());
         EventBus eventBus = mock(EventBus.class);
         mSubscriber.postToEventBus(eventBus);
-
-        ArgumentCaptor<EventAwardsEvent> awardsArg = ArgumentCaptor.forClass(EventAwardsEvent.class);
-        verify(eventBus).post(awardsArg.capture());
-        List<Award> awards = awardsArg.getValue().getAwards();
-
-        assertEquals(0, (int) awards.get(0).getAwardType()); // First award should be chairman's
-        assertEquals(9, (int) awards.get(0).getAwardType()); // Second award should be EI
+        verify(eventBus).post(any(EventAwardsEvent.class));
     }
 
     @Test
@@ -89,28 +83,28 @@ public class AwardsListSubscriberTest {
 
     @Test
     public void testParseMultiTeamWinner()  {
-        assertItemsEqual(0);
+        assertItemsEqual(0, 0);
     }
 
     @Test
     public void testParseSinglePersonWinner()  {
-        assertItemsEqual(1);
+        assertItemsEqual(16, 3);
     }
 
     @Test
     public void testParseMultiPersonWinner()  {
-        assertItemsEqual(2);
+        assertItemsEqual(18, 5);
     }
 
     @Test
     public void testParseSingleTeamWinner()  {
-        assertItemsEqual(3);
+        assertItemsEqual(2, 2);
     }
 
-    private void assertItemsEqual(int index)  {
+    private void assertItemsEqual(int rawIndex, int sortedIndex)  {
         List<ListItem> data = DatafeedTestDriver.getParsedData(mSubscriber, mAwards);
-        CardedAwardListElement element = (CardedAwardListElement) data.get(index);
-        Award award = mAwards.get(index);
+        CardedAwardListElement element = (CardedAwardListElement) data.get(sortedIndex);
+        Award award = mAwards.get(rawIndex);
 
         assertEquals(element.mAwardName, award.getName());
         assertEquals(element.mEventKey, award.getEventKey());

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/AwardsListSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/AwardsListSubscriberTest.java
@@ -16,6 +16,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -23,7 +24,6 @@ import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -69,7 +69,13 @@ public class AwardsListSubscriberTest {
         assertTrue(mSubscriber.shouldPostToEventBus());
         EventBus eventBus = mock(EventBus.class);
         mSubscriber.postToEventBus(eventBus);
-        verify(eventBus).post(any(EventAwardsEvent.class));
+
+        ArgumentCaptor<EventAwardsEvent> awardsArg = ArgumentCaptor.forClass(EventAwardsEvent.class);
+        verify(eventBus).post(awardsArg.capture());
+        List<Award> awards = awardsArg.getValue().getAwards();
+
+        assertEquals(0, (int) awards.get(0).getAwardType()); // First award should be chairman's
+        assertEquals(9, (int) awards.get(0).getAwardType()); // Second award should be EI
     }
 
     @Test


### PR DESCRIPTION
**Summary:** 
Matches our awards sorting to web's.

**Issues Reference:** 
#834 

**Test Plan:** 
Added unit tests for sort order.

**Screenshots:**
![awards_sorted](https://user-images.githubusercontent.com/3267925/54640938-ec19b600-4a5e-11e9-8b3d-8ab8b9a069ac.png)
