### PR TITLE
[notification] Don't use message_type key in payloads

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
@@ -143,7 +143,7 @@ public class GCMMessageHandler extends IntentService implements FollowsChecker {
         TbaLogger.d("Intent extras: " + extras.toString());
 
         // We got a standard message. Parse it and handle it.
-        String type = extras.getString("message_type", "");
+        String type = extras.getString("notification_type", "");
         String data = extras.getString("message_data", "");
         handleMessage(getApplicationContext(), type, data);
 

--- a/scripts/test_notification.py
+++ b/scripts/test_notification.py
@@ -42,7 +42,7 @@ def notify(message_type, json_data):
 
     template = """am broadcast -a com.google.android.c2dm.intent.RECEIVE \
         -c com.thebluealliance.androidclient \
-        --es message_type %s \
+        --es notification_type %s \
         --es message_data '%s'"""
     command = template % (message_type, json_text)
 


### PR DESCRIPTION
Long story.

Mainly, this is a reserved key in FCM that wasn't in GCM, so we see random failures.