### PR TITLE
Set compatibility level to Java 8, remove retrolambda

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,15 +28,9 @@ buildscript {
         // auto-push releases
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
 
-        // Retrolambda + Lint fixes
-        classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
-
         // Automated Screenshot Testing
         classpath 'com.facebook.testing.screenshot:plugin:0.5.0'
     }
-
-    // Exclude the linter version that the android plugin depends on.
-    configurations.classpath.exclude group: 'com.android.tools.external.lombok'
 }
 
 allprojects {
@@ -48,8 +42,8 @@ allprojects {
     }
 
     tasks.withType(JavaCompile) {
-        sourceCompatibility = "1.7"
-        targetCompatibility = "1.7"
+        sourceCompatibility = "1.8"
+        targetCompatibility = "1.8"
     }
 
     ext {

--- a/libTba/build.gradle
+++ b/libTba/build.gradle
@@ -5,8 +5,8 @@ group = 'com.appspot.tbatv_prod_hrd'
 archivesBaseName = 'tbaMobile'
 version = 'v9-1.21.0-SNAPSHOT'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 task sourceJar(type: Jar) {
   classifier = 'sources'


### PR DESCRIPTION
**Summary:** 
We can use many Java 8 language features (like lambdas) thanks to the Android Gradle Plugin's desugaring. We no longer need retrolambda (but it wasn't actually being applied anyway, so I'm just removing dead code).

**Test Plan:** 
There really wasn't much of a change here, but everything still compiles and seems to run fine.
