### PR TITLE
Swagger updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - JOB=UNIT
   - JOB=COVERAGE
   - JOB=CHECKSTYLE
+  - JOB=DATAFEED_CODEGEN
   - JOB=PROD-BUILD
   global:
   - GRADLE_OPTS="-Xmx2g -Xms128m -Xss1m"

--- a/android/src/main/java/com/thebluealliance/androidclient/api/call/TbaApiV3.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/api/call/TbaApiV3.java
@@ -1,25 +1,29 @@
 package com.thebluealliance.androidclient.api.call;
 
 
-import com.thebluealliance.androidclient.models.ApiStatus;
-import com.thebluealliance.androidclient.models.Award;
-import com.thebluealliance.androidclient.models.District;
-import com.thebluealliance.androidclient.models.DistrictRanking;
-import com.thebluealliance.androidclient.models.Event;
-import com.thebluealliance.androidclient.models.EventAlliance;
-import com.thebluealliance.androidclient.models.Match;
-import com.thebluealliance.androidclient.models.Media;
-import com.thebluealliance.androidclient.models.RankingResponseObject;
-import com.thebluealliance.androidclient.models.Robot;
-import com.thebluealliance.androidclient.models.Team;
-import com.thebluealliance.androidclient.models.TeamAtEventStatus;
-
-import java.util.List;
 
 import retrofit2.Call;
-import retrofit2.http.GET;
-import retrofit2.http.Header;
-import retrofit2.http.Path;
+import retrofit2.http.*;
+
+import okhttp3.RequestBody;
+
+import com.thebluealliance.androidclient.models.ApiStatus;
+import com.thebluealliance.androidclient.models.Event;
+import com.thebluealliance.androidclient.models.District;
+import com.thebluealliance.androidclient.models.DistrictRanking;
+import com.thebluealliance.androidclient.models.Team;
+import com.thebluealliance.androidclient.models.EventAlliance;
+import com.thebluealliance.androidclient.models.Award;
+import com.thebluealliance.androidclient.models.Match;
+import com.thebluealliance.androidclient.models.RankingResponseObject;
+import com.thebluealliance.androidclient.models.TeamAtEventStatus;
+import com.thebluealliance.androidclient.models.Media;
+import com.thebluealliance.androidclient.models.Robot;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public interface TbaApiV3 {
   /**

--- a/android/src/main/java/com/thebluealliance/androidclient/api/rx/TbaApiV3.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/api/rx/TbaApiV3.java
@@ -1,26 +1,30 @@
 package com.thebluealliance.androidclient.api.rx;
 
 import com.google.gson.JsonElement;
+import rx.Observable;
+import retrofit2.Response;
+
+import retrofit2.http.*;
+
+import okhttp3.RequestBody;
+
 import com.thebluealliance.androidclient.models.ApiStatus;
-import com.thebluealliance.androidclient.models.Award;
+import com.thebluealliance.androidclient.models.Event;
 import com.thebluealliance.androidclient.models.District;
 import com.thebluealliance.androidclient.models.DistrictRanking;
-import com.thebluealliance.androidclient.models.Event;
-import com.thebluealliance.androidclient.models.EventAlliance;
-import com.thebluealliance.androidclient.models.Match;
-import com.thebluealliance.androidclient.models.Media;
-import com.thebluealliance.androidclient.models.RankingResponseObject;
-import com.thebluealliance.androidclient.models.Robot;
 import com.thebluealliance.androidclient.models.Team;
+import com.thebluealliance.androidclient.models.EventAlliance;
+import com.thebluealliance.androidclient.models.Award;
+import com.thebluealliance.androidclient.models.Match;
+import com.thebluealliance.androidclient.models.RankingResponseObject;
 import com.thebluealliance.androidclient.models.TeamAtEventStatus;
+import com.thebluealliance.androidclient.models.Media;
+import com.thebluealliance.androidclient.models.Robot;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-
-import retrofit2.Response;
-import retrofit2.http.GET;
-import retrofit2.http.Header;
-import retrofit2.http.Path;
-import rx.Observable;
+import java.util.Map;
 
 public interface TbaApiV3 {
   /**

--- a/doc/api/DefaultApi.md
+++ b/doc/api/DefaultApi.md
@@ -1,6 +1,6 @@
 # DefaultApi
 
-All URIs are relative to *http://www.thebluealliance.com/api/v3*
+All URIs are relative to *https://www.thebluealliance.com/api/v3*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/libTba/src/main/java/com/thebluealliance/api/model/IAllianceBackup.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IAllianceBackup.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 /**
  * AllianceBackup
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IAllianceBackup   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IApiStatus.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IApiStatus.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 /**
  * ApiStatus
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IApiStatus   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IAward.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IAward.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
 /**
  * Award
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IAward   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IAwardRecipient.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IAwardRecipient.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 /**
  * AwardRecipient
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IAwardRecipient   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IDistrict.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IDistrict.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 /**
  * District
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IDistrict   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IDistrictEventPoints.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IDistrictEventPoints.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 /**
  * DistrictEventPoints
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IDistrictEventPoints   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IDistrictRanking.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IDistrictRanking.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
 /**
  * DistrictRanking
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IDistrictRanking   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IEvent.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IEvent.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 /**
  * Event
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IEvent   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IEventAlliance.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IEventAlliance.java
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
 /**
  * EventAlliance
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IEventAlliance   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IMatch.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IMatch.java
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
 /**
  * Match
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IMatch   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IMatchAlliance.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IMatchAlliance.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 /**
  * MatchAlliance
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IMatchAlliance   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IMatchAlliancesContainer.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IMatchAlliancesContainer.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
 /**
  * MatchAlliancesContainer
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IMatchAlliancesContainer   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IMatchVideo.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IMatchVideo.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 /**
  * MatchVideo
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IMatchVideo   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IMedia.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IMedia.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 /**
  * Media
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IMedia   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IRankingItem.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IRankingItem.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
 /**
  * RankingItem
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IRankingItem   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IRankingResponseObject.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IRankingResponseObject.java
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
 /**
  * RankingResponseObject
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IRankingResponseObject   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IRankingSortOrder.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IRankingSortOrder.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 /**
  * RankingSortOrder
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IRankingSortOrder   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/IRobot.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/IRobot.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 /**
  * Robot
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface IRobot   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/ITeam.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/ITeam.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 /**
  * Team
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface ITeam   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/ITeamAtEventAlliance.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/ITeamAtEventAlliance.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
 /**
  * TeamAtEventAlliance
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface ITeamAtEventAlliance   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/ITeamAtEventPlayoff.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/ITeamAtEventPlayoff.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
 /**
  * TeamAtEventPlayoff
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface ITeamAtEventPlayoff   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/ITeamAtEventQual.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/ITeamAtEventQual.java
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
 /**
  * TeamAtEventQual
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface ITeamAtEventQual   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/ITeamAtEventStatus.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/ITeamAtEventStatus.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
 /**
  * TeamAtEventStatus
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface ITeamAtEventStatus   {
 
 

--- a/libTba/src/main/java/com/thebluealliance/api/model/ITeamRecord.java
+++ b/libTba/src/main/java/com/thebluealliance/api/model/ITeamRecord.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 /**
  * TeamRecord
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2017-04-12T17:25:08.276-04:00")
+
 public interface ITeamRecord   {
 
 

--- a/libTba/swagger/mutate_spec.py
+++ b/libTba/swagger/mutate_spec.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import collections
 import sys
@@ -13,7 +13,7 @@ ALL_PROPERTIES_KEY = "allProperties"
 
 
 def update(d, u):
-    for k, v in u.iteritems():
+    for k, v in u.items():
         if isinstance(v, collections.Mapping):
             r = update(d.get(k, {}), v)
             d[k] = r
@@ -32,7 +32,7 @@ def main():
     options, _ = parser.parse_args()
 
     swagger_data = None
-    print("Using base file {}".format(options.file))
+    print(("Using base file {}".format(options.file)))
     with open(options.file, 'r') as datafile:
         swagger_data = json.loads(datafile.read())
 
@@ -42,7 +42,7 @@ def main():
 
     for f in sorted(glob("{}/*.json".format(options.json))):
         data = None
-        print("Reading from {}".format(f))
+        print(("Reading from {}".format(f)))
         with open(f, 'r') as datafile:
             data = json.loads(datafile.read())
 
@@ -50,23 +50,23 @@ def main():
             print("Data file is invalid")
             sys.exit(-1)
 
-        for key, value in data.iteritems():
+        for key, value in data.items():
             if key in MERGE_KEYS:
                 if key not in swagger_data:
                     swagger_data[key] = {}
                 update(swagger_data[key], value)
             elif key == HEADER_KEY:
-                for path, obj in swagger_data["paths"].iteritems():
+                for path, obj in swagger_data["paths"].items():
                     if not isinstance(obj.get("parameters", None), list):
                         obj["parameters"] = []
                     obj["parameters"].extend(value)
             elif key == ALL_PROPERTIES_KEY:
-                for model, obj in swagger_data["definitions"].iteritems():
-                  if model not in value.get("exclude", []):
+                for model, obj in swagger_data["definitions"].items():
+                  if model not in value.get("exclude", []) and "parameters" in value:
                         swagger_data["definitions"][model]["properties"].update(value["parameters"])
 
     pretty = json.dumps(swagger_data, indent=2, sort_keys=True)
-    print("Writing data back to {}".format(options.out))
+    print(("Writing data back to {}".format(options.out)))
     with open(options.out, 'w') as datafile:
         datafile.write(pretty)
 

--- a/libTba/swagger/tba-call.json
+++ b/libTba/swagger/tba-call.json
@@ -5,5 +5,6 @@
   "invokerPackage": "com.thebluealliance.api",
   "modelPackage": "com.thebluealliance.api.model",
   "apiPackage": "com.thebluealliance.api.call",
+  "hideGenerationTimestamp": "true",
   "dateLibrary": "legacy"
 }

--- a/libTba/swagger/tba-rx.json
+++ b/libTba/swagger/tba-rx.json
@@ -6,5 +6,6 @@
   "modelPackage": "com.thebluealliance.api.model",
   "apiPackage": "com.thebluealliance.api.rx",
   "useRxJava": "true",
+  "hideGenerationTimestamp": "true",
   "dateLibrary": "legacy"
 }

--- a/scripts/travis/travis-before.sh
+++ b/scripts/travis/travis-before.sh
@@ -35,6 +35,11 @@ case "$1" in
         common
         ;;
 
+    "DATAFEED_CODEGEN")
+        echo "Setting up environment for datafeed codegen"
+        common
+        ;;
+
     "PROD-BUILD")
         echo "Setting up environment for test production build"
         common

--- a/scripts/travis/travis-worker.sh
+++ b/scripts/travis/travis-worker.sh
@@ -35,6 +35,16 @@ case "$1" in
         filter_code $CODE
         ;;
 
+    "DATAFEED_CODEGEN")
+        echo "Running datafeed codegen"
+        set -e
+        # Run the regeneration ourselves
+        ./scripts/update_datafeed.sh
+
+        # Fail if there are an uncommitted changes
+        git diff-files --quiet --ignore-submodules
+        ;;
+
     "PROD-BUILD")
         echo "Making sure we can build a prod apk (although with different keys)"
 

--- a/scripts/travis/travis-worker.sh
+++ b/scripts/travis/travis-worker.sh
@@ -42,7 +42,7 @@ case "$1" in
         ./scripts/update_datafeed.sh -l v2.2.1-FORKED2
 
         # Fail if there are an uncommitted changes
-        git diff-files --quiet --ignore-submodules
+        git diff --exit-code --ignore-submodules
         ;;
 
     "PROD-BUILD")

--- a/scripts/travis/travis-worker.sh
+++ b/scripts/travis/travis-worker.sh
@@ -39,7 +39,7 @@ case "$1" in
         echo "Running datafeed codegen"
         set -e
         # Run the regeneration ourselves
-        ./scripts/update_datafeed.sh
+        ./scripts/update_datafeed.sh -l v2.2.1-FORKED2
 
         # Fail if there are an uncommitted changes
         git diff-files --quiet --ignore-submodules

--- a/scripts/update_datafeed.sh
+++ b/scripts/update_datafeed.sh
@@ -3,7 +3,7 @@
 # Script to generate Retrofit datafeed from swagger spec
 # Usage ./scripts/update_datafeed.sh [-l <lib version>] [-a <tba-api version>]
 
-TBA_VERSION=2
+TBA_VERSION=3
 while getopts ":l:v:" opt; do
   case $opt in
     l) LIB_VERSION="$OPTARG" && echo "Setting GCE Library Version to $LIB_VERSION" ;;

--- a/scripts/update_datafeed.sh
+++ b/scripts/update_datafeed.sh
@@ -72,12 +72,20 @@ NEW_NAME=TbaApiV$TBA_VERSION
 
 mv android/$APP_PKG/call/DefaultApi.java android/$APP_PKG/call/TbaApiV$TBA_VERSION.java
 mv android/$APP_PKG/rx/DefaultApi.java android/$APP_PKG/rx/TbaApiV$TBA_VERSION.java
-perl -pi -e "s/$OLD_NAME/$NEW_NAME/g" android/$APP_PKG/{call,rx}/TbaApiV$TBA_VERSION.java
-perl -pi -e "s/$OLD_NAME/$NEW_NAME/g" android/$APP_PKG/{call,rx}/TbaApiV$TBA_VERSION.java
-perl -pi -e "s/thebluealliance/thebluealliance\.androidclient/g" android/$APP_PKG/{call,rx}/TbaApiV$TBA_VERSION.java
-perl -pi -e "s/api\.model/models/g" android/$APP_PKG/{call,rx}/TbaApiV$TBA_VERSION.java
-perl -pi -e "s/Response<String>/Response<JsonElement>/g" android/$APP_PKG/{call,rx}/TbaApiV$TBA_VERSION.java
-perl -pi -e "s/import rx\.Observable;/import com\.google\.gson\.JsonElement;\nimport rx\.Observable;/g" android/$APP_PKG/{call,rx}/TbaApiV$TBA_VERSION.java
+perl -pi -e "s/$OLD_NAME/$NEW_NAME/g" android/$APP_PKG/call/TbaApiV$TBA_VERSION.java
+perl -pi -e "s/$OLD_NAME/$NEW_NAME/g" android/$APP_PKG/rx/TbaApiV$TBA_VERSION.java
+
+perl -pi -e "s/thebluealliance/thebluealliance\.androidclient/g" android/$APP_PKG/call/TbaApiV$TBA_VERSION.java
+perl -pi -e "s/thebluealliance/thebluealliance\.androidclient/g" android/$APP_PKG/rx/TbaApiV$TBA_VERSION.java
+
+perl -pi -e "s/api\.model/models/g" android/$APP_PKG/call/TbaApiV$TBA_VERSION.java
+perl -pi -e "s/api\.model/models/g" android/$APP_PKG/rx/TbaApiV$TBA_VERSION.java
+
+perl -pi -e "s/Response<String>/Response<JsonElement>/g" android/$APP_PKG/call/TbaApiV$TBA_VERSION.java
+perl -pi -e "s/Response<String>/Response<JsonElement>/g" android/$APP_PKG/rx/TbaApiV$TBA_VERSION.java
+
+perl -pi -e "s/import rx\.Observable;/import com\.google\.gson\.JsonElement;\nimport rx\.Observable;/g" android/$APP_PKG/call/TbaApiV$TBA_VERSION.java
+perl -pi -e "s/import rx\.Observable;/import com\.google\.gson\.JsonElement;\nimport rx\.Observable;/g" android/$APP_PKG/rx/TbaApiV$TBA_VERSION.java
 
 # Rename models to start with I<name>.java
 CUR=$(pwd)


### PR DESCRIPTION
Improve some of the jank around the way we auto-generate datafeed components. Like:
 - use python3 for the script
 - remove the `@Generated` annotations so we can run the script idempotently
 - hook up into travis so we can constantly check it works (and fail if there are uncommitted changes)