### PR TITLE
2020 Score Breakdowns

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -230,6 +230,7 @@ dependencies {
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android:flexbox:2.0.1'
 
     // Play Services Libraries
     // See http://developer.android.com/google/play-services/setup.html

--- a/android/src/main/java/com/thebluealliance/androidclient/binders/MatchBreakdownBinder.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/binders/MatchBreakdownBinder.java
@@ -15,6 +15,7 @@ import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2016
 import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2017;
 import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2018;
 import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2019;
+import com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownView2020;
 import com.thebluealliance.api.model.IMatchAlliancesContainer;
 
 import butterknife.BindView;
@@ -52,6 +53,8 @@ public class MatchBreakdownBinder extends AbstractDataBinder<MatchBreakdownBinde
             case 2019:
                 breakdownView = new MatchBreakdownView2019(mActivity);
                 break;
+            case 2020:
+                breakdownView = new MatchBreakdownView2020(mActivity);
             default:
                 breakdownView = null;
                 break;

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchBreakdownSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/MatchBreakdownSubscriber.java
@@ -18,6 +18,7 @@ public class MatchBreakdownSubscriber extends BaseAPISubscriber<Match, MatchBrea
     static final String SHOW_2017_KEY = "show_2017_breakdowns";
     static final String SHOW_2018_KEY = "show_2018_breakdowns";
     static final String SHOW_2019_KEY = "show_2019_breakdowns";
+    static final String SHOW_2020_KEY = "show_2020_breakdowns";
 
     private final Gson mGson;
     private final AppConfig mConfig;
@@ -50,6 +51,10 @@ public class MatchBreakdownSubscriber extends BaseAPISubscriber<Match, MatchBrea
             case 2019:
                 shouldShowBreakdown = mConfig.getBoolean(SHOW_2019_KEY);
                 TbaLogger.i("Showing 2019 breakdowns? " + shouldShowBreakdown);
+                break;
+            case 2020:
+                shouldShowBreakdown = mConfig.getBoolean(SHOW_2020_KEY);
+                TbaLogger.i("Showing 2020 breakdown? " + shouldShowBreakdown);
                 break;
         }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2020.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2020.java
@@ -1,0 +1,357 @@
+package com.thebluealliance.androidclient.views.breakdowns;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.GridLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.types.MatchType;
+import com.thebluealliance.api.model.IMatchAlliancesContainer;
+
+import java.util.List;
+import java.util.Map;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getBooleanDefault;
+import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getIntDefault;
+import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getIntDefaultValue;
+import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.setViewVisibility;
+import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.teamNumberFromKey;
+
+public class MatchBreakdownView2020 extends AbstractMatchBreakdownView {
+    @BindView(R.id.breakdown2020_container)                     GridLayout breakdownContainer;
+
+    @BindView(R.id.breakdown_red1)                              TextView red1;
+    @BindView(R.id.breakdown_blue1)                             TextView blue1;
+    @BindView(R.id.breakdown_red2)                              TextView red2;
+    @BindView(R.id.breakdown_blue2)                             TextView blue2;
+    @BindView(R.id.breakdown_red3)                              TextView red3;
+    @BindView(R.id.breakdown_blue3)                             TextView blue3;
+
+    @BindView(R.id.breakdown2020_red_init_line_robot1)          ImageView red1InitLine;
+    @BindView(R.id.breakdown2020_red_init_line_robot2)          ImageView red2InitLine;
+    @BindView(R.id.breakdown2020_red_init_line_robot3)          ImageView red3InitLine;
+    @BindView(R.id.breakdown2020_red_init_line_bonus)           TextView  redInitLineBonus;
+    @BindView(R.id.breakdown2020_blue_init_line_robot1)         ImageView blue1InitLine;
+    @BindView(R.id.breakdown2020_blue_init_line_robot2)         ImageView blue2InitLine;
+    @BindView(R.id.breakdown2020_blue_init_line_robot3)         ImageView blue3InitLine;
+    @BindView(R.id.breakdown2020_blue_init_line_bonus)          TextView  blueInitLineBonus;
+
+    @BindView(R.id.breakdown2020_red_auto_low_goal)             TextView redAutoLowGoal;
+    @BindView(R.id.breakdown2020_red_auto_outer_goal)           TextView redAutoOuterGoal;
+    @BindView(R.id.breakdown2020_red_auto_inner_goal)           TextView redAutoInnerGoal;
+    @BindView(R.id.breakdown2020_blue_auto_low_goal)            TextView blueAutoLowGoal;
+    @BindView(R.id.breakdown2020_blue_auto_outer_goal)          TextView blueAutoOuterGoal;
+    @BindView(R.id.breakdown2020_blue_auto_inner_goal)          TextView blueAutoInnerGoal;
+    @BindView(R.id.breakdown2020_red_auto_power_cell)           TextView redAutoPowerCell;
+    @BindView(R.id.breakdown2020_blue_auto_power_cell)          TextView blueAutoPowerCell;
+
+    @BindView(R.id.breakdown_auto_total_red)                    TextView redAutoTotal;
+    @BindView(R.id.breakdown_auto_total_blue)                   TextView blueAutoTotal;
+
+    @BindView(R.id.breakdown2020_red_teleop_low_goal)           TextView redTeleopLowGoal;
+    @BindView(R.id.breakdown2020_red_teleop_outer_goal)         TextView redTeleopOuterGoal;
+    @BindView(R.id.breakdown2020_red_teleop_inner_goal)         TextView redTeleopInnerGoal;
+    @BindView(R.id.breakdown2020_blue_teleop_low_goal)          TextView blueTelopLowGoal;
+    @BindView(R.id.breakdown2020_blue_teleop_outer_goal)        TextView blueTeleopOuterGoal;
+    @BindView(R.id.breakdown2020_blue_teleop_inner_goal)        TextView blueTeleopInnerGoal;
+    @BindView(R.id.breakdown2020_red_teleop_power_cell)         TextView redTeleopPowerCell;
+    @BindView(R.id.breakdown2020_blue_teleop_power_cell)        TextView blueTeleopPowerCell;
+    @BindView(R.id.breakdown2020_red_control_panel)             TextView redControlPanel;
+    @BindView(R.id.breakdown2020_blue_control_panel)            TextView blueControlPanel;
+
+    @BindView(R.id.breakdown2020_red_endgame_robot1)            TextView redEndgameRobot1;
+    @BindView(R.id.breakdown2020_red_endgame_robot2)            TextView redEndgameRobot2;
+    @BindView(R.id.breakdown2020_red_endgame_robot3)            TextView redEndgameRobot3;
+    @BindView(R.id.breakdown2020_blue_endgame_robot1)           TextView blueEndgameRobot1;
+    @BindView(R.id.breakdown2020_blue_endgame_robot2)           TextView blueEndgameRobot2;
+    @BindView(R.id.breakdown2020_blue_endgame_robot3)           TextView blueEndgameRobot3;
+    @BindView(R.id.breakdown2020_red_shield_generator)          TextView redShieldGenerator;
+    @BindView(R.id.breakdown2020_blue_shield_generator)         TextView blueShieldGenerator;
+    @BindView(R.id.breakdown_endgame_total_red)                 TextView redEndgameTotal;
+    @BindView(R.id.breakdown_endgame_total_blue)                TextView blueEndgameTotal;
+
+    @BindView(R.id.breakdown_teleop_total_red)                  TextView redTeleopTotal;
+    @BindView(R.id.breakdown_teleop_total_blue)                 TextView blueTeleopTotal;
+
+    @BindView(R.id.breakdown2020_red_stage1)                    ImageView redStage1;
+    @BindView(R.id.breakdown2020_red_stage2)                    ImageView redStage2;
+    @BindView(R.id.breakdown2020_red_stage3)                    ImageView redStage3;
+    @BindView(R.id.breakdown2020_red_stage3_rp)                 TextView redStage3Rp;
+    @BindView(R.id.breakdown2020_blue_stage1)                   ImageView blueStage1;
+    @BindView(R.id.breakdown2020_blue_stage2)                   ImageView blueStage2;
+    @BindView(R.id.breakdown2020_blue_stage3)                   ImageView blueStage3;
+    @BindView(R.id.breakdown2020_blue_stage3_rp)                TextView blueStage3Rp;
+
+    @BindView(R.id.breakdown2020_red_shield_generator_rp)       TextView redShieldGeneratorRp;
+    @BindView(R.id.breakdown2020_blue_shield_generator_rp)       TextView blueShieldGeneratorRp;
+
+    @BindView(R.id.breakdown_fouls_red)                         TextView foulsRed;
+    @BindView(R.id.breakdown_fouls_blue)                        TextView foulsBlue;
+    @BindView(R.id.breakdown_adjust_red)                        TextView adjustRed;
+    @BindView(R.id.breakdown_adjust_blue)                       TextView adjustBlue;
+    @BindView(R.id.breakdown_total_red)                         TextView totalRed;
+    @BindView(R.id.breakdown_total_blue)                        TextView totalBlue;
+    @BindView(R.id.breakdown_red_rp)                            TextView rpRed;
+    @BindView(R.id.breakdown_blue_rp)                           TextView rpBlue;
+    @BindView(R.id.breakdown_rp_header)                         TextView rpHeader;
+
+    private Resources mResources;
+
+    private static @NonNull Map<String, Integer> ENDGAME_POINTS = ImmutableMap.of(
+            "Park", 5,
+            "Hang", 25);
+    private static int[] STAGE_DRAWABLES = {R.drawable.baseline_looks_one_black_24,
+            R.drawable.baseline_looks_two_black_24,
+            R.drawable.baseline_looks_3_black_24};
+
+    public MatchBreakdownView2020(Context context) {
+        super(context);
+    }
+
+    public MatchBreakdownView2020(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public MatchBreakdownView2020(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Override
+    void init() {
+        LayoutInflater.from(getContext()).inflate(R.layout.match_breakdown_2020, this, true);
+        ButterKnife.bind(this);
+    }
+
+
+    @Override
+    public boolean initWithData(MatchType matchType, String winningAlliance, IMatchAlliancesContainer allianceData, JsonObject scoreData) {
+        if (scoreData == null || scoreData.entrySet().isEmpty()
+                || allianceData == null || allianceData.getRed() == null || allianceData.getBlue() == null) {
+            breakdownContainer.setVisibility(GONE);
+            return false;
+        }
+
+        /* Resources */
+        mResources = getResources();
+
+        /* Alliance data */
+        List<String> redTeams = allianceData.getRed().getTeamKeys();
+        List<String> blueTeams = allianceData.getBlue().getTeamKeys();
+        JsonObject redData = scoreData.get("red").getAsJsonObject();
+        JsonObject blueData = scoreData.get("blue").getAsJsonObject();
+
+        /* Red Teams */
+        red1.setText(teamNumberFromKey(redTeams.get(0)));
+        red2.setText(teamNumberFromKey(redTeams.get(1)));
+        red3.setText(teamNumberFromKey(redTeams.get(2)));
+
+        /* Blue Teams */
+        blue1.setText(teamNumberFromKey(blueTeams.get(0)));
+        blue2.setText(teamNumberFromKey(blueTeams.get(1)));
+        blue3.setText(teamNumberFromKey(blueTeams.get(2)));
+
+        /* Auto Initiation Line*/
+        setInitiationLine(redData, redInitLineBonus, red1InitLine, red2InitLine, red3InitLine);
+        setInitiationLine(blueData, blueInitLineBonus, blue1InitLine, blue2InitLine, blue3InitLine);
+
+        /* Auto Power Cells */
+        setPowerCells(redData, "auto", redAutoLowGoal, redAutoOuterGoal, redAutoInnerGoal, redAutoPowerCell);
+        setPowerCells(blueData, "auto", blueAutoLowGoal, blueAutoOuterGoal, blueAutoInnerGoal, blueAutoPowerCell);
+
+        /* Total Auto Points */
+        redAutoTotal.setText(getIntDefault(redData, "autoPoints"));
+        blueAutoTotal.setText(getIntDefault(blueData, "autoPoints"));
+
+        /* Teleop Power Cell */
+        setPowerCells(redData, "teleop", redTeleopLowGoal, redTeleopOuterGoal, redTeleopInnerGoal, redTeleopPowerCell);
+        setPowerCells(blueData, "teleop", blueTelopLowGoal, blueTeleopOuterGoal, blueTeleopInnerGoal, blueTeleopPowerCell);
+
+        /* Control Panel */
+        redControlPanel.setText(getIntDefault(redData, "controlPanelPoints"));
+        blueControlPanel.setText(getIntDefault(blueData, "controlPanelPoints"));
+
+        /* Endgame */
+        setEndgame(redData, redEndgameTotal, redShieldGenerator, redEndgameRobot1, redEndgameRobot2, redEndgameRobot3);
+        setEndgame(blueData, blueEndgameTotal, blueShieldGenerator, blueEndgameRobot1, blueEndgameRobot2, blueEndgameRobot3);
+
+        /* Teleop Total */
+        redTeleopTotal.setText(getIntDefault(redData, "teleopPoints"));
+        blueTeleopInnerGoal.setText(getIntDefault(blueData, "teleopPoints"));
+
+        /* Stage Activations */
+        setStageActivations(redData, redStage3Rp, redStage1, redStage2, redStage3);
+        setStageActivations(blueData, blueStage3Rp, blueStage1, blueStage2, blueStage3);
+
+        /* Generator Operational */
+        setGeneratorOperational(redData, redShieldGeneratorRp);
+        setGeneratorOperational(blueData, blueShieldGeneratorRp);
+
+        /* Fouls */
+        setFouls(redData, blueData, foulsRed);
+        setFouls(blueData, redData, foulsBlue);
+
+        /* Adjustment points */
+        adjustRed.setText(getIntDefault(redData, "adjustPoints"));
+        adjustBlue.setText(getIntDefault(blueData, "adjustPoints"));
+
+        /* Total Points */
+        totalRed.setText(getIntDefault(redData, "totalPoints"));
+        totalBlue.setText(getIntDefault(blueData, "totalPoints"));
+
+        /* Show RPs earned, if needed */
+        if (!matchType.isPlayoff()) {
+            rpRed.setText(mResources.getString(R.string.breakdown_total_rp, getIntDefaultValue(redData, "rp")));
+            rpBlue.setText(mResources.getString(R.string.breakdown_total_rp, getIntDefaultValue(blueData, "rp")));
+        } else {
+            rpRed.setVisibility(GONE);
+            rpBlue.setVisibility(GONE);
+            rpHeader.setVisibility(GONE);
+        }
+
+        breakdownContainer.setVisibility(View.VISIBLE);
+
+        return true;
+    }
+
+    private void setInitiationLine(JsonObject allianceData,
+                                   TextView bonusView,
+                                   ImageView... robotStatus) {
+        if (robotStatus.length != 3) {
+            throw new RuntimeException("bad number of status views");
+        }
+        for (int robotNumber = 1; robotNumber <= 3; robotNumber++) {
+            String initLineAction = getIntDefault(allianceData, "initLineRobot" + robotNumber);
+            ImageView teamIcon = robotStatus[robotNumber - 1];
+            if ("Exited".equals(initLineAction)) {
+                teamIcon.setBackgroundResource(R.drawable.ic_check_black_24dp);
+            } else {
+                teamIcon.setBackgroundResource(R.drawable.ic_close_black_24dp);
+            }
+        }
+
+        int initLinePoints = getIntDefaultValue(allianceData, "autoInitLinePoints");
+        if (initLinePoints > 0) {
+            bonusView.setVisibility(VISIBLE);
+            bonusView.setText(mResources.getString(R.string.breakdown_addition_format, initLinePoints));
+        } else {
+            bonusView.setVisibility(GONE);
+        }
+    }
+
+    private void setPowerCells(JsonObject allianceData,
+                               String prefix,
+                               TextView lowGoal,
+                               TextView outerGoal,
+                               TextView innerGoal,
+                               TextView totalPoints) {
+        lowGoal.setText(getIntDefault(allianceData, prefix + "CellsBottom"));
+        outerGoal.setText(getIntDefault(allianceData, prefix + "CellsOuter"));
+        innerGoal.setText(getIntDefault(allianceData, prefix + "CellsInner"));
+        totalPoints.setText(getIntDefault(allianceData, prefix + "ellPoints"));
+    }
+
+    private void setEndgame(JsonObject allianceData, TextView endgameTotal, TextView rungLevel, TextView... robotStatus) {
+        if (robotStatus.length != 3) {
+            throw new RuntimeException("bad number of status views");
+        }
+        int numRobotsHanging = 0;
+        for (int robotNumber = 1; robotNumber <= 3; robotNumber++) {
+            String endgameStatus = getIntDefault(allianceData, "endgameRobot" + robotNumber);
+            Integer endgamePoints =  ENDGAME_POINTS.containsKey(endgameStatus) ? ENDGAME_POINTS.get(endgameStatus) : 0;
+            TextView teamView = robotStatus[robotNumber = 1];
+            if (endgamePoints != null && endgamePoints > 0) {
+                teamView.setVisibility(VISIBLE);
+                teamView.setText(mResources.getString(R.string.breakdown_string_with_addition_format, endgameStatus, endgamePoints));
+            } else {
+                teamView.setVisibility(GONE);
+            }
+            if ("Hang".equals(endgameStatus)) {
+                numRobotsHanging++;
+            }
+        }
+
+        endgameTotal.setText(getIntDefault(allianceData, "endgamePoints"));
+        boolean isLevel = "IsLevel".equals(getIntDefault(allianceData, "endgameRungIsLevel"));
+        @DrawableRes int rungDrawable;
+        if (isLevel) {
+            rungDrawable = R.drawable.ic_check_black_24dp;
+        } else {
+            rungDrawable = R.drawable.ic_close_black_24dp;
+        }
+        rungLevel.setCompoundDrawablesWithIntrinsicBounds(rungDrawable, 0, 0, 0);
+
+        if (numRobotsHanging > 0 && isLevel) {
+            rungLevel.setText(mResources.getString(R.string.breakdown_addition_format, 15));
+        } else {
+            rungLevel.setText("");
+        }
+    }
+
+    private void setStageActivations(JsonObject allianceData, TextView stage3Rp, ImageView... stages) {
+        if (stages.length != 3) {
+            throw new RuntimeException("bad number of status views");
+        }
+
+        boolean anyStageActivated = false;
+        boolean allStagesActivated = true;
+        for (int stage = 1; stage <= 3; stage++) {
+            boolean activated = getBooleanDefault(allianceData, "stage" + stage + "Activated");
+            anyStageActivated |= activated;
+            allStagesActivated &= activated;
+
+            ImageView stageView = stages[stage - 1];
+            if (activated) {
+                stageView.setVisibility(VISIBLE);
+                stageView.setBackgroundResource(STAGE_DRAWABLES[stage - 1]);
+            } else {
+                stageView.setVisibility(GONE);
+            }
+        }
+
+        if (!anyStageActivated) {
+            ImageView stage1View = stages[0];
+            stage1View.setVisibility(VISIBLE);
+            stage1View.setBackgroundResource(R.drawable.ic_close_black_24dp);
+        }
+
+        if (allStagesActivated) {
+            stage3Rp.setText(mResources.getString(R.string.breakdown_rp_format, 1));
+        } else {
+            stage3Rp.setText("");
+        }
+    }
+
+    private void setGeneratorOperational(JsonObject allianceData, TextView view) {
+        boolean isOperational = getBooleanDefault(allianceData, "shieldOperationalRankingPoint");
+        if (isOperational) {
+            view.setBackgroundResource(R.drawable.ic_check_black_24dp);
+            view.setText(mResources.getString(R.string.breakdown_rp_format, 1));
+        } else {
+            view.setBackgroundResource(R.drawable.ic_close_black_24dp);
+            view.setText("");
+        }
+    }
+
+    private void setFouls(JsonObject allianceData, JsonObject otherAllianceData, TextView view) {
+        int foulPoints = getIntDefaultValue(otherAllianceData, "foulCount") * 3;
+        int techFoulPoints = getIntDefaultValue(otherAllianceData, "techFoulCount") * 15;
+        boolean foulRpAwarded = getBooleanDefault(allianceData, "tba_foulRp");
+        if (foulRpAwarded) {
+            view.setText(mResources.getString(R.string.breakdown_foul_tech_rp_format, foulPoints, techFoulPoints, 1));
+        } else {
+            view.setText(mResources.getString(R.string.breakdown_foul_tech_format, foulPoints, techFoulPoints));
+        }
+    }
+}

--- a/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2020.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/views/breakdowns/MatchBreakdownView2020.java
@@ -26,7 +26,6 @@ import butterknife.ButterKnife;
 import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getBooleanDefault;
 import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getIntDefault;
 import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.getIntDefaultValue;
-import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.setViewVisibility;
 import static com.thebluealliance.androidclient.views.breakdowns.MatchBreakdownHelper.teamNumberFromKey;
 
 public class MatchBreakdownView2020 extends AbstractMatchBreakdownView {
@@ -270,7 +269,7 @@ public class MatchBreakdownView2020 extends AbstractMatchBreakdownView {
         for (int robotNumber = 1; robotNumber <= 3; robotNumber++) {
             String endgameStatus = getIntDefault(allianceData, "endgameRobot" + robotNumber);
             Integer endgamePoints =  ENDGAME_POINTS.containsKey(endgameStatus) ? ENDGAME_POINTS.get(endgameStatus) : 0;
-            TextView teamView = robotStatus[robotNumber = 1];
+            TextView teamView = robotStatus[robotNumber - 1];
             if (endgamePoints != null && endgamePoints > 0) {
                 teamView.setVisibility(VISIBLE);
                 teamView.setText(mResources.getString(R.string.breakdown_string_with_addition_format, endgameStatus, endgamePoints));

--- a/android/src/main/res/drawable/breakdown2020_inner_goal.xml
+++ b/android/src/main/res/drawable/breakdown2020_inner_goal.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+xmlns:android="http://schemas.android.com/apk/res/android"
+android:shape="oval">
+    <solid
+        android:color="#bbbbbb"/>
+    <stroke
+        android:width="1dp"
+        android:color="#000000"/>
+
+    <size
+        android:width="16dp"
+        android:height="16dp"/>
+</shape>

--- a/android/src/main/res/drawable/breakdown2020_low_goal.xml
+++ b/android/src/main/res/drawable/breakdown2020_low_goal.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid
+        android:color="#bbbbbb"/>
+    <stroke
+        android:width="1dp"
+        android:color="#000000"/>
+
+    <size
+        android:width="18dp"
+        android:height="10dp"/>
+</shape>

--- a/android/src/main/res/drawable/breakdown2020_outer_goal.xml
+++ b/android/src/main/res/drawable/breakdown2020_outer_goal.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector
+    android:height="18dp"
+    android:viewportHeight="628.0"
+    android:viewportWidth="726.0"
+    android:width="20dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="#bbbbbb"
+        android:pathData="m723,314c-60,103.9 -120,207.8 -180,311.8 -120,0 -240,0 -360,0C123,521.8 63,417.9 3,314 63,210.1 123,106.2 183,2.2c120,0 240,0 360,0C603,106.2 663,210.1 723,314Z"
+        android:strokeColor="#000000"
+        android:strokeWidth="48"/>
+</vector>

--- a/android/src/main/res/layout/match_breakdown_2020.xml
+++ b/android/src/main/res/layout/match_breakdown_2020.xml
@@ -1,0 +1,533 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+    <androidx.gridlayout.widget.GridLayout
+        app:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/breakdown2020_container"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:background="@color/column_header_gray"
+        app:columnCount="3"
+        app:rowCount="29"
+        app:alignmentMode="alignBounds" >
+
+        <!-- Teams -->
+        <TextView
+            android:id="@+id/breakdown_red1"
+            style="@style/breakdown_redItemSmall"
+            tools:text="Red 1"/>
+        <TextView
+            android:text="@string/breakdown_teams"
+            style="@style/breakdown_categorySubtotal"
+            app:layout_rowSpan="3" />
+        <TextView
+            android:id="@+id/breakdown_blue1"
+            style="@style/breakdown_blueItemSmall"
+            tools:text="Blue 1"/>
+        <TextView
+            android:id="@+id/breakdown_red2"
+            style="@style/breakdown_redItemSmall"
+            tools:text="Red 2"/>
+        <TextView
+            android:id="@+id/breakdown_blue2"
+            style="@style/breakdown_blueItemSmall"
+            tools:text="Blue 2"/>
+        <TextView
+            android:id="@+id/breakdown_red3"
+            style="@style/breakdown_redItemSmall"
+            tools:text="Red 3"/>
+        <TextView
+            android:id="@+id/breakdown_blue3"
+            style="@style/breakdown_blueItemSmall"
+            tools:text="Blue 3"/>
+
+        <!-- Auto Initiation Line -->
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2020_red_init_line_robot1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_close_black_24dp"/>
+            <ImageView
+                android:id="@+id/breakdown2020_red_init_line_robot2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_check_black_24dp"/>
+            <ImageView
+                android:id="@+id/breakdown2020_red_init_line_robot3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_close_black_24dp"/>
+            <TextView
+                android:id="@+id/breakdown2020_red_init_line_bonus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="(+10)"/>
+        </LinearLayout>
+        <TextView
+            android:text="Initiation Line Exited"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2020_blue_init_line_robot1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_close_black_24dp"/>
+            <ImageView
+                android:id="@+id/breakdown2020_blue_init_line_robot2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_check_black_24dp"/>
+            <ImageView
+                android:id="@+id/breakdown2020_blue_init_line_robot3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_check_black_24dp"/>
+            <TextView
+                android:id="@+id/breakdown2020_blue_init_line_bonus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="(+20)"/>
+        </LinearLayout>
+        <!-- Auto Power Cell -->
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_red_auto_low_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingRight="10dp"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_low_goal"
+                tools:text="2"/>
+            <TextView
+                android:id="@+id/breakdown2020_red_auto_outer_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingRight="10dp"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_outer_goal"
+                tools:text="2"/>
+            <TextView
+                android:id="@+id/breakdown2020_red_auto_inner_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_inner_goal"
+                tools:text="2"/>
+        </LinearLayout>
+        <TextView
+            android:text="Auto Power Cells"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_blue_auto_low_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingRight="10dp"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_low_goal"
+                tools:text="2"/>
+            <TextView
+                android:id="@+id/breakdown2020_blue_auto_outer_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingRight="10dp"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_outer_goal"
+                tools:text="3"/>
+            <TextView
+                android:id="@+id/breakdown2020_blue_auto_inner_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_inner_goal"
+                tools:text="1"/>
+        </LinearLayout>
+        <!-- Auto Power Cell Points -->
+        <TextView
+            android:id="@+id/breakdown2020_red_auto_power_cell"
+            style="@style/breakdown_redItem"
+            tools:text="10"/>
+        <TextView
+            android:text="Auto Power Cell Points"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2020_blue_auto_power_cell"
+            style="@style/breakdown_blueItem"
+            tools:text="25"/>
+
+
+        <!-- Auto Points -->
+        <TextView
+            android:id="@+id/breakdown_auto_total_red"
+            style="@style/breakdown_redTotal"
+            tools:text="60"/>
+        <TextView
+            android:text="@string/breakdown_auto_total"
+            style="@style/breakdown_categoryTotal" />
+        <TextView
+            android:id="@+id/breakdown_auto_total_blue"
+            style="@style/breakdown_blueTotal"
+            tools:text="5"/>
+
+        <!-- Teleop Power Cells -->
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_red_teleop_low_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingRight="10dp"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_low_goal"
+                tools:text="21"/>
+            <TextView
+                android:id="@+id/breakdown2020_red_teleop_outer_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingRight="10dp"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_outer_goal"
+                tools:text="29"/>
+            <TextView
+                android:id="@+id/breakdown2020_red_teleop_inner_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_inner_goal"
+                tools:text="24"/>
+        </LinearLayout>
+        <TextView
+            android:text="Teleop Power Cells"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_blue_teleop_low_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingRight="10dp"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_low_goal"
+                tools:text="50"/>
+            <TextView
+                android:id="@+id/breakdown2020_blue_teleop_outer_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingRight="10dp"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_outer_goal"
+                tools:text="30"/>
+            <TextView
+                android:id="@+id/breakdown2020_blue_teleop_inner_goal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawablePadding="3dp"
+                android:drawableLeft="@drawable/breakdown2020_inner_goal"
+                tools:text="10"/>
+        </LinearLayout>
+        <!-- Teleop Power Cell Points -->
+        <TextView
+            android:id="@+id/breakdown2020_red_teleop_power_cell"
+            style="@style/breakdown_redItem"
+            tools:text="10"/>
+        <TextView
+            android:text="Teleop Power Cell Points"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2020_blue_teleop_power_cell"
+            style="@style/breakdown_blueItem"
+            tools:text="25"/>
+
+
+        <!-- Control Panel Points -->
+        <TextView
+            android:id="@+id/breakdown2020_red_control_panel"
+            style="@style/breakdown_redItem"
+            tools:text="0"/>
+        <TextView
+            android:text="Control Panel Points"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown2020_blue_control_panel"
+            style="@style/breakdown_blueItem"
+            tools:text="5"/>
+
+
+        <!-- Endgame Climb -->
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_red_endgame_robot1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                tools:text="Park (+5)"/>
+        </LinearLayout>
+        <TextView
+            android:text="Robot 1 Endgame"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_blue_endgame_robot1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                tools:text="Hang (+25)"/>
+        </LinearLayout>
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_red_endgame_robot2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                tools:text="Park (+5)"/>
+        </LinearLayout>
+        <TextView
+            android:text="Robot 2 Endgame"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_blue_endgame_robot2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                tools:text="Hang (+25)"/>
+        </LinearLayout>
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_red_endgame_robot3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                tools:text="Hang (+25)"/>
+        </LinearLayout>
+        <TextView
+            android:text="Robot 3 Endgame"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_blue_endgame_robot3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                tools:text="Hang (+25)"/>
+        </LinearLayout>
+
+        <!-- Shield Generator Status -->
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_red_shield_generator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawableLeft="@drawable/ic_check_black_24dp"
+                tools:text="(+15)"/>
+        </LinearLayout>
+        <TextView
+            android:text="Shield Generator Level"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_blue_shield_generator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawableLeft="@drawable/ic_check_black_24dp"
+                tools:text="(+15)"/>
+        </LinearLayout>
+
+        <!-- Endgame Points -->
+        <TextView
+            android:id="@+id/breakdown_endgame_total_red"
+            style="@style/breakdown_redTotal"
+            tools:text="30"/>
+        <TextView
+            android:text="Endgame Points"
+            style="@style/breakdown_categorySubtotal" />
+        <TextView
+            android:id="@+id/breakdown_endgame_total_blue"
+            style="@style/breakdown_blueTotal"
+            tools:text="75"/>
+
+        <!-- Teleop Total -->
+        <TextView
+            android:id="@+id/breakdown_teleop_total_red"
+            style="@style/breakdown_redTotal"
+            tools:text="40"/>
+        <TextView
+            android:text="@string/breakdown_teleop_total"
+            style="@style/breakdown_categoryTotal" />
+        <TextView
+            android:id="@+id/breakdown_teleop_total_blue"
+            style="@style/breakdown_blueTotal"
+            tools:text="80"/>
+
+        <!-- Stage Activation -->
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2020_red_stage1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/baseline_looks_one_black_24"/>
+            <ImageView
+                android:id="@+id/breakdown2020_red_stage2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/baseline_looks_two_black_24"/>
+            <ImageView
+                android:id="@+id/breakdown2020_red_stage3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/baseline_looks_3_black_24"/>
+            <TextView
+                android:id="@+id/breakdown2020_red_stage3_rp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="(+1 RP)" />
+        </LinearLayout>
+        <TextView
+            android:text="Stage Activations"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <ImageView
+                android:id="@+id/breakdown2020_blue_stage_none"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_close_black_24dp"/>
+            <ImageView
+                android:id="@+id/breakdown2020_blue_stage1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/baseline_looks_one_black_24"
+                tools:visibility="gone"/>
+            <ImageView
+                android:id="@+id/breakdown2020_blue_stage2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/baseline_looks_two_black_24"
+                tools:visibility="gone"/>
+            <ImageView
+                android:id="@+id/breakdown2020_blue_stage3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/baseline_looks_3_black_24"
+                tools:visibility="gone"/>
+            <TextView
+                android:id="@+id/breakdown2020_blue_stage3_rp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="" />
+        </LinearLayout>
+
+        <!-- Endgame RP -->
+        <LinearLayout
+            style="@style/breakdown_redItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_red_shield_generator_rp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawableLeft="@drawable/ic_close_black_24dp"
+                android:text=""/>
+        </LinearLayout>
+        <TextView
+            android:text="Shield Generator Operational"
+            style="@style/breakdown_category" />
+        <LinearLayout
+            style="@style/breakdown_blueItem"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/breakdown2020_blue_shield_generator_rp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawableLeft="@drawable/ic_check_black_24dp"
+                android:text="(+1 RP)"/>
+        </LinearLayout>
+
+        <!-- Fouls -->
+        <TextView
+            android:id="@+id/breakdown_fouls_red"
+            style="@style/breakdown_redItem"
+            tools:text="+ 0 / + 0"/>
+        <TextView
+            android:text="Fouls / Tech Fouls"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown_fouls_blue"
+            style="@style/breakdown_blueItem"
+            tools:text="+ 5 / + 15 / + 1 RP"/>
+
+        <!-- Adjustments -->
+        <TextView
+            android:id="@+id/breakdown_adjust_red"
+            style="@style/breakdown_redItem"
+            tools:text="0"/>
+        <TextView
+            android:text="@string/breakdown_adjust"
+            style="@style/breakdown_category" />
+        <TextView
+            android:id="@+id/breakdown_adjust_blue"
+            style="@style/breakdown_blueItem"
+            tools:text="0"/>
+
+        <!-- Total -->
+        <TextView
+            android:id="@+id/breakdown_total_red"
+            style="@style/breakdown_redTotal"
+            tools:text="100"/>
+        <TextView
+            android:text="@string/breakdown_total"
+            style="@style/breakdown_categoryTotal" />
+        <TextView
+            android:id="@+id/breakdown_total_blue"
+            style="@style/breakdown_blueTotal"
+            tools:text="90"/>
+
+        <!-- Ranking Points -->
+        <TextView
+            android:id="@+id/breakdown_red_rp"
+            style="@style/breakdown_redTotal"
+            tools:text="1 RP"/>
+        <TextView
+            android:text="@string/breakdown_rp"
+            android:id="@+id/breakdown_rp_header"
+            style="@style/breakdown_categorySubtotal" />
+        <TextView
+            android:id="@+id/breakdown_blue_rp"
+            style="@style/breakdown_blueTotal"
+            tools:text="2 RP"/>
+    </androidx.gridlayout.widget.GridLayout>
+</ScrollView>

--- a/android/src/main/res/values/strings_score_breakdown.xml
+++ b/android/src/main/res/values/strings_score_breakdown.xml
@@ -9,11 +9,14 @@
     <string name="breakdown_number_format">%1$d</string>
     <string name="breakdown_addition_format">(+ %1$d)</string>
     <string name="breakdown_number_with_addition_format">%1$d (+ %2$d)</string>
+    <string name="breakdown_string_with_addition_format">%1$s (+ %2$d)</string>
     <string name="breakdown_rp_format">(+ %1$d RP)</string>
     <string name="breakdown_total_rp">%1$d RP</string>
     <string name="breakdown_foul">Fouls</string>
     <string name="breakdown_foul_format_add">+ %1$d</string>
     <string name="breakdown_foul_format_subtract">- %1$d</string>
+    <string name="breakdown_foul_tech_format">+ %1$d / + %2$d</string>
+    <string name="breakdown_foul_tech_rp_format">+ %1$d / + %2$d / + %3$d RP</string>
     <string name="breakdown_adjust">Adjustments</string>
     <string name="breakdown_total">Total Score</string>
     <string name="breakdown_rp">Ranking Points</string>


### PR DESCRIPTION
**Summary:** 
Adding breakdown view for 2020 scoring.

**Test Plan:** 
There's no official data for 2020 available yet, so this diff yolos it, but puts it behind a feature flag so we can easily test come week 0.

**Screenshots:**
![image](https://user-images.githubusercontent.com/2754863/73596826-db95f100-44f3-11ea-97b7-4b38e7d8cccc.png)
