### PR TITLE
Fix URL for viewing Event photos on Chief Delphi

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/binders/EventInfoBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/EventInfoBinder.java
@@ -169,7 +169,7 @@ public class EventInfoBinder extends AbstractDataBinder<EventInfoBinder.Model> {
         eventYoutubeTitle.setText(mActivity.getString(R.string.view_event_youtube, data.eventKey));
         eventYoutubeContainer.setOnClickListener(mSocialClickListener);
 
-        eventCdContainer.setTag("http://www.chiefdelphi.com/media/photos/tags/" + data.eventKey);
+        eventCdContainer.setTag("https://www.chiefdelphi.com/search?q=category%3A11%20tags%3A" + data.eventKey);
         eventCdContainer.setOnClickListener(mSocialClickListener);
 
         if (data.isLive && data.webcasts != null && data.webcasts.size() > 0) {


### PR DESCRIPTION
Fix Chief Delphi link for seeing photos for an event (see changes from https://github.com/the-blue-alliance/the-blue-alliance-ios/pull/420)