### PR TITLE
Update Butterknife to 10.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -267,8 +267,8 @@ dependencies {
     implementation "io.reactivex:rxjava:${rxJavaVersion}"
     implementation 'io.reactivex:rxjava-math:1.0.0'
     implementation 'me.relex:circleindicator:1.2.1@aar'
-    implementation 'com.jakewharton:butterknife:7.0.1'
-    annotationProcessor 'com.jakewharton:butterknife:7.0.1'
+    implementation 'com.jakewharton:butterknife:10.1.0'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:10.1.0'
     implementation 'io.nlopez.smartadapters:library:1.3.1'
     implementation 'com.wada811:android-material-design-colors:3.0.0'
     implementation 'javax.annotation:javax.annotation-api:1.2'

--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -35,19 +35,6 @@ public static *** v(...);
     public void onEvent*(**);
 }
 
-# ButterKnife
--keep class butterknife.** { *; }
--dontwarn butterknife.internal.**
--keep class **$$ViewBinder { *; }
-
--keepclasseswithmembernames class * {
-    @butterknife.* <fields>;
-}
-
--keepclasseswithmembernames class * {
-    @butterknife.* <methods>;
-}
-
 -dontnote com.google.**
 -dontwarn afu.org.checkerframework.**
 -dontwarn org.checkerframework.**

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ConfirmImageSuggestionActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ConfirmImageSuggestionActivity.java
@@ -29,7 +29,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
@@ -43,12 +43,12 @@ public class ConfirmImageSuggestionActivity extends AppCompatActivity implements
 
     private static final String SAVED_TEMP_FILE_PATH = "saved_file_url";
 
-    @Bind(R.id.toolbar) Toolbar mToolbar;
-    @Bind(R.id.header) TextView mHeader;
-    @Bind(R.id.image) ImageView mImageView;
-    @Bind(R.id.progress) ProgressBar mProgressBar;
-    @Bind(R.id.confirm_fab) FloatingActionButton mConfirmFab;
-    @Bind(R.id.cancel_fab) FloatingActionButton mCancelFab;
+    @BindView(R.id.toolbar) Toolbar mToolbar;
+    @BindView(R.id.header) TextView mHeader;
+    @BindView(R.id.image) ImageView mImageView;
+    @BindView(R.id.progress) ProgressBar mProgressBar;
+    @BindView(R.id.confirm_fab) FloatingActionButton mConfirmFab;
+    @BindView(R.id.cancel_fab) FloatingActionButton mCancelFab;
 
     private Uri mUri;
     private String mTeamKey;

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/MyTBAOnboardingActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/MyTBAOnboardingActivity.java
@@ -20,7 +20,7 @@ import com.thebluealliance.androidclient.views.MyTBAOnboardingViewPager;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 
@@ -31,10 +31,10 @@ public class MyTBAOnboardingActivity extends AppCompatActivity
     private static final String MYTBA_LOGIN_COMPLETE = "mytba_login_complete";
     private static final int SIGNIN_CODE = 254;
 
-    @Bind(R.id.mytba_view_pager)
+    @BindView(R.id.mytba_view_pager)
     MyTBAOnboardingViewPager mMyTBAOnboardingViewPager;
 
-    @Bind(R.id.continue_button_label)
+    @BindView(R.id.continue_button_label)
     TextView mContinueButtonText;
 
     private boolean isMyTBALoginComplete = false;

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/OnboardingActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/OnboardingActivity.java
@@ -17,6 +17,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import butterknife.Unbinder;
 import com.thebluealliance.androidclient.BuildConfig;
 import com.thebluealliance.androidclient.Constants;
 import com.thebluealliance.androidclient.R;
@@ -38,7 +39,7 @@ import com.thebluealliance.androidclient.views.MyTBAOnboardingViewPager;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 
@@ -54,20 +55,22 @@ public class OnboardingActivity extends AppCompatActivity
 
     private DatafeedComponent mComponent;
 
-    @Bind(R.id.view_pager)
+    @BindView(R.id.view_pager)
     DisableSwipeViewPager viewPager;
 
-    @Bind(R.id.mytba_view_pager)
+    @BindView(R.id.mytba_view_pager)
     MyTBAOnboardingViewPager mMyTBAOnboardingViewPager;
 
-    @Bind(R.id.loading_message)
+    @BindView(R.id.loading_message)
     TextView loadingMessage;
 
-    @Bind(R.id.loading_progress_bar)
+    @BindView(R.id.loading_progress_bar)
     ProgressBar loadingProgressBar;
 
-    @Bind(R.id.continue_to_end)
+    @BindView(R.id.continue_to_end)
     View continueToEndButton;
+
+    private Unbinder unbinder;
 
     private String currentLoadingMessage = "";
 
@@ -89,7 +92,7 @@ public class OnboardingActivity extends AppCompatActivity
                 .build()
                 .inject(this);
         setContentView(R.layout.activity_onboarding);
-        ButterKnife.bind(this);
+        unbinder = ButterKnife.bind(this);
 
         viewPager.setSwipeEnabled(false);
         viewPager.setOffscreenPageLimit(10);
@@ -151,7 +154,9 @@ public class OnboardingActivity extends AppCompatActivity
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        ButterKnife.unbind(this);
+        if (unbinder != null) {
+            unbinder.unbind();
+        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/ViewTeamActivity.java
@@ -60,7 +60,7 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import permissions.dispatcher.NeedsPermission;
 import permissions.dispatcher.OnShowRationale;
@@ -88,11 +88,11 @@ public class ViewTeamActivity extends MyTBASettingsActivity implements
     private static final int CHOOSE_IMAGE_REQUEST = 42;
     private static final int TAKE_PICTURE_REQUEST = 43;
 
-    @Bind(R.id.year_selector_container) View mYearSelectorContainer;
-    @Bind(R.id.year_selector_subtitle_container) View mYearSelectorSubtitleContainer;
-    @Bind(R.id.year_selector_title) TextView mYearSelectorTitle;
-    @Bind(R.id.year_selector_subtitle) TextView mYearSelectorSubtitle;
-    @Bind(R.id.view_pager) ViewPager mPager;
+    @BindView(R.id.year_selector_container) View mYearSelectorContainer;
+    @BindView(R.id.year_selector_subtitle_container) View mYearSelectorSubtitleContainer;
+    @BindView(R.id.year_selector_title) TextView mYearSelectorTitle;
+    @BindView(R.id.year_selector_subtitle) TextView mYearSelectorSubtitle;
+    @BindView(R.id.view_pager) ViewPager mPager;
 
     private Snackbar mMediaSnackbar;
 

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/EventInfoBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/EventInfoBinder.java
@@ -14,6 +14,7 @@ import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import butterknife.Unbinder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.thebluealliance.androidclient.R;
@@ -36,7 +37,7 @@ import org.greenrobot.eventbus.Subscribe;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import rx.android.schedulers.AndroidSchedulers;
 
@@ -52,30 +53,32 @@ public class EventInfoBinder extends AbstractDataBinder<EventInfoBinder.Model> {
     @Inject SocialClickListener mSocialClickListener;
     @Inject EventInfoContainerClickListener mInfoClickListener;
 
-    @Bind(R.id.content) View content;
-    @Bind(R.id.event_name) TextView eventName;
-    @Bind(R.id.event_date) TextView eventDate;
-    @Bind(R.id.event_venue) TextView eventVenue;
-    @Bind(R.id.top_teams) TextView topTeams;
-    @Bind(R.id.top_oprs) TextView topOprs;
-    @Bind(R.id.top_teams_container) View topTeamsContainer;
-    @Bind(R.id.top_oprs_container) View topOprsContainer;
-    @Bind(R.id.progress) ProgressBar progressBar;
-    @Bind(R.id.event_date_container) View eventDateContainer;
-    @Bind(R.id.event_venue_container) View eventVenueContainer;
-    @Bind(R.id.event_website_container) View eventWebsiteContainer;
-    @Bind(R.id.event_website_title) TextView eventWebsiteTitle;
-    @Bind(R.id.event_twitter_container) View eventTwitterContainer;
-    @Bind(R.id.event_twitter_title) TextView eventTwitterTitle;
-    @Bind(R.id.event_youtube_container) View eventYoutubeContainer;
-    @Bind(R.id.event_youtube_title) TextView eventYoutubeTitle;
-    @Bind(R.id.event_cd_container) View eventCdContainer;
-    @Bind(R.id.last_match_view) FrameLayout lastMatchView;
-    @Bind(R.id.next_match_container) CardView nextMatchContainer;
-    @Bind(R.id.next_match_view) FrameLayout nextMatchView;
-    @Bind(R.id.last_match_container) CardView lastMatchContainer;
-    @Bind(R.id.event_webcast_container) FrameLayout webcastContainer;
-    @Bind((R.id.event_webcast_button)) Button webcastButton;
+    @BindView(R.id.content) View content;
+    @BindView(R.id.event_name) TextView eventName;
+    @BindView(R.id.event_date) TextView eventDate;
+    @BindView(R.id.event_venue) TextView eventVenue;
+    @BindView(R.id.top_teams) TextView topTeams;
+    @BindView(R.id.top_oprs) TextView topOprs;
+    @BindView(R.id.top_teams_container) View topTeamsContainer;
+    @BindView(R.id.top_oprs_container) View topOprsContainer;
+    @BindView(R.id.progress) ProgressBar progressBar;
+    @BindView(R.id.event_date_container) View eventDateContainer;
+    @BindView(R.id.event_venue_container) View eventVenueContainer;
+    @BindView(R.id.event_website_container) View eventWebsiteContainer;
+    @BindView(R.id.event_website_title) TextView eventWebsiteTitle;
+    @BindView(R.id.event_twitter_container) View eventTwitterContainer;
+    @BindView(R.id.event_twitter_title) TextView eventTwitterTitle;
+    @BindView(R.id.event_youtube_container) View eventYoutubeContainer;
+    @BindView(R.id.event_youtube_title) TextView eventYoutubeTitle;
+    @BindView(R.id.event_cd_container) View eventCdContainer;
+    @BindView(R.id.last_match_view) FrameLayout lastMatchView;
+    @BindView(R.id.next_match_container) CardView nextMatchContainer;
+    @BindView(R.id.next_match_view) FrameLayout nextMatchView;
+    @BindView(R.id.last_match_container) CardView lastMatchContainer;
+    @BindView(R.id.event_webcast_container) FrameLayout webcastContainer;
+    @BindView((R.id.event_webcast_button)) Button webcastButton;
+
+    private Unbinder unbinder;
 
     @Inject
     public EventInfoBinder(MatchRenderer renderer,
@@ -95,7 +98,7 @@ public class EventInfoBinder extends AbstractDataBinder<EventInfoBinder.Model> {
     @Override
     public void bindViews() {
         if (!mAreViewsBound) {
-            ButterKnife.bind(this, mRootView);
+            unbinder = ButterKnife.bind(this, mRootView);
             mAreViewsBound = true;
         }
     }
@@ -226,8 +229,8 @@ public class EventInfoBinder extends AbstractDataBinder<EventInfoBinder.Model> {
     @Override
     public void unbind(boolean unbindViews) {
         super.unbind(unbindViews);
-        if (unbindViews) {
-            ButterKnife.unbind(this);
+        if (unbindViews && unbinder != null) {
+            unbinder.unbind();
             mAreViewsBound = false;
         }
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/EventTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/EventTabBinder.java
@@ -2,6 +2,7 @@ package com.thebluealliance.androidclient.binders;
 
 import androidx.annotation.Nullable;
 
+import butterknife.Unbinder;
 import com.thebluealliance.androidclient.TbaLogger;
 import com.thebluealliance.androidclient.fragments.EventsByWeekFragment;
 import com.thebluealliance.androidclient.models.EventWeekTab;
@@ -14,6 +15,7 @@ public class EventTabBinder extends AbstractDataBinder<List<EventWeekTab>> {
 
     private EventsByWeekFragment mFragment;
     private List<EventWeekTab> mTabs;
+    private Unbinder unbinder;
 
     public void setFragment(EventsByWeekFragment fragment) {
         mFragment = fragment;
@@ -34,14 +36,14 @@ public class EventTabBinder extends AbstractDataBinder<List<EventWeekTab>> {
 
     @Override
     public void bindViews() {
-        ButterKnife.bind(this, mRootView);
+        unbinder = ButterKnife.bind(this, mRootView);
     }
 
     @Override
     public void unbind(boolean unbindViews) {
         super.unbind(unbindViews);
-        if (unbindViews) {
-            ButterKnife.unbind(this);
+        if (unbindViews && unbinder != null) {
+            unbinder.unbind();
         }
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/ExpandableListViewBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/ExpandableListViewBinder.java
@@ -4,6 +4,7 @@ import androidx.annotation.Nullable;
 import android.view.View;
 import android.widget.ProgressBar;
 
+import butterknife.Unbinder;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.TbaLogger;
 import com.thebluealliance.androidclient.adapters.ExpandableListViewAdapter;
@@ -16,7 +17,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class ExpandableListViewBinder extends AbstractDataBinder<List<ListGroup>> {
@@ -27,9 +28,10 @@ public class ExpandableListViewBinder extends AbstractDataBinder<List<ListGroup>
             MODE_EXPAND_ONLY = 2,
             MODE_EXPAND_ALL = 3;
 
-    @Bind(R.id.expandable_list) ExpandableListView expandableListView;
-    @Bind(R.id.progress) ProgressBar progressBar;
+    @BindView(R.id.expandable_list) ExpandableListView expandableListView;
+    @BindView(R.id.progress) ProgressBar progressBar;
 
+    private Unbinder unbinder;
     private short mExpandMode;
     protected ModelRendererSupplier mRendererSupplier;
 
@@ -46,7 +48,7 @@ public class ExpandableListViewBinder extends AbstractDataBinder<List<ListGroup>
 
     @Override
     public void bindViews() {
-        ButterKnife.bind(this, mRootView);
+        unbinder = ButterKnife.bind(this, mRootView);
     }
 
     @Override
@@ -157,8 +159,8 @@ public class ExpandableListViewBinder extends AbstractDataBinder<List<ListGroup>
     @Override
     public void unbind(boolean unbindViews) {
         super.unbind(unbindViews);
-        if (unbindViews) {
-            ButterKnife.unbind(this);
+        if (unbindViews && unbinder != null) {
+            unbinder.unbind();
         }
         if (expandableListView != null) {
             expandableListView.setVisibility(View.GONE);

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/ListViewBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/ListViewBinder.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 
+import butterknife.Unbinder;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.TbaLogger;
 import com.thebluealliance.androidclient.adapters.ListViewAdapter;
@@ -14,19 +15,21 @@ import com.thebluealliance.androidclient.listitems.ListItem;
 import java.util.ArrayList;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class ListViewBinder extends AbstractDataBinder<List<ListItem>> {
 
-    @Bind(R.id.list) ListView listView;
-    @Bind(R.id.progress) ProgressBar progressBar;
+    @BindView(R.id.list) ListView listView;
+    @BindView(R.id.progress) ProgressBar progressBar;
 
     ListViewAdapter mAdapter;
 
+    private Unbinder unbinder;
+
     @Override
     public void bindViews() {
-        ButterKnife.bind(this, mRootView);
+        unbinder = ButterKnife.bind(this, mRootView);
     }
 
     @Override
@@ -109,8 +112,8 @@ public class ListViewBinder extends AbstractDataBinder<List<ListItem>> {
     @Override
     public void unbind(boolean unbindViews) {
         super.unbind(unbindViews);
-        if (unbindViews) {
-            ButterKnife.unbind(this);
+        if (unbindViews && unbinder != null) {
+            unbinder.unbind();
         }
         if (listView != null) {
             listView.setVisibility(View.GONE);

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/MatchBreakdownBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/MatchBreakdownBinder.java
@@ -17,13 +17,13 @@ import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2018
 import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2019;
 import com.thebluealliance.api.model.IMatchAlliancesContainer;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class MatchBreakdownBinder extends AbstractDataBinder<MatchBreakdownBinder.Model> {
 
-    @Bind(R.id.match_breakdown) FrameLayout breakdownContainer;
-    @Bind(R.id.progress) ProgressBar progressBar;
+    @BindView(R.id.match_breakdown) FrameLayout breakdownContainer;
+    @BindView(R.id.progress) ProgressBar progressBar;
 
     @Override
     public void updateData(@Nullable MatchBreakdownBinder.Model data) {

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/RecyclerViewBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/RecyclerViewBinder.java
@@ -5,26 +5,29 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.ProgressBar;
 
+import butterknife.Unbinder;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.TbaLogger;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.SmartAdapter;
 import io.nlopez.smartadapters.adapters.RecyclerMultiAdapter;
 
 public class RecyclerViewBinder extends AbstractDataBinder<List<Object>> {
 
-    @Bind(R.id.list) RecyclerView mRecyclerView;
-    @Bind(R.id.progress) ProgressBar mProgressBar;
+    @BindView(R.id.list) RecyclerView mRecyclerView;
+    @BindView(R.id.progress) ProgressBar mProgressBar;
 
     protected RecyclerViewAdapterCreatorInitializer mMapper;
     protected RecyclerMultiAdapter mAdapter;
 
     protected List<Object> mList;
+
+    private Unbinder unbinder;
 
     public void setRecyclerViewBinderMapper(RecyclerViewAdapterCreatorInitializer mapper) {
         mMapper = mapper;
@@ -32,7 +35,7 @@ public class RecyclerViewBinder extends AbstractDataBinder<List<Object>> {
 
     @Override
     public void bindViews() {
-        ButterKnife.bind(this, mRootView);
+        unbinder = ButterKnife.bind(this, mRootView);
     }
 
     @Override
@@ -102,8 +105,8 @@ public class RecyclerViewBinder extends AbstractDataBinder<List<Object>> {
     @Override
     public void unbind(boolean unbindViews) {
         super.unbind(unbindViews);
-        if (unbindViews) {
-            ButterKnife.unbind(this);
+        if (unbindViews && unbinder != null) {
+            unbinder.unbind();
         }
         if (mRecyclerView != null) {
             mRecyclerView.setVisibility(View.GONE);

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/StatsListBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/StatsListBinder.java
@@ -15,13 +15,13 @@ import com.thebluealliance.androidclient.listitems.ListItem;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 
 public class StatsListBinder extends ListViewBinder implements RadioGroup.OnCheckedChangeListener {
 
-    @Bind(R.id.stats_type_selector) RadioGroup mSelectorGroup;
-    @Bind(R.id.show_event_stats) RadioButton mShowEventStats;
-    @Bind(R.id.show_team_stats) RadioButton mShowTeamStats;
+    @BindView(R.id.stats_type_selector) RadioGroup mSelectorGroup;
+    @BindView(R.id.show_event_stats) RadioButton mShowEventStats;
+    @BindView(R.id.show_team_stats) RadioButton mShowTeamStats;
 
     private ListPair<ListItem> mData;
     private Menu mMenu;

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamInfoBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamInfoBinder.java
@@ -12,6 +12,7 @@ import android.text.style.TextAppearanceSpan;
 import android.view.View;
 import android.widget.TextView;
 
+import butterknife.Unbinder;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.TbaLogger;
 import com.thebluealliance.androidclient.helpers.PitLocationHelper;
@@ -22,7 +23,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class TeamInfoBinder extends AbstractDataBinder<TeamInfoBinder.Model> {
@@ -31,36 +32,38 @@ public class TeamInfoBinder extends AbstractDataBinder<TeamInfoBinder.Model> {
 
     @Inject SocialClickListener mSocialClickListener;
 
-    @Bind(R.id.content) View content;
-    @Bind(R.id.team_name) TextView teamName;
-    @Bind(R.id.team_location_container) View teamLocationContainer;
-    @Bind(R.id.team_location) TextView teamLocation;
+    @BindView(R.id.content) View content;
+    @BindView(R.id.team_name) TextView teamName;
+    @BindView(R.id.team_location_container) View teamLocationContainer;
+    @BindView(R.id.team_location) TextView teamLocation;
 
-    @Bind(R.id.team_website_container) View teamWebsiteContainer;
-    @Bind(R.id.team_website_title) TextView teamWebsiteTitle;
-    @Bind(R.id.team_twitter_container) View teamTwitterContainer;
-    @Bind(R.id.team_twitter_title) TextView teamTwitterTitle;
-    @Bind(R.id.twitter_divider) View twitterDivider;
-    @Bind(R.id.team_youtube_container) View teamYoutubeContainer;
-    @Bind(R.id.team_youtube_title) TextView teamYoutubeTitle;
-    @Bind(R.id.youtube_divider) View youtubeDivider;
-    @Bind(R.id.team_facebook_container) View teamFbContainer;
-    @Bind(R.id.team_facebook_title) TextView teamFbTitle;
-    @Bind(R.id.facebook_divider) View facebookDivider;
-    @Bind(R.id.team_github_container) View teamGitHubContainer;
-    @Bind(R.id.team_github_title) TextView teamGitHubTitle;
-    @Bind(R.id.team_instagram_container) View teamInstaContainer;
-    @Bind(R.id.team_instagram_title) TextView teamInstaTitle;
-    @Bind(R.id.instagram_divider) View instagramDivider;
-    @Bind(R.id.team_full_name_container) View teamFullNameContainer;
-    @Bind(R.id.team_full_name) TextView teamFullName;
-    @Bind(R.id.team_next_match_label) View teamNextMatchLabel;
-    @Bind(R.id.team_next_match_details) View teamNextMatchDetails;
-    @Bind(R.id.progress) View progress;
-    @Bind(R.id.team_motto_container) View teamMottoContainer;
-    @Bind(R.id.team_motto) TextView teamMotto;
-    @Bind(R.id.champs_pit_location_container) View champsPitLocationContainer;
-    @Bind(R.id.champs_pit_location) TextView champsPitLocation;
+    @BindView(R.id.team_website_container) View teamWebsiteContainer;
+    @BindView(R.id.team_website_title) TextView teamWebsiteTitle;
+    @BindView(R.id.team_twitter_container) View teamTwitterContainer;
+    @BindView(R.id.team_twitter_title) TextView teamTwitterTitle;
+    @BindView(R.id.twitter_divider) View twitterDivider;
+    @BindView(R.id.team_youtube_container) View teamYoutubeContainer;
+    @BindView(R.id.team_youtube_title) TextView teamYoutubeTitle;
+    @BindView(R.id.youtube_divider) View youtubeDivider;
+    @BindView(R.id.team_facebook_container) View teamFbContainer;
+    @BindView(R.id.team_facebook_title) TextView teamFbTitle;
+    @BindView(R.id.facebook_divider) View facebookDivider;
+    @BindView(R.id.team_github_container) View teamGitHubContainer;
+    @BindView(R.id.team_github_title) TextView teamGitHubTitle;
+    @BindView(R.id.team_instagram_container) View teamInstaContainer;
+    @BindView(R.id.team_instagram_title) TextView teamInstaTitle;
+    @BindView(R.id.instagram_divider) View instagramDivider;
+    @BindView(R.id.team_full_name_container) View teamFullNameContainer;
+    @BindView(R.id.team_full_name) TextView teamFullName;
+    @BindView(R.id.team_next_match_label) View teamNextMatchLabel;
+    @BindView(R.id.team_next_match_details) View teamNextMatchDetails;
+    @BindView(R.id.progress) View progress;
+    @BindView(R.id.team_motto_container) View teamMottoContainer;
+    @BindView(R.id.team_motto) TextView teamMotto;
+    @BindView(R.id.champs_pit_location_container) View champsPitLocationContainer;
+    @BindView(R.id.champs_pit_location) TextView champsPitLocation;
+
+    private Unbinder unbinder;
 
     @Inject
     public TeamInfoBinder(SocialClickListener socialClickListener) {
@@ -69,7 +72,7 @@ public class TeamInfoBinder extends AbstractDataBinder<TeamInfoBinder.Model> {
 
     @Override
     public void bindViews() {
-        ButterKnife.bind(this, mRootView);
+        unbinder = ButterKnife.bind(this, mRootView);
     }
 
     @Override
@@ -296,8 +299,8 @@ public class TeamInfoBinder extends AbstractDataBinder<TeamInfoBinder.Model> {
     @Override
     public void unbind(boolean unbindViews) {
         super.unbind(unbindViews);
-        if (unbindViews) {
-            ButterKnife.unbind(this);
+        if (unbindViews && unbinder != null) {
+            unbinder.unbind();
         }
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
@@ -4,6 +4,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentManager;
 import androidx.viewpager.widget.ViewPager;
 
+import butterknife.Unbinder;
 import com.thebluealliance.androidclient.adapters.TeamListFragmentPagerAdapter;
 import com.thebluealliance.androidclient.views.SlidingTabs;
 
@@ -18,7 +19,7 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
     public FragmentManager fragmentManager;
 
     private Integer oldData;
-
+    private Unbinder unbinder;
     private int mInitialTab;
 
     @Inject
@@ -58,14 +59,14 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
 
     @Override
     public void bindViews() {
-        ButterKnife.bind(this, mRootView);
+        unbinder = ButterKnife.bind(this, mRootView);
     }
 
     @Override
     public void unbind(boolean unbindViews) {
         super.unbind(unbindViews);
-        if (unbindViews) {
-            ButterKnife.unbind(this);
+        if (unbindViews && unbinder != null) {
+            unbinder.unbind();
         }
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/FirebaseTickerFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/FirebaseTickerFragment.java
@@ -61,7 +61,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.utils.Mapper;
 import rx.Observable;
@@ -86,15 +86,15 @@ public abstract class FirebaseTickerFragment extends Fragment implements Action1
     @Inject DatabaseWriter mWriter;
     @Inject @Named("firebase_api") FirebaseAPI mFirebaseApi;
 
-    @Bind(R.id.list) RecyclerView mNotificationsRecyclerView;
-    @Bind(R.id.filter_list) ListView mFilterListView;
-    @Bind(R.id.filter_list_container) View mFilterListContainer;
-    @Bind(R.id.no_data) NoDataView mNoDataView;
-    @Bind(R.id.progress) ProgressBar mProgressBar;
-    @Bind(R.id.left_button) TextView mLeftButton;
-    @Bind(R.id.right_button) TextView mRightButton;
-    @Bind(R.id.filter_shadow) View mShadow;
-    @Bind(R.id.foreground_dim) View mForegroundDim;
+    @BindView(R.id.list) RecyclerView mNotificationsRecyclerView;
+    @BindView(R.id.filter_list) ListView mFilterListView;
+    @BindView(R.id.filter_list_container) View mFilterListContainer;
+    @BindView(R.id.no_data) NoDataView mNoDataView;
+    @BindView(R.id.progress) ProgressBar mProgressBar;
+    @BindView(R.id.left_button) TextView mLeftButton;
+    @BindView(R.id.right_button) TextView mRightButton;
+    @BindView(R.id.filter_shadow) View mShadow;
+    @BindView(R.id.foreground_dim) View mForegroundDim;
 
     private AnimatedRecyclerMultiAdapter mNotificationsAdapter;
     private ListViewAdapter mNotificationFilterAdapter;

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/GamedayFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/GamedayFragment.java
@@ -13,15 +13,15 @@ import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.adapters.GamedayFragmentPagerAdapter;
 import com.thebluealliance.androidclient.views.SlidingTabs;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class GamedayFragment extends Fragment {
 
     public static final String SELECTED_TAB = "selected_tab";
 
-    @Bind(R.id.pager) ViewPager mViewPager;
-    @Bind(R.id.tabs) SlidingTabs mTabs;
+    @BindView(R.id.pager) ViewPager mViewPager;
+    @BindView(R.id.tabs) SlidingTabs mTabs;
 
     private int mInitialTab;
 

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/AllianceSelectionNotificationItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/AllianceSelectionNotificationItemView.java
@@ -8,15 +8,15 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.listeners.GamedayTickerClickListener;
 import com.thebluealliance.androidclient.viewmodels.AllianceSelectionNotificationViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class AllianceSelectionNotificationItemView extends BindableFrameLayout<AllianceSelectionNotificationViewModel> {
-    @Bind(R.id.card_header) TextView header;
-    @Bind(R.id.details) TextView details;
-    @Bind(R.id.notification_time) TextView time;
-    @Bind(R.id.summary_container) View summaryContainer;
+    @BindView(R.id.card_header) TextView header;
+    @BindView(R.id.details) TextView details;
+    @BindView(R.id.notification_time) TextView time;
+    @BindView(R.id.summary_container) View summaryContainer;
 
     public AllianceSelectionNotificationItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/AwardsPostedNotificationItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/AwardsPostedNotificationItemView.java
@@ -9,15 +9,15 @@ import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.listeners.GamedayTickerClickListener;
 import com.thebluealliance.androidclient.viewmodels.AwardsPostedNotificationViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class AwardsPostedNotificationItemView extends BindableFrameLayout<AwardsPostedNotificationViewModel> {
-    @Bind(R.id.card_header) TextView header;
-    @Bind(R.id.details) TextView details;
-    @Bind(R.id.notification_time) TextView time;
-    @Bind(R.id.summary_container) View summaryContainer;
+    @BindView(R.id.card_header) TextView header;
+    @BindView(R.id.details) TextView details;
+    @BindView(R.id.notification_time) TextView time;
+    @BindView(R.id.summary_container) View summaryContainer;
 
     public AwardsPostedNotificationItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/CompLevelStartingNotificationItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/CompLevelStartingNotificationItemView.java
@@ -8,15 +8,15 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.listeners.GamedayTickerClickListener;
 import com.thebluealliance.androidclient.viewmodels.CompLevelStartingNotificationViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class CompLevelStartingNotificationItemView extends BindableFrameLayout<CompLevelStartingNotificationViewModel> {
-    @Bind(R.id.card_header) TextView header;
-    @Bind(R.id.title) TextView details;
-    @Bind(R.id.notification_time) TextView time;
-    @Bind(R.id.summary_container) View summaryContainer;
+    @BindView(R.id.card_header) TextView header;
+    @BindView(R.id.title) TextView details;
+    @BindView(R.id.notification_time) TextView time;
+    @BindView(R.id.summary_container) View summaryContainer;
 
     public CompLevelStartingNotificationItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/EventItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/EventItemView.java
@@ -12,16 +12,16 @@ import com.thebluealliance.androidclient.listeners.ModelSettingsClickListener;
 import com.thebluealliance.androidclient.types.ModelType;
 import com.thebluealliance.androidclient.viewmodels.EventViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class EventItemView extends BindableFrameLayout<EventViewModel> {
 
-    @Bind(R.id.event_name) TextView eventName;
-    @Bind(R.id.event_dates) TextView eventDates;
-    @Bind(R.id.event_location) TextView eventLocation;
-    @Bind(R.id.model_settings) ImageView modelSettings;
+    @BindView(R.id.event_name) TextView eventName;
+    @BindView(R.id.event_dates) TextView eventDates;
+    @BindView(R.id.event_location) TextView eventLocation;
+    @BindView(R.id.model_settings) ImageView modelSettings;
 
     public EventItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/GenericNotificationItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/GenericNotificationItemView.java
@@ -8,16 +8,16 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.listeners.GamedayTickerClickListener;
 import com.thebluealliance.androidclient.viewmodels.GenericNotificationViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class GenericNotificationItemView extends BindableFrameLayout<GenericNotificationViewModel> {
-    @Bind(R.id.card_header) TextView header;
-    @Bind(R.id.title) TextView title;
-    @Bind(R.id.message) TextView message;
-    @Bind(R.id.notification_time) TextView time;
-    @Bind(R.id.summary_container) View summaryContainer;
+    @BindView(R.id.card_header) TextView header;
+    @BindView(R.id.title) TextView title;
+    @BindView(R.id.message) TextView message;
+    @BindView(R.id.notification_time) TextView time;
+    @BindView(R.id.summary_container) View summaryContainer;
 
     public GenericNotificationItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/LabelValueItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/LabelValueItemView.java
@@ -7,14 +7,14 @@ import android.widget.TextView;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.viewmodels.LabelValueViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class LabelValueItemView extends BindableFrameLayout<LabelValueViewModel> {
 
-    @Bind(R.id.label) TextView label;
-    @Bind(R.id.value) TextView value;
+    @BindView(R.id.label) TextView label;
+    @BindView(R.id.value) TextView value;
 
     public LabelValueItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/LabeledMatchItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/LabeledMatchItemView.java
@@ -8,14 +8,14 @@ import android.widget.TextView;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.viewmodels.LabeledMatchViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class LabeledMatchItemView extends BindableFrameLayout<LabeledMatchViewModel> {
 
-    @Bind(R.id.label) TextView label;
-    @Bind(R.id.match_container) FrameLayout matchContainer;
+    @BindView(R.id.label) TextView label;
+    @BindView(R.id.match_container) FrameLayout matchContainer;
 
     public LabeledMatchItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/ListSectionHeaderItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/ListSectionHeaderItemView.java
@@ -7,13 +7,13 @@ import android.widget.TextView;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.viewmodels.ListSectionHeaderViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class ListSectionHeaderItemView extends BindableFrameLayout<ListSectionHeaderViewModel> {
 
-    @Bind(R.id.event_type) TextView eventType;
+    @BindView(R.id.event_type) TextView eventType;
 
     public ListSectionHeaderItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/ScheduleUpdatedNotificationItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/ScheduleUpdatedNotificationItemView.java
@@ -8,15 +8,15 @@ import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.listeners.GamedayTickerClickListener;
 import com.thebluealliance.androidclient.viewmodels.ScheduleUpdatedNotificationViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class ScheduleUpdatedNotificationItemView extends BindableFrameLayout<ScheduleUpdatedNotificationViewModel> {
-    @Bind(R.id.card_header) TextView header;
-    @Bind(R.id.details) TextView details;
-    @Bind(R.id.notification_time) TextView time;
-    @Bind(R.id.summary_container) View summaryContainer;
+    @BindView(R.id.card_header) TextView header;
+    @BindView(R.id.details) TextView details;
+    @BindView(R.id.notification_time) TextView time;
+    @BindView(R.id.summary_container) View summaryContainer;
 
     public ScheduleUpdatedNotificationItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/ScoreNotificationItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/ScoreNotificationItemView.java
@@ -12,16 +12,16 @@ import com.thebluealliance.androidclient.renderers.MatchRenderer;
 import com.thebluealliance.androidclient.viewmodels.ScoreNotificationViewModel;
 import com.thebluealliance.androidclient.views.MatchView;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class ScoreNotificationItemView extends BindableFrameLayout<ScoreNotificationViewModel> {
-    @Bind(R.id.card_header) TextView header;
-    @Bind(R.id.title) TextView title;
-    @Bind(R.id.match_details) MatchView matchView;
-    @Bind(R.id.notification_time) TextView time;
-    @Bind(R.id.summary_container) ViewGroup summaryContainer;
+    @BindView(R.id.card_header) TextView header;
+    @BindView(R.id.title) TextView title;
+    @BindView(R.id.match_details) MatchView matchView;
+    @BindView(R.id.notification_time) TextView time;
+    @BindView(R.id.summary_container) ViewGroup summaryContainer;
 
     MatchRenderer mRenderer;
 

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/TeamItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/TeamItemView.java
@@ -13,17 +13,17 @@ import com.thebluealliance.androidclient.listeners.TeamClickListener;
 import com.thebluealliance.androidclient.types.ModelType;
 import com.thebluealliance.androidclient.viewmodels.TeamViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class TeamItemView extends BindableFrameLayout<TeamViewModel> {
 
-    @Bind(R.id.team_number) TextView teamNumber;
-    @Bind(R.id.team_name) TextView teamName;
-    @Bind(R.id.team_location) TextView teamLocation;
-    @Bind(R.id.team_info) ImageView teamInfo;
-    @Bind(R.id.model_settings) ImageView modelSettings;
+    @BindView(R.id.team_number) TextView teamNumber;
+    @BindView(R.id.team_name) TextView teamName;
+    @BindView(R.id.team_location) TextView teamLocation;
+    @BindView(R.id.team_info) ImageView teamInfo;
+    @BindView(R.id.model_settings) ImageView modelSettings;
 
     public TeamItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/TeamRankingItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/TeamRankingItemView.java
@@ -16,20 +16,20 @@ import com.thebluealliance.androidclient.Interactions;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.viewmodels.TeamRankingViewModel;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class TeamRankingItemView extends BindableFrameLayout<TeamRankingViewModel> {
 
-    @Bind(R.id.team_number) TextView teamNumber;
-    @Bind(R.id.team_rank) TextView teamRank;
-    @Bind(R.id.team_record) TextView teamRecord;
-    @Bind(R.id.team_name) TextView teamName;
-    @Bind(R.id.ranking_breakdown_container) LinearLayout breakdownContainer;
-    @Bind(R.id.ranking_breakdown) TextView rankingBreakdown;
-    @Bind(R.id.ranking_summary) TextView rankingSummary;
-    @Bind(R.id.ranking_detail_button) Button rankingDetail;
+    @BindView(R.id.team_number) TextView teamNumber;
+    @BindView(R.id.team_rank) TextView teamRank;
+    @BindView(R.id.team_record) TextView teamRecord;
+    @BindView(R.id.team_name) TextView teamName;
+    @BindView(R.id.ranking_breakdown_container) LinearLayout breakdownContainer;
+    @BindView(R.id.ranking_breakdown) TextView rankingBreakdown;
+    @BindView(R.id.ranking_summary) TextView rankingSummary;
+    @BindView(R.id.ranking_detail_button) Button rankingDetail;
 
     private int originalHeight;
     private int expandedHeightDelta;

--- a/android/src/main/java/com/thebluealliance/androidclient/itemviews/UpcomingMatchNotificationItemView.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/itemviews/UpcomingMatchNotificationItemView.java
@@ -11,16 +11,16 @@ import com.thebluealliance.androidclient.listitems.MatchListElement;
 import com.thebluealliance.androidclient.viewmodels.UpcomingMatchNotificationViewModel;
 import com.thebluealliance.androidclient.views.MatchView;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.nlopez.smartadapters.views.BindableFrameLayout;
 
 public class UpcomingMatchNotificationItemView extends BindableFrameLayout<UpcomingMatchNotificationViewModel> {
-    @Bind(R.id.card_header) TextView header;
-    @Bind(R.id.title) TextView title;
-    @Bind(R.id.match_details) MatchView matchView;
-    @Bind(R.id.notification_time) TextView time;
-    @Bind(R.id.summary_container) View summaryContainer;
+    @BindView(R.id.card_header) TextView header;
+    @BindView(R.id.title) TextView title;
+    @BindView(R.id.match_details) MatchView matchView;
+    @BindView(R.id.notification_time) TextView time;
+    @BindView(R.id.summary_container) View summaryContainer;
 
     public UpcomingMatchNotificationItemView(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2015.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2015.java
@@ -14,7 +14,7 @@ import com.thebluealliance.api.model.IMatchAlliancesContainer;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getIntDefault;
@@ -23,50 +23,50 @@ import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownH
 
 public class MatchBreakdownView2015 extends AbstractMatchBreakdownView {
 
-    @Bind(R.id.breakdown2015_container)                  GridLayout breakdownContainer;
+    @BindView(R.id.breakdown2015_container)                  GridLayout breakdownContainer;
 
-    @Bind(R.id.breakdown_red1)                           TextView red1;
-    @Bind(R.id.breakdown_blue1)                          TextView blue1;
-    @Bind(R.id.breakdown_red2)                           TextView red2;
-    @Bind(R.id.breakdown_blue2)                          TextView blue2;
-    @Bind(R.id.breakdown_red3)                           TextView red3;
-    @Bind(R.id.breakdown_blue3)                          TextView blue3;
+    @BindView(R.id.breakdown_red1)                           TextView red1;
+    @BindView(R.id.breakdown_blue1)                          TextView blue1;
+    @BindView(R.id.breakdown_red2)                           TextView red2;
+    @BindView(R.id.breakdown_blue2)                          TextView blue2;
+    @BindView(R.id.breakdown_red3)                           TextView red3;
+    @BindView(R.id.breakdown_blue3)                          TextView blue3;
 
-    @Bind(R.id.breakdown2015_auto_tote_points_red)       TextView autoTotePointsRed;
-    @Bind(R.id.breakdown2015_auto_tote_points_blue)      TextView autoTotePointsBlue;
-    @Bind(R.id.breakdown2015_auto_container_points_red)  TextView autoContainerPointsRed;
-    @Bind(R.id.breakdown2015_auto_container_points_blue) TextView autoContainerPointsBlue;
-    @Bind(R.id.breakdown2015_auto_robot_points_red)      TextView autoRobotPointsRed;
-    @Bind(R.id.breakdown2015_auto_robot_points_blue)     TextView autoRobotPointsBlue;
-    @Bind(R.id.breakdown_auto_total_red)                 TextView autoTotalRed;
-    @Bind(R.id.breakdown_auto_total_blue)                TextView autoTotalBlue;
+    @BindView(R.id.breakdown2015_auto_tote_points_red)       TextView autoTotePointsRed;
+    @BindView(R.id.breakdown2015_auto_tote_points_blue)      TextView autoTotePointsBlue;
+    @BindView(R.id.breakdown2015_auto_container_points_red)  TextView autoContainerPointsRed;
+    @BindView(R.id.breakdown2015_auto_container_points_blue) TextView autoContainerPointsBlue;
+    @BindView(R.id.breakdown2015_auto_robot_points_red)      TextView autoRobotPointsRed;
+    @BindView(R.id.breakdown2015_auto_robot_points_blue)     TextView autoRobotPointsBlue;
+    @BindView(R.id.breakdown_auto_total_red)                 TextView autoTotalRed;
+    @BindView(R.id.breakdown_auto_total_blue)                TextView autoTotalBlue;
 
-    @Bind(R.id.breakdown2015_tote_points_red)            TextView totePointsRed;
-    @Bind(R.id.breakdown2015_tote_points_blue)           TextView totePointsBlue;
-    @Bind(R.id.breakdown2015_container_points_red)       TextView containerPointsRed;
-    @Bind(R.id.breakdown2015_container_points_blue)      TextView containerPointsBlue;
-    @Bind(R.id.breakdown2015_litter_points_red)          TextView litterPointsRed;
-    @Bind(R.id.breakdown2015_litter_points_blue)         TextView litterPointsBlue;
-    @Bind(R.id.breakdown_teleop_total_red)               TextView teleopTotalRed;
-    @Bind(R.id.breakdown_teleop_total_blue)              TextView teleopTotalBlue;
+    @BindView(R.id.breakdown2015_tote_points_red)            TextView totePointsRed;
+    @BindView(R.id.breakdown2015_tote_points_blue)           TextView totePointsBlue;
+    @BindView(R.id.breakdown2015_container_points_red)       TextView containerPointsRed;
+    @BindView(R.id.breakdown2015_container_points_blue)      TextView containerPointsBlue;
+    @BindView(R.id.breakdown2015_litter_points_red)          TextView litterPointsRed;
+    @BindView(R.id.breakdown2015_litter_points_blue)         TextView litterPointsBlue;
+    @BindView(R.id.breakdown_teleop_total_red)               TextView teleopTotalRed;
+    @BindView(R.id.breakdown_teleop_total_blue)              TextView teleopTotalBlue;
 
-    @Bind(R.id.breakdown2015_coop_points_red)            TextView coopPointsRed;
-    @Bind(R.id.breakdown2015_coop_points_blue)           TextView coopPointsBlue;
-    @Bind(R.id.breakdown_fouls_red)                      TextView foulsRed;
-    @Bind(R.id.breakdown_fouls_blue)                     TextView foulsBlue;
-    @Bind(R.id.breakdown_adjust_red)                     TextView adjustRed;
-    @Bind(R.id.breakdown_adjust_blue)                    TextView adjustBlue;
-    @Bind(R.id.breakdown_total_red)                      TextView totalRed;
-    @Bind(R.id.breakdown_total_blue)                     TextView totalBlue;
+    @BindView(R.id.breakdown2015_coop_points_red)            TextView coopPointsRed;
+    @BindView(R.id.breakdown2015_coop_points_blue)           TextView coopPointsBlue;
+    @BindView(R.id.breakdown_fouls_red)                      TextView foulsRed;
+    @BindView(R.id.breakdown_fouls_blue)                     TextView foulsBlue;
+    @BindView(R.id.breakdown_adjust_red)                     TextView adjustRed;
+    @BindView(R.id.breakdown_adjust_blue)                    TextView adjustBlue;
+    @BindView(R.id.breakdown_total_red)                      TextView totalRed;
+    @BindView(R.id.breakdown_total_blue)                     TextView totalBlue;
 
-    @Bind(R.id.breakdown2015_auto_totes_icon_red)        ImageView autoTotesIconRed;
-    @Bind(R.id.breakdown2015_auto_totes_icon_blue)       ImageView autoTotesIconBlue;
-    @Bind(R.id.breakdown2015_auto_containers_icon_red)   ImageView autoContainersIconRed;
-    @Bind(R.id.breakdown2015_auto_containers_icon_blue)  ImageView autoContainersIconBlue;
-    @Bind(R.id.breakdown2015_auto_robots_icon_red)       ImageView autoRobotsIconRed;
-    @Bind(R.id.breakdown2015_auto_robots_icon_blue)      ImageView autoRobotsIconBlue;
-    @Bind(R.id.breakdown2015_coop_icon_red)              ImageView coopIconRed;
-    @Bind(R.id.breakdown2015_coop_icon_blue)             ImageView coopIconBlue;
+    @BindView(R.id.breakdown2015_auto_totes_icon_red)        ImageView autoTotesIconRed;
+    @BindView(R.id.breakdown2015_auto_totes_icon_blue)       ImageView autoTotesIconBlue;
+    @BindView(R.id.breakdown2015_auto_containers_icon_red)   ImageView autoContainersIconRed;
+    @BindView(R.id.breakdown2015_auto_containers_icon_blue)  ImageView autoContainersIconBlue;
+    @BindView(R.id.breakdown2015_auto_robots_icon_red)       ImageView autoRobotsIconRed;
+    @BindView(R.id.breakdown2015_auto_robots_icon_blue)      ImageView autoRobotsIconBlue;
+    @BindView(R.id.breakdown2015_coop_icon_red)              ImageView coopIconRed;
+    @BindView(R.id.breakdown2015_coop_icon_blue)             ImageView coopIconBlue;
 
     private static final int ROBOT_SET_POINTS = 4;
     private static final int TOTE_SET_POINTS = 6;

--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2017.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2017.java
@@ -15,7 +15,7 @@ import com.thebluealliance.api.model.IMatchAlliancesContainer;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getBooleanDefault;
@@ -26,74 +26,74 @@ import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownH
 
 public class MatchBreakdownView2017 extends AbstractMatchBreakdownView {
 
-    @Bind(R.id.breakdown2017_container)                  GridLayout breakdownContainer;
+    @BindView(R.id.breakdown2017_container)                  GridLayout breakdownContainer;
 
-    @Bind(R.id.breakdown_red1)                           TextView red1;
-    @Bind(R.id.breakdown_blue1)                          TextView blue1;
-    @Bind(R.id.breakdown_red2)                           TextView red2;
-    @Bind(R.id.breakdown_blue2)                          TextView blue2;
-    @Bind(R.id.breakdown_red3)                           TextView red3;
-    @Bind(R.id.breakdown_blue3)                          TextView blue3;
+    @BindView(R.id.breakdown_red1)                           TextView red1;
+    @BindView(R.id.breakdown_blue1)                          TextView blue1;
+    @BindView(R.id.breakdown_red2)                           TextView red2;
+    @BindView(R.id.breakdown_blue2)                          TextView blue2;
+    @BindView(R.id.breakdown_red3)                           TextView red3;
+    @BindView(R.id.breakdown_blue3)                          TextView blue3;
 
-    @Bind(R.id.breakdown2017_red_auto_mobility)          TextView redMobility;
-    @Bind(R.id.breakdown2017_blue_auto_mobility)         TextView blueMobility;
-    @Bind(R.id.breakdown2017_red_auto_fuel_high)         TextView redAutoFuelHigh;
-    @Bind(R.id.breakdown2017_red_auto_fuel_low)          TextView redAutoFuelLow;
-    @Bind(R.id.breakdown2017_blue_auto_fuel_high)        TextView blueAutoFuelHigh;
-    @Bind(R.id.breakdown2017_blue_auto_fuel_low)         TextView blueAutoFuelLow;
-    @Bind(R.id.breakdown2017_red_auto_pressure)          TextView redAutoPressure;
-    @Bind(R.id.breakdown2017_blue_auto_pressure)         TextView blueAutoPressure;
-    @Bind(R.id.breakdown2017_auto_rotor1_red)            ImageView redAutoRotor1;
-    @Bind(R.id.breakdown2017_auto_rotor2_red)            ImageView redAutoRotor2;
-    @Bind(R.id.breakdown2017_auto_rotor1_blue)           ImageView blueAutoRotor1;
-    @Bind(R.id.breakdown2017_auto_rotor2_blue)           ImageView blueAutoRotor2;
-    @Bind(R.id.breakdown2017_red_auto_rotor)             TextView redAutoRotorPoints;
-    @Bind(R.id.breakdown2017_blue_auto_rotor)            TextView blueAutoRotorPoints;
-    @Bind(R.id.breakdown_auto_total_red)                 TextView redAutoTotal;
-    @Bind(R.id.breakdown_auto_total_blue)                TextView blueAutoTotal;
+    @BindView(R.id.breakdown2017_red_auto_mobility)          TextView redMobility;
+    @BindView(R.id.breakdown2017_blue_auto_mobility)         TextView blueMobility;
+    @BindView(R.id.breakdown2017_red_auto_fuel_high)         TextView redAutoFuelHigh;
+    @BindView(R.id.breakdown2017_red_auto_fuel_low)          TextView redAutoFuelLow;
+    @BindView(R.id.breakdown2017_blue_auto_fuel_high)        TextView blueAutoFuelHigh;
+    @BindView(R.id.breakdown2017_blue_auto_fuel_low)         TextView blueAutoFuelLow;
+    @BindView(R.id.breakdown2017_red_auto_pressure)          TextView redAutoPressure;
+    @BindView(R.id.breakdown2017_blue_auto_pressure)         TextView blueAutoPressure;
+    @BindView(R.id.breakdown2017_auto_rotor1_red)            ImageView redAutoRotor1;
+    @BindView(R.id.breakdown2017_auto_rotor2_red)            ImageView redAutoRotor2;
+    @BindView(R.id.breakdown2017_auto_rotor1_blue)           ImageView blueAutoRotor1;
+    @BindView(R.id.breakdown2017_auto_rotor2_blue)           ImageView blueAutoRotor2;
+    @BindView(R.id.breakdown2017_red_auto_rotor)             TextView redAutoRotorPoints;
+    @BindView(R.id.breakdown2017_blue_auto_rotor)            TextView blueAutoRotorPoints;
+    @BindView(R.id.breakdown_auto_total_red)                 TextView redAutoTotal;
+    @BindView(R.id.breakdown_auto_total_blue)                TextView blueAutoTotal;
 
-    @Bind(R.id.breakdown2017_red_teleop_fuel_high)       TextView redTeleopFuelHigh;
-    @Bind(R.id.breakdown2017_red_teleop_fuel_low)        TextView redTeleopFuelLow;
-    @Bind(R.id.breakdown2017_blue_teleop_fuel_high)      TextView blueTeleopFuelHigh;
-    @Bind(R.id.breakdown2017_blue_teleop_fuel_low)       TextView blueTeleopFuelLow;
-    @Bind(R.id.breakdown2017_red_teleop_pressure)        TextView redTeleopPressure;
-    @Bind(R.id.breakdown2017_blue_teleop_pressure)       TextView blueTeleopPressure;
+    @BindView(R.id.breakdown2017_red_teleop_fuel_high)       TextView redTeleopFuelHigh;
+    @BindView(R.id.breakdown2017_red_teleop_fuel_low)        TextView redTeleopFuelLow;
+    @BindView(R.id.breakdown2017_blue_teleop_fuel_high)      TextView blueTeleopFuelHigh;
+    @BindView(R.id.breakdown2017_blue_teleop_fuel_low)       TextView blueTeleopFuelLow;
+    @BindView(R.id.breakdown2017_red_teleop_pressure)        TextView redTeleopPressure;
+    @BindView(R.id.breakdown2017_blue_teleop_pressure)       TextView blueTeleopPressure;
 
-    @Bind(R.id.breakdown2017_teleop_rotor1_red)          ImageView redTeleopRotor1;
-    @Bind(R.id.breakdown2017_teleop_rotor2_red)          ImageView redTeleopRotor2;
-    @Bind(R.id.breakdown2017_teleop_rotor3_red)          ImageView redTeleopRotor3;
-    @Bind(R.id.breakdown2017_teleop_rotor4_red)          ImageView redTeleopRotor4;
-    @Bind(R.id.breakdown2017_teleop_rotor1_blue)         ImageView blueTeleopRotor1;
-    @Bind(R.id.breakdown2017_teleop_rotor2_blue)         ImageView blueTeleopRotor2;
-    @Bind(R.id.breakdown2017_teleop_rotor3_blue)         ImageView blueTeleopRotor3;
-    @Bind(R.id.breakdown2017_teleop_rotor4_blue)         ImageView blueTeleopRotor4;
-    @Bind(R.id.breakdown2017_red_teleop_rotor)           TextView redTeleopRotor;
-    @Bind(R.id.breakdown2017_blue_teleop_rotor)          TextView blueTeleopRotor;
+    @BindView(R.id.breakdown2017_teleop_rotor1_red)          ImageView redTeleopRotor1;
+    @BindView(R.id.breakdown2017_teleop_rotor2_red)          ImageView redTeleopRotor2;
+    @BindView(R.id.breakdown2017_teleop_rotor3_red)          ImageView redTeleopRotor3;
+    @BindView(R.id.breakdown2017_teleop_rotor4_red)          ImageView redTeleopRotor4;
+    @BindView(R.id.breakdown2017_teleop_rotor1_blue)         ImageView blueTeleopRotor1;
+    @BindView(R.id.breakdown2017_teleop_rotor2_blue)         ImageView blueTeleopRotor2;
+    @BindView(R.id.breakdown2017_teleop_rotor3_blue)         ImageView blueTeleopRotor3;
+    @BindView(R.id.breakdown2017_teleop_rotor4_blue)         ImageView blueTeleopRotor4;
+    @BindView(R.id.breakdown2017_red_teleop_rotor)           TextView redTeleopRotor;
+    @BindView(R.id.breakdown2017_blue_teleop_rotor)          TextView blueTeleopRotor;
 
-    @Bind(R.id.breakdown2017_red_teleop_takeoff)         TextView redTeleopTakeoff;
-    @Bind(R.id.breakdown2017_blue_teleop_takeoff)        TextView blueTeleopTakeoff;
-    @Bind(R.id.breakdown_teleop_total_red)               TextView redTeleopTotal;
-    @Bind(R.id.breakdown_teleop_total_blue)              TextView blueTeleopTotal;
+    @BindView(R.id.breakdown2017_red_teleop_takeoff)         TextView redTeleopTakeoff;
+    @BindView(R.id.breakdown2017_blue_teleop_takeoff)        TextView blueTeleopTakeoff;
+    @BindView(R.id.breakdown_teleop_total_red)               TextView redTeleopTotal;
+    @BindView(R.id.breakdown_teleop_total_blue)              TextView blueTeleopTotal;
 
-    @Bind(R.id.breakdown2017_red_pressure_icon)          ImageView redPressureIcon;
-    @Bind(R.id.breakdown2017_blue_pressure_icon)         ImageView bluePressureIcon;
-    @Bind(R.id.breakdown2017_red_pressure_reached)       TextView redPressureBonus;
-    @Bind(R.id.breakdown2017_blue_pressure_reached)      TextView bluePressureBonus;
+    @BindView(R.id.breakdown2017_red_pressure_icon)          ImageView redPressureIcon;
+    @BindView(R.id.breakdown2017_blue_pressure_icon)         ImageView bluePressureIcon;
+    @BindView(R.id.breakdown2017_red_pressure_reached)       TextView redPressureBonus;
+    @BindView(R.id.breakdown2017_blue_pressure_reached)      TextView bluePressureBonus;
 
-    @Bind(R.id.breakdown2017_red_all_rotors_icon)        ImageView redRotorsIcon;
-    @Bind(R.id.breakdown2017_blue_all_rotors_icon)       ImageView blueRotorsIcon;
-    @Bind(R.id.breakdown2017_red_all_rotors_points)      TextView redRotorBonus;
-    @Bind(R.id.breakdown2017_blue_all_rotors_points)     TextView blueRotorBonus;
+    @BindView(R.id.breakdown2017_red_all_rotors_icon)        ImageView redRotorsIcon;
+    @BindView(R.id.breakdown2017_blue_all_rotors_icon)       ImageView blueRotorsIcon;
+    @BindView(R.id.breakdown2017_red_all_rotors_points)      TextView redRotorBonus;
+    @BindView(R.id.breakdown2017_blue_all_rotors_points)     TextView blueRotorBonus;
 
-    @Bind(R.id.breakdown_fouls_red)                      TextView foulsRed;
-    @Bind(R.id.breakdown_fouls_blue)                     TextView foulsBlue;
-    @Bind(R.id.breakdown_adjust_red)                     TextView adjustRed;
-    @Bind(R.id.breakdown_adjust_blue)                    TextView adjustBlue;
-    @Bind(R.id.breakdown_total_red)                      TextView totalRed;
-    @Bind(R.id.breakdown_total_blue)                     TextView totalBlue;
-    @Bind(R.id.breakdown_red_rp)                         TextView rpRed;
-    @Bind(R.id.breakdown_blue_rp)                        TextView rpBlue;
-    @Bind(R.id.breakdown_rp_header)                      TextView rpHeader;
+    @BindView(R.id.breakdown_fouls_red)                      TextView foulsRed;
+    @BindView(R.id.breakdown_fouls_blue)                     TextView foulsBlue;
+    @BindView(R.id.breakdown_adjust_red)                     TextView adjustRed;
+    @BindView(R.id.breakdown_adjust_blue)                    TextView adjustBlue;
+    @BindView(R.id.breakdown_total_red)                      TextView totalRed;
+    @BindView(R.id.breakdown_total_blue)                     TextView totalBlue;
+    @BindView(R.id.breakdown_red_rp)                         TextView rpRed;
+    @BindView(R.id.breakdown_blue_rp)                        TextView rpBlue;
+    @BindView(R.id.breakdown_rp_header)                      TextView rpHeader;
 
     private static final String AUTO_ROTOR_FORMAT = "rotor%1$dAuto";
     private static final String TELEOP_ROTOR_FORMAT = "rotor%1$dEngaged";

--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2018.java
@@ -17,7 +17,7 @@ import com.thebluealliance.api.model.IMatchAlliancesContainer;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getBooleanDefault;
@@ -26,74 +26,74 @@ import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownH
 import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.teamNumberFromKey;
 
 public class MatchBreakdownView2018 extends AbstractMatchBreakdownView {
-    @Bind(R.id.breakdown2018_container)                     GridLayout breakdownContainer;
+    @BindView(R.id.breakdown2018_container)                     GridLayout breakdownContainer;
 
-    @Bind(R.id.breakdown_red1)                              TextView red1;
-    @Bind(R.id.breakdown_blue1)                             TextView blue1;
-    @Bind(R.id.breakdown_red2)                              TextView red2;
-    @Bind(R.id.breakdown_blue2)                             TextView blue2;
-    @Bind(R.id.breakdown_red3)                              TextView red3;
-    @Bind(R.id.breakdown_blue3)                             TextView blue3;
+    @BindView(R.id.breakdown_red1)                              TextView red1;
+    @BindView(R.id.breakdown_blue1)                             TextView blue1;
+    @BindView(R.id.breakdown_red2)                              TextView red2;
+    @BindView(R.id.breakdown_blue2)                             TextView blue2;
+    @BindView(R.id.breakdown_red3)                              TextView red3;
+    @BindView(R.id.breakdown_blue3)                             TextView blue3;
 
-    @Bind(R.id.breakdown2018_red_auto_run_robot_1)          ImageView redAutoRunRobot1;
-    @Bind(R.id.breakdown2018_blue_auto_run_robot_1)         ImageView blueAutoRunRobot1;
-    @Bind(R.id.breakdown2018_red_auto_run_robot_2)          ImageView redAutoRunRobot2;
-    @Bind(R.id.breakdown2018_blue_auto_run_robot_2)         ImageView blueAutoRunRobot2;
-    @Bind(R.id.breakdown2018_red_auto_run_robot_3)          ImageView redAutoRunRobot3;
-    @Bind(R.id.breakdown2018_blue_auto_run_robot_3)         ImageView blueAutoRunRobot3;
-    @Bind(R.id.breakdown2018_red_auto_run_points)           TextView redAutoRunPoints;
-    @Bind(R.id.breakdown2018_blue_auto_run_points)          TextView blueAutoRunPoints;
-    @Bind(R.id.breakdown2018_red_auto_scale_seconds)        TextView redAutoScaleSeconds;
-    @Bind(R.id.breakdown2018_blue_auto_scale_seconds)       TextView blueAutoScaleSeconds;
-    @Bind(R.id.breakdown2018_red_auto_switch_seconds)       TextView redAutoSwitchSeconds;
-    @Bind(R.id.breakdown2018_blue_auto_switch_seconds)      TextView blueAutoSwitchSeconds;
-    @Bind(R.id.breakdown2018_red_auto_ownership_points)     TextView redAutoOwnershipPoints;
-    @Bind(R.id.breakdown2018_blue_auto_ownership_points)    TextView blueAutoOwnershipPoints;
-    @Bind(R.id.breakdown_auto_total_red)                    TextView redAutoTotal;
-    @Bind(R.id.breakdown_auto_total_blue)                   TextView blueAutoTotal;
+    @BindView(R.id.breakdown2018_red_auto_run_robot_1)          ImageView redAutoRunRobot1;
+    @BindView(R.id.breakdown2018_blue_auto_run_robot_1)         ImageView blueAutoRunRobot1;
+    @BindView(R.id.breakdown2018_red_auto_run_robot_2)          ImageView redAutoRunRobot2;
+    @BindView(R.id.breakdown2018_blue_auto_run_robot_2)         ImageView blueAutoRunRobot2;
+    @BindView(R.id.breakdown2018_red_auto_run_robot_3)          ImageView redAutoRunRobot3;
+    @BindView(R.id.breakdown2018_blue_auto_run_robot_3)         ImageView blueAutoRunRobot3;
+    @BindView(R.id.breakdown2018_red_auto_run_points)           TextView redAutoRunPoints;
+    @BindView(R.id.breakdown2018_blue_auto_run_points)          TextView blueAutoRunPoints;
+    @BindView(R.id.breakdown2018_red_auto_scale_seconds)        TextView redAutoScaleSeconds;
+    @BindView(R.id.breakdown2018_blue_auto_scale_seconds)       TextView blueAutoScaleSeconds;
+    @BindView(R.id.breakdown2018_red_auto_switch_seconds)       TextView redAutoSwitchSeconds;
+    @BindView(R.id.breakdown2018_blue_auto_switch_seconds)      TextView blueAutoSwitchSeconds;
+    @BindView(R.id.breakdown2018_red_auto_ownership_points)     TextView redAutoOwnershipPoints;
+    @BindView(R.id.breakdown2018_blue_auto_ownership_points)    TextView blueAutoOwnershipPoints;
+    @BindView(R.id.breakdown_auto_total_red)                    TextView redAutoTotal;
+    @BindView(R.id.breakdown_auto_total_blue)                   TextView blueAutoTotal;
 
-    @Bind(R.id.breakdown2018_teleop_red_scale_seconds)      TextView redTeleopScaleSeconds;
-    @Bind(R.id.breakdown2018_teleop_blue_scale_seconds)     TextView blueTeleopScaleSeconds;
-    @Bind(R.id.breakdown2018_teleop_red_switch_seconds)     TextView redTeleopSwitchSeconds;
-    @Bind(R.id.breakdown2018_teleop_blue_switch_seconds)    TextView blueTeleopSwitchSeconds;
-    @Bind(R.id.breakdown2018_teleop_red_ownership_points)   TextView redTeleopOwnershipPoints;
-    @Bind(R.id.breakdown2018_teleop_blue_ownership_points)  TextView blueTeleopOwnershipPoints;
+    @BindView(R.id.breakdown2018_teleop_red_scale_seconds)      TextView redTeleopScaleSeconds;
+    @BindView(R.id.breakdown2018_teleop_blue_scale_seconds)     TextView blueTeleopScaleSeconds;
+    @BindView(R.id.breakdown2018_teleop_red_switch_seconds)     TextView redTeleopSwitchSeconds;
+    @BindView(R.id.breakdown2018_teleop_blue_switch_seconds)    TextView blueTeleopSwitchSeconds;
+    @BindView(R.id.breakdown2018_teleop_red_ownership_points)   TextView redTeleopOwnershipPoints;
+    @BindView(R.id.breakdown2018_teleop_blue_ownership_points)  TextView blueTeleopOwnershipPoints;
 
-    @Bind(R.id.breakdown2018_vault_red_force_cubes)         TextView redVaultForceCubes;
-    @Bind(R.id.breakdown2018_vault_blue_force_cubes)        TextView blueVaultForceCubes;
-    @Bind(R.id.breakdown2018_vault_red_levitate_cubes)      TextView redVaultLevitateCubes;
-    @Bind(R.id.breakdown2018_vault_blue_levitate_cubes)     TextView blueVaultLevitateCubes;
-    @Bind(R.id.breakdown2018_vault_red_boost_cubes)         TextView redVaultBoostCubes;
-    @Bind(R.id.breakdown2018_vault_blue_boost_cubes)        TextView blueVaultBoostCubes;
-    @Bind(R.id.breakdown2018_vault_red_total)               TextView redVaultPoints;
-    @Bind(R.id.breakdown2018_vault_blue_total)              TextView blueVaultPoints;
+    @BindView(R.id.breakdown2018_vault_red_force_cubes)         TextView redVaultForceCubes;
+    @BindView(R.id.breakdown2018_vault_blue_force_cubes)        TextView blueVaultForceCubes;
+    @BindView(R.id.breakdown2018_vault_red_levitate_cubes)      TextView redVaultLevitateCubes;
+    @BindView(R.id.breakdown2018_vault_blue_levitate_cubes)     TextView blueVaultLevitateCubes;
+    @BindView(R.id.breakdown2018_vault_red_boost_cubes)         TextView redVaultBoostCubes;
+    @BindView(R.id.breakdown2018_vault_blue_boost_cubes)        TextView blueVaultBoostCubes;
+    @BindView(R.id.breakdown2018_vault_red_total)               TextView redVaultPoints;
+    @BindView(R.id.breakdown2018_vault_blue_total)              TextView blueVaultPoints;
 
-    @Bind(R.id.breakdown2018_endgame_red_robot_1)           TextView redEndgameRobot1;
-    @Bind(R.id.breakdown2018_endgame_blue_robot_1)          TextView blueEndgameRobot1;
-    @Bind(R.id.breakdown2018_endgame_red_robot_2)           TextView redEndgameRobot2;
-    @Bind(R.id.breakdown2018_endgame_blue_robot_2)          TextView blueEndgameRobot2;
-    @Bind(R.id.breakdown2018_endgame_red_robot_3)           TextView redEndgameRobot3;
-    @Bind(R.id.breakdown2018_endgame_blue_robot_3)          TextView blueEndgameRobot3;
-    @Bind(R.id.breakdown2018_endgame_red_total)             TextView redEndgamePoints;
-    @Bind(R.id.breakdown2018_endgame_blue_total)            TextView blueEndgamePoints;
+    @BindView(R.id.breakdown2018_endgame_red_robot_1)           TextView redEndgameRobot1;
+    @BindView(R.id.breakdown2018_endgame_blue_robot_1)          TextView blueEndgameRobot1;
+    @BindView(R.id.breakdown2018_endgame_red_robot_2)           TextView redEndgameRobot2;
+    @BindView(R.id.breakdown2018_endgame_blue_robot_2)          TextView blueEndgameRobot2;
+    @BindView(R.id.breakdown2018_endgame_red_robot_3)           TextView redEndgameRobot3;
+    @BindView(R.id.breakdown2018_endgame_blue_robot_3)          TextView blueEndgameRobot3;
+    @BindView(R.id.breakdown2018_endgame_red_total)             TextView redEndgamePoints;
+    @BindView(R.id.breakdown2018_endgame_blue_total)            TextView blueEndgamePoints;
 
-    @Bind(R.id.breakdown_teleop_total_red)                  TextView redTeleopTotal;
-    @Bind(R.id.breakdown_teleop_total_blue)                 TextView blueTeleopTotal;
+    @BindView(R.id.breakdown_teleop_total_red)                  TextView redTeleopTotal;
+    @BindView(R.id.breakdown_teleop_total_blue)                 TextView blueTeleopTotal;
 
-    @Bind(R.id.breakdown2018_red_face_the_boss)             ImageView redFaceTheBoss;
-    @Bind(R.id.breakdown2018_blue_face_the_boss)            ImageView blueFaceTheBoss;
-    @Bind(R.id.breakdown2018_red_auto_quest)                ImageView redAutoQuest;
-    @Bind(R.id.breakdown2018_blue_auto_quest)               ImageView blueAutoQuest;
+    @BindView(R.id.breakdown2018_red_face_the_boss)             ImageView redFaceTheBoss;
+    @BindView(R.id.breakdown2018_blue_face_the_boss)            ImageView blueFaceTheBoss;
+    @BindView(R.id.breakdown2018_red_auto_quest)                ImageView redAutoQuest;
+    @BindView(R.id.breakdown2018_blue_auto_quest)               ImageView blueAutoQuest;
 
-    @Bind(R.id.breakdown_fouls_red)                         TextView foulsRed;
-    @Bind(R.id.breakdown_fouls_blue)                        TextView foulsBlue;
-    @Bind(R.id.breakdown_adjust_red)                        TextView adjustRed;
-    @Bind(R.id.breakdown_adjust_blue)                       TextView adjustBlue;
-    @Bind(R.id.breakdown_total_red)                         TextView totalRed;
-    @Bind(R.id.breakdown_total_blue)                        TextView totalBlue;
-    @Bind(R.id.breakdown_red_rp)                            TextView rpRed;
-    @Bind(R.id.breakdown_blue_rp)                           TextView rpBlue;
-    @Bind(R.id.breakdown_rp_header)                         TextView rpHeader;
+    @BindView(R.id.breakdown_fouls_red)                         TextView foulsRed;
+    @BindView(R.id.breakdown_fouls_blue)                        TextView foulsBlue;
+    @BindView(R.id.breakdown_adjust_red)                        TextView adjustRed;
+    @BindView(R.id.breakdown_adjust_blue)                       TextView adjustBlue;
+    @BindView(R.id.breakdown_total_red)                         TextView totalRed;
+    @BindView(R.id.breakdown_total_blue)                        TextView totalBlue;
+    @BindView(R.id.breakdown_red_rp)                            TextView rpRed;
+    @BindView(R.id.breakdown_blue_rp)                           TextView rpBlue;
+    @BindView(R.id.breakdown_rp_header)                         TextView rpHeader;
 
     public MatchBreakdownView2018(Context context) {
         super(context);

--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2019.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2019.java
@@ -16,7 +16,7 @@ import com.thebluealliance.api.model.IMatchAlliancesContainer;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getBooleanDefault;
@@ -25,72 +25,72 @@ import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownH
 import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.teamNumberFromKey;
 
 public class MatchBreakdownView2019 extends AbstractMatchBreakdownView {
-    @Bind(R.id.breakdown2019_container)                     GridLayout breakdownContainer;
+    @BindView(R.id.breakdown2019_container)                     GridLayout breakdownContainer;
 
-    @Bind(R.id.breakdown_red1)                              TextView red1;
-    @Bind(R.id.breakdown_blue1)                             TextView blue1;
-    @Bind(R.id.breakdown_red2)                              TextView red2;
-    @Bind(R.id.breakdown_blue2)                             TextView blue2;
-    @Bind(R.id.breakdown_red3)                              TextView red3;
-    @Bind(R.id.breakdown_blue3)                             TextView blue3;
+    @BindView(R.id.breakdown_red1)                              TextView red1;
+    @BindView(R.id.breakdown_blue1)                             TextView blue1;
+    @BindView(R.id.breakdown_red2)                              TextView red2;
+    @BindView(R.id.breakdown_blue2)                             TextView blue2;
+    @BindView(R.id.breakdown_red3)                              TextView red3;
+    @BindView(R.id.breakdown_blue3)                             TextView blue3;
 
-    @Bind(R.id.breakdown2019_red_sandstorm_bonus_robot_1)   TextView redSandstormBonusRobot1;
-    @Bind(R.id.breakdown2019_blue_sandstorm_bonus_robot_1)  TextView blueSandstormBonusRobot1;
-    @Bind(R.id.breakdown2019_red_sandstorm_bonus_robot_2)   TextView redSandstormBonusRobot2;
-    @Bind(R.id.breakdown2019_blue_sandstorm_bonus_robot_2)  TextView blueSandstormBonusRobot2;
-    @Bind(R.id.breakdown2019_red_sandstorm_bonus_robot_3)   TextView redSandstormBonusRobot3;
-    @Bind(R.id.breakdown2019_blue_sandstorm_bonus_robot_3)  TextView blueSandstormBonusRobot3;
-    @Bind(R.id.breakdown2019_sandstorm_total_red)           TextView redSandstormTotal;
-    @Bind(R.id.breakdown2019_sandstorm_total_blue)          TextView blueSandstormTotal;
+    @BindView(R.id.breakdown2019_red_sandstorm_bonus_robot_1)   TextView redSandstormBonusRobot1;
+    @BindView(R.id.breakdown2019_blue_sandstorm_bonus_robot_1)  TextView blueSandstormBonusRobot1;
+    @BindView(R.id.breakdown2019_red_sandstorm_bonus_robot_2)   TextView redSandstormBonusRobot2;
+    @BindView(R.id.breakdown2019_blue_sandstorm_bonus_robot_2)  TextView blueSandstormBonusRobot2;
+    @BindView(R.id.breakdown2019_red_sandstorm_bonus_robot_3)   TextView redSandstormBonusRobot3;
+    @BindView(R.id.breakdown2019_blue_sandstorm_bonus_robot_3)  TextView blueSandstormBonusRobot3;
+    @BindView(R.id.breakdown2019_sandstorm_total_red)           TextView redSandstormTotal;
+    @BindView(R.id.breakdown2019_sandstorm_total_blue)          TextView blueSandstormTotal;
 
 
-    @Bind(R.id.breakdown2019_red_cargo_ship_panels)         TextView redCargoShipPanels;
-    @Bind(R.id.breakdown2019_red_cargo_ship_null_panels)    TextView redCargoShipNullPanels;
-    @Bind(R.id.breakdown2019_red_cargo_ship_cargo)          TextView redCargoShipCargo;
-    @Bind(R.id.breakdown2019_red_rocket_1_panels)           TextView redRocket1Panels;
-    @Bind(R.id.breakdown2019_red_rocket_1_cargo)            TextView redRocket1Cargo;
-    @Bind(R.id.breakdown2019_red_rocket_2_panels)           TextView redRocket2Panels;
-    @Bind(R.id.breakdown2019_red_rocket_2_cargo)            TextView redRocket2Cargo;
+    @BindView(R.id.breakdown2019_red_cargo_ship_panels)         TextView redCargoShipPanels;
+    @BindView(R.id.breakdown2019_red_cargo_ship_null_panels)    TextView redCargoShipNullPanels;
+    @BindView(R.id.breakdown2019_red_cargo_ship_cargo)          TextView redCargoShipCargo;
+    @BindView(R.id.breakdown2019_red_rocket_1_panels)           TextView redRocket1Panels;
+    @BindView(R.id.breakdown2019_red_rocket_1_cargo)            TextView redRocket1Cargo;
+    @BindView(R.id.breakdown2019_red_rocket_2_panels)           TextView redRocket2Panels;
+    @BindView(R.id.breakdown2019_red_rocket_2_cargo)            TextView redRocket2Cargo;
 
-    @Bind(R.id.breakdown2019_blue_cargo_ship_panels)        TextView blueCargoShipPanels;
-    @Bind(R.id.breakdown2019_blue_cargo_ship_null_panels)   TextView blueCargoShipNullPanels;
-    @Bind(R.id.breakdown2019_blue_cargo_ship_cargo)         TextView blueCargoShipCargo;
-    @Bind(R.id.breakdown2019_blue_rocket_1_panels)          TextView blueRocket1Panels;
-    @Bind(R.id.breakdown2019_blue_rocket_1_cargo)           TextView blueRocket1Cargo;
-    @Bind(R.id.breakdown2019_blue_rocket_2_panels)          TextView blueRocket2Panels;
-    @Bind(R.id.breakdown2019_blue_rocket_2_cargo)           TextView blueRocket2Cargo;
+    @BindView(R.id.breakdown2019_blue_cargo_ship_panels)        TextView blueCargoShipPanels;
+    @BindView(R.id.breakdown2019_blue_cargo_ship_null_panels)   TextView blueCargoShipNullPanels;
+    @BindView(R.id.breakdown2019_blue_cargo_ship_cargo)         TextView blueCargoShipCargo;
+    @BindView(R.id.breakdown2019_blue_rocket_1_panels)          TextView blueRocket1Panels;
+    @BindView(R.id.breakdown2019_blue_rocket_1_cargo)           TextView blueRocket1Cargo;
+    @BindView(R.id.breakdown2019_blue_rocket_2_panels)          TextView blueRocket2Panels;
+    @BindView(R.id.breakdown2019_blue_rocket_2_cargo)           TextView blueRocket2Cargo;
 
-    @Bind(R.id.breakdown2019_red_hatch_panel_points)        TextView redHatchPanelPoints;
-    @Bind(R.id.breakdown2019_blue_hatch_panel_points)       TextView blueHatchPanelPoints;
-    @Bind(R.id.breakdown2019_red_cargo_points)              TextView redCargoPoints;
-    @Bind(R.id.breakdown2019_blue_cargo_points)             TextView blueCargoPoints;
+    @BindView(R.id.breakdown2019_red_hatch_panel_points)        TextView redHatchPanelPoints;
+    @BindView(R.id.breakdown2019_blue_hatch_panel_points)       TextView blueHatchPanelPoints;
+    @BindView(R.id.breakdown2019_red_cargo_points)              TextView redCargoPoints;
+    @BindView(R.id.breakdown2019_blue_cargo_points)             TextView blueCargoPoints;
 
-    @Bind(R.id.breakdown2019_red_hab_robot_1)               TextView redHabRobot1;
-    @Bind(R.id.breakdown2019_blue_hab_robot_1)              TextView blueHabRobot1;
-    @Bind(R.id.breakdown2019_red_hab_robot_2)               TextView redHabRobot2;
-    @Bind(R.id.breakdown2019_blue_hab_robot_2)              TextView blueHabRobot2;
-    @Bind(R.id.breakdown2019_red_hab_robot_3)               TextView redHabRobot3;
-    @Bind(R.id.breakdown2019_blue_hab_robot_3)              TextView blueHabRobot3;
-    @Bind(R.id.breakdown2019_hab_total_red)                 TextView redHabTotal;
-    @Bind(R.id.breakdown2019_hab_total_blue)                TextView blueHabTotal;
+    @BindView(R.id.breakdown2019_red_hab_robot_1)               TextView redHabRobot1;
+    @BindView(R.id.breakdown2019_blue_hab_robot_1)              TextView blueHabRobot1;
+    @BindView(R.id.breakdown2019_red_hab_robot_2)               TextView redHabRobot2;
+    @BindView(R.id.breakdown2019_blue_hab_robot_2)              TextView blueHabRobot2;
+    @BindView(R.id.breakdown2019_red_hab_robot_3)               TextView redHabRobot3;
+    @BindView(R.id.breakdown2019_blue_hab_robot_3)              TextView blueHabRobot3;
+    @BindView(R.id.breakdown2019_hab_total_red)                 TextView redHabTotal;
+    @BindView(R.id.breakdown2019_hab_total_blue)                TextView blueHabTotal;
 
-    @Bind(R.id.breakdown_teleop_total_red)                  TextView redTeleopTotal;
-    @Bind(R.id.breakdown_teleop_total_blue)                 TextView blueTeleopTotal;
+    @BindView(R.id.breakdown_teleop_total_red)                  TextView redTeleopTotal;
+    @BindView(R.id.breakdown_teleop_total_blue)                 TextView blueTeleopTotal;
 
-    @Bind(R.id.breakdown2019_red_complete_rocket)           TextView redCompleteRocket;
-    @Bind(R.id.breakdown2019_blue_complete_rocket)          TextView blueCompleteRocket;
-    @Bind(R.id.breakdown2019_red_hab_docking)               TextView redHabDocking;
-    @Bind(R.id.breakdown2019_blue_hab_docking)              TextView blueHabDocking;
+    @BindView(R.id.breakdown2019_red_complete_rocket)           TextView redCompleteRocket;
+    @BindView(R.id.breakdown2019_blue_complete_rocket)          TextView blueCompleteRocket;
+    @BindView(R.id.breakdown2019_red_hab_docking)               TextView redHabDocking;
+    @BindView(R.id.breakdown2019_blue_hab_docking)              TextView blueHabDocking;
 
-    @Bind(R.id.breakdown_fouls_red)                         TextView foulsRed;
-    @Bind(R.id.breakdown_fouls_blue)                        TextView foulsBlue;
-    @Bind(R.id.breakdown_adjust_red)                        TextView adjustRed;
-    @Bind(R.id.breakdown_adjust_blue)                       TextView adjustBlue;
-    @Bind(R.id.breakdown_total_red)                         TextView totalRed;
-    @Bind(R.id.breakdown_total_blue)                        TextView totalBlue;
-    @Bind(R.id.breakdown_red_rp)                            TextView rpRed;
-    @Bind(R.id.breakdown_blue_rp)                           TextView rpBlue;
-    @Bind(R.id.breakdown_rp_header)                         TextView rpHeader;
+    @BindView(R.id.breakdown_fouls_red)                         TextView foulsRed;
+    @BindView(R.id.breakdown_fouls_blue)                        TextView foulsBlue;
+    @BindView(R.id.breakdown_adjust_red)                        TextView adjustRed;
+    @BindView(R.id.breakdown_adjust_blue)                       TextView adjustBlue;
+    @BindView(R.id.breakdown_total_red)                         TextView totalRed;
+    @BindView(R.id.breakdown_total_blue)                        TextView totalBlue;
+    @BindView(R.id.breakdown_red_rp)                            TextView rpRed;
+    @BindView(R.id.breakdown_blue_rp)                           TextView rpBlue;
+    @BindView(R.id.breakdown_rp_header)                         TextView rpHeader;
 
     private Resources mResources;
 


### PR DESCRIPTION
**Summary:** 
We were on Butterknife 7.0.1, the latest is 10.1.0.

Butterknife 8 changed the annotation names, and also started providing its own Proguard rules (so we don't need to include them ourselves). `Butterknife.unbind()` was also removed- now `Butterknife.bind()` returns an `Unbinder` instance.

Butterknife 9 & 10 also bring AndroidX support, getting us closer to dropping Jetifier.

**Test Plan:** 
Did a few laps through the app checking for any issues, but as expected the upgrade was fairly smooth.