### PR TITLE
Migrate team list to ViewPager2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -230,6 +230,8 @@ dependencies {
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.viewpager2:viewpager2:1.0.0-rc01'
+    implementation 'com.google.android.material:material:1.2.0-alpha01'
 
     // Play Services Libraries
     // See http://developer.android.com/google/play-services/setup.html

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.google.android.material:material:1.0.0'
-    implementation 'androidx.viewpager2:viewpager2:1.0.0-rc01'
+    implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'com.google.android.material:material:1.2.0-alpha01'
 
     // Play Services Libraries

--- a/android/src/main/java/com/thebluealliance/androidclient/adapters/TeamListFragmentPagerAdapter.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/adapters/TeamListFragmentPagerAdapter.java
@@ -14,8 +14,8 @@ public class TeamListFragmentPagerAdapter extends FragmentStateAdapter {
 
     private int pageCount;
 
-    public TeamListFragmentPagerAdapter(@NonNull FragmentActivity fragmentActivity) {
-        super(fragmentActivity);
+    public TeamListFragmentPagerAdapter(@NonNull Fragment parentFragment) {
+        super(parentFragment);
     }
 
     public void setMaxTeamNumber(int maxTeamNumber) {

--- a/android/src/main/java/com/thebluealliance/androidclient/adapters/TeamListFragmentPagerAdapter.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/adapters/TeamListFragmentPagerAdapter.java
@@ -1,43 +1,38 @@
 package com.thebluealliance.androidclient.adapters;
 
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentPagerAdapter;
-
 import com.thebluealliance.androidclient.TbaLogger;
 import com.thebluealliance.androidclient.fragments.TeamListFragment;
 
-public class TeamListFragmentPagerAdapter extends FragmentPagerAdapter {
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
+
+public class TeamListFragmentPagerAdapter extends FragmentStateAdapter {
 
     private static final int TEAMS_PER_TAB = 1000;
 
-    private int mCount;
+    private int pageCount;
 
-    public TeamListFragmentPagerAdapter(FragmentManager fm, int largestTeamNumber) {
-        super(fm);
-        mCount = (largestTeamNumber / TEAMS_PER_TAB) + 1;
-        TbaLogger.d("LARGEST TEAM: " + largestTeamNumber);
-        TbaLogger.d("USING " + mCount + " PAGES");
+    public TeamListFragmentPagerAdapter(@NonNull FragmentActivity fragmentActivity) {
+        super(fragmentActivity);
     }
 
-    @Override
-    public CharSequence getPageTitle(int position) {
-        switch (position) {
-            case 0:
-                return "1-999";
-            default:
-                return (position * 1000) + "-" + ((position * 1000) + 999);
-        }
-
+    public void setMaxTeamNumber(int maxTeamNumber) {
+        pageCount = (maxTeamNumber / TEAMS_PER_TAB) + 1;
+        TbaLogger.d("LARGEST TEAM: " + maxTeamNumber);
+        TbaLogger.d("USING " + pageCount + " PAGES");
+        notifyDataSetChanged();
     }
 
+    @NonNull
     @Override
-    public int getCount() {
-        return mCount;
-    }
-
-    @Override
-    public Fragment getItem(int position) {
+    public Fragment createFragment(int position) {
         return TeamListFragment.newInstance(position * 1000);
+    }
+
+    @Override
+    public int getItemCount() {
+        return pageCount;
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
@@ -20,18 +20,18 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
 
     private Integer oldData;
     private Unbinder unbinder;
-    private int mInitialTab;
+    private int initialTab;
     private TeamListFragmentPagerAdapter adapter;
     private TabLayoutMediator tabLayoutMediator;
 
     @Inject
     public TeamTabBinder() {
         super();
-        mInitialTab = 0;
+        initialTab = 0;
     }
 
     public void setInitialTab(int initialTab) {
-        mInitialTab = initialTab;
+        this.initialTab = initialTab;
     }
 
     public void setupAdapter() {
@@ -62,7 +62,7 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
          */
         viewPager.post(() -> {
             adapter.setMaxTeamNumber(data == null ? 0 : data);
-            viewPager.setCurrentItem(mInitialTab);
+            viewPager.setCurrentItem(initialTab);
         });
 
         oldData = data;

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
@@ -1,26 +1,27 @@
 package com.thebluealliance.androidclient.binders;
 
-import androidx.annotation.Nullable;
-import androidx.fragment.app.FragmentManager;
-import androidx.viewpager.widget.ViewPager;
-
-import butterknife.Unbinder;
+import com.google.android.material.tabs.TabLayout;
+import com.google.android.material.tabs.TabLayoutMediator;
 import com.thebluealliance.androidclient.adapters.TeamListFragmentPagerAdapter;
-import com.thebluealliance.androidclient.views.SlidingTabs;
 
 import javax.inject.Inject;
 
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager2.widget.ViewPager2;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 public class TeamTabBinder extends AbstractDataBinder<Integer> {
 
-    public ViewPager viewPager;
-    public SlidingTabs tabs;
-    public FragmentManager fragmentManager;
+    public ViewPager2 viewPager;
+    public TabLayout tabs;
+    public FragmentActivity fragmentActivity;
 
     private Integer oldData;
     private Unbinder unbinder;
     private int mInitialTab;
+    private TeamListFragmentPagerAdapter adapter;
 
     @Inject
     public TeamTabBinder() {
@@ -30,6 +31,20 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
 
     public void setInitialTab(int initialTab) {
         mInitialTab = initialTab;
+    }
+
+    public void setupAdapter() {
+        adapter = new TeamListFragmentPagerAdapter(fragmentActivity);
+        viewPager.setAdapter(adapter);
+        new TabLayoutMediator(tabs, viewPager, (tab, position) -> {
+            switch (position) {
+                case 0:
+                    tab.setText("1-999");
+                default: {
+                    String title = (position * 1000) + "-" + ((position * 1000) + 999);
+                    tab.setText(title);
+                }
+        }}).attach();
     }
 
     @Override
@@ -44,8 +59,7 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
          * So set the view pager's adapter in another thread to avoid a race condition, or something.
          */
         viewPager.post(() -> {
-            viewPager.setAdapter(new TeamListFragmentPagerAdapter(fragmentManager, data == null ? 0 : data));
-            tabs.setViewPager(viewPager);
+            adapter.setMaxTeamNumber(data == null ? 0 : data);
             viewPager.setCurrentItem(mInitialTab);
         });
 

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
@@ -1,6 +1,8 @@
 package com.thebluealliance.androidclient.binders;
 
-import android.util.Log;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
@@ -8,10 +10,6 @@ import com.thebluealliance.androidclient.adapters.TeamListFragmentPagerAdapter;
 
 import javax.inject.Inject;
 
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.viewpager2.widget.ViewPager2;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
 

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
@@ -83,8 +83,8 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
     @Override
     public void unbind(boolean unbindViews) {
         super.unbind(unbindViews);
-        tabLayoutMediator.detach();
         if (unbindViews && unbinder != null) {
+            tabLayoutMediator.detach();
             unbinder.unbind();
         }
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
@@ -22,6 +22,7 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
     private Unbinder unbinder;
     private int mInitialTab;
     private TeamListFragmentPagerAdapter adapter;
+    private TabLayoutMediator tabLayoutMediator;
 
     @Inject
     public TeamTabBinder() {
@@ -36,7 +37,7 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
     public void setupAdapter() {
         adapter = new TeamListFragmentPagerAdapter(fragmentActivity);
         viewPager.setAdapter(adapter);
-        new TabLayoutMediator(tabs, viewPager, (tab, position) -> {
+        tabLayoutMediator = new TabLayoutMediator(tabs, viewPager, (tab, position) -> {
             switch (position) {
                 case 0:
                     tab.setText("1-999");
@@ -44,7 +45,8 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
                     String title = (position * 1000) + "-" + ((position * 1000) + 999);
                     tab.setText(title);
                 }
-        }}).attach();
+        }});
+        tabLayoutMediator.attach();
     }
 
     @Override
@@ -79,6 +81,7 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
     @Override
     public void unbind(boolean unbindViews) {
         super.unbind(unbindViews);
+        tabLayoutMediator.detach();
         if (unbindViews && unbinder != null) {
             unbinder.unbind();
         }

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/TeamTabBinder.java
@@ -1,5 +1,7 @@
 package com.thebluealliance.androidclient.binders;
 
+import android.util.Log;
+
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 import com.thebluealliance.androidclient.adapters.TeamListFragmentPagerAdapter;
@@ -7,6 +9,7 @@ import com.thebluealliance.androidclient.adapters.TeamListFragmentPagerAdapter;
 import javax.inject.Inject;
 
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.viewpager2.widget.ViewPager2;
 import butterknife.ButterKnife;
@@ -16,7 +19,7 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
 
     public ViewPager2 viewPager;
     public TabLayout tabs;
-    public FragmentActivity fragmentActivity;
+    public Fragment parentFragment;
 
     private Integer oldData;
     private Unbinder unbinder;
@@ -35,8 +38,9 @@ public class TeamTabBinder extends AbstractDataBinder<Integer> {
     }
 
     public void setupAdapter() {
-        adapter = new TeamListFragmentPagerAdapter(fragmentActivity);
+        adapter = new TeamListFragmentPagerAdapter(parentFragment);
         viewPager.setAdapter(adapter);
+
         tabLayoutMediator = new TabLayoutMediator(tabs, viewPager, (tab, position) -> {
             switch (position) {
                 case 0:

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/AllTeamsListFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/AllTeamsListFragment.java
@@ -2,25 +2,26 @@ package com.thebluealliance.androidclient.fragments;
 
 
 import android.os.Bundle;
-import androidx.core.view.ViewCompat;
-import androidx.viewpager.widget.ViewPager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.google.android.material.tabs.TabLayout;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.binders.TeamTabBinder;
 import com.thebluealliance.androidclient.subscribers.TeamTabSubscriber;
-import com.thebluealliance.androidclient.views.SlidingTabs;
 
+import androidx.core.view.ViewCompat;
+import androidx.viewpager2.widget.MarginPageTransformer;
+import androidx.viewpager2.widget.ViewPager2;
 import rx.Observable;
 
 public class AllTeamsListFragment extends DatafeedFragment<Integer, Integer, TeamTabSubscriber, TeamTabBinder> {
 
     public static final String SELECTED_TAB = "selected_tab";
 
-    private ViewPager mViewPager;
+    private ViewPager2 mViewPager;
     private int mInitialTab;
 
     public static AllTeamsListFragment newInstance(int tab) {
@@ -47,18 +48,21 @@ public class AllTeamsListFragment extends DatafeedFragment<Integer, Integer, Tea
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View v = inflater.inflate(R.layout.fragment_team_list_fragment_pager, container, false);
-        mViewPager = (ViewPager) v.findViewById(R.id.team_pager);
+        mViewPager = v.findViewById(R.id.team_pager);
         // Make this ridiculously big
         mViewPager.setOffscreenPageLimit(50);
-        mViewPager.setPageMargin(Utilities.getPixelsFromDp(getActivity(), 16));
+        int pageMargin = Utilities.getPixelsFromDp(requireActivity(), 16);
+        mViewPager.setPageTransformer(new MarginPageTransformer(pageMargin));
         mBinder.setInitialTab(mInitialTab);
 
-        SlidingTabs tabs = (SlidingTabs) v.findViewById(R.id.team_pager_tabs);
+        TabLayout tabs = v.findViewById(R.id.team_pager_tabs);
         ViewCompat.setElevation(tabs, getResources().getDimension(R.dimen.toolbar_elevation));
 
+
         mBinder.viewPager = mViewPager;
-        mBinder.fragmentManager = getChildFragmentManager();
+        mBinder.fragmentActivity = requireActivity();
         mBinder.tabs = tabs;
+        mBinder.setupAdapter();
 
         return v;
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/AllTeamsListFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/AllTeamsListFragment.java
@@ -50,8 +50,6 @@ public class AllTeamsListFragment extends DatafeedFragment<Integer, Integer, Tea
         // Inflate the layout for this fragment
         View v = inflater.inflate(R.layout.fragment_team_list_fragment_pager, container, false);
         mViewPager = v.findViewById(R.id.team_pager);
-        // Make this ridiculously big
-        mViewPager.setOffscreenPageLimit(50);
         int pageMargin = Utilities.getPixelsFromDp(requireActivity(), 16);
         mViewPager.setPageTransformer(new MarginPageTransformer(pageMargin));
         mBinder.setInitialTab(mInitialTab);

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/AllTeamsListFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/AllTeamsListFragment.java
@@ -6,17 +6,16 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.core.view.ViewCompat;
+import androidx.viewpager2.widget.MarginPageTransformer;
+import androidx.viewpager2.widget.ViewPager2;
+
 import com.google.android.material.tabs.TabLayout;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.binders.TeamTabBinder;
 import com.thebluealliance.androidclient.subscribers.TeamTabSubscriber;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.view.ViewCompat;
-import androidx.viewpager2.widget.MarginPageTransformer;
-import androidx.viewpager2.widget.ViewPager2;
 import rx.Observable;
 
 public class AllTeamsListFragment extends DatafeedFragment<Integer, Integer, TeamTabSubscriber, TeamTabBinder> {
@@ -59,7 +58,6 @@ public class AllTeamsListFragment extends DatafeedFragment<Integer, Integer, Tea
 
         TabLayout tabs = v.findViewById(R.id.team_pager_tabs);
         ViewCompat.setElevation(tabs, getResources().getDimension(R.dimen.toolbar_elevation));
-
 
         mBinder.viewPager = mViewPager;
         mBinder.parentFragment = this;

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/AllTeamsListFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/AllTeamsListFragment.java
@@ -12,6 +12,8 @@ import com.thebluealliance.androidclient.Utilities;
 import com.thebluealliance.androidclient.binders.TeamTabBinder;
 import com.thebluealliance.androidclient.subscribers.TeamTabSubscriber;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
 import androidx.viewpager2.widget.MarginPageTransformer;
 import androidx.viewpager2.widget.ViewPager2;
@@ -60,7 +62,7 @@ public class AllTeamsListFragment extends DatafeedFragment<Integer, Integer, Tea
 
 
         mBinder.viewPager = mViewPager;
-        mBinder.fragmentActivity = requireActivity();
+        mBinder.parentFragment = this;
         mBinder.tabs = tabs;
         mBinder.setupAdapter();
 

--- a/android/src/main/res/layout/fragment_team_list_fragment_pager.xml
+++ b/android/src/main/res/layout/fragment_team_list_fragment_pager.xml
@@ -5,13 +5,14 @@
     android:orientation="vertical"
     tools:context="com.thebluealliance.androidclient.fragments.EventsByWeekFragment">
 
-    <com.thebluealliance.androidclient.views.SlidingTabs
+    <com.google.android.material.tabs.TabLayout
         android:id="@+id/team_pager_tabs"
         android:layout_width="match_parent"
         android:layout_height="48dp"
-        android:background="@color/primary" />
+        android:background="@color/primary"
+        style="@style/TabBar"/>
 
-    <androidx.viewpager.widget.ViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/team_pager"
         android:layout_width="match_parent"
         android:layout_height="fill_parent" />

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -173,7 +173,9 @@
     <style name="TextAppearance.TabTitle">
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>
-        <item name="android:textColor">@color/white</item>
+        <item name="android:textColor">@color/tab_indicator_text_color</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:textAllCaps">true</item>
     </style>
 
     <!-- Used for the checkboxes in the gameday ticker filterer -->

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -162,6 +162,20 @@
         <item name="android:background">?android:attr/selectableItemBackground</item>
     </style>
 
+    <style name="TabBar">
+        <item name="tabMode">scrollable</item>
+        <item name="tabIndicatorColor">@color/white</item>
+        <item name="tabTextAppearance">@style/TextAppearance.TabTitle</item>
+    </style>
+
+    <style name="TextAppearance" parent="TextAppearance.AppCompat" />
+
+    <style name="TextAppearance.TabTitle">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/white</item>
+    </style>
+
     <!-- Used for the checkboxes in the gameday ticker filterer -->
 
     <style name="GamedayTickerCheckboxUpcomingMatch" parent="Theme.AppCompat.Light">

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 01 21:37:58 CDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
**Summary:** 
ViewPager2 has been released! ViewPager2 is a re-write of ViewPager that now leverages `RecyclerView` to manage its pages.

This means that updating the number of pages and the content in the tabs is much easier, and we can resolve #706 .

This PR moves only the team list to ViewPager2. Future PRs will move other screens.
The initial work involved was twofold: First, pulling in ViewPager2 and doing the work of replacing the existing ViewPager, and second matching the styling of the new tab strip to the old one.

**Issues Reference:** 
#706 - Dynamic tab strips

**Test Plan:** 
Manually tested on a variety of devices. I also manually overrode our data loading to simulate loading additional/fewer teams to verify that the tabs and their contents updated appropriately. Seems to be working!

**Screenshots:**
Here's a screenshot to prove that the new tabs look the same as they did before!
![teams_new](https://user-images.githubusercontent.com/3267925/69444182-6ea4f480-0d15-11ea-9dd8-891551e7b090.png)

