### PR TITLE
Rewrite Event Tab Creation To Be Better

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/adapters/EventsByWeekFragmentPagerAdapter.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/adapters/EventsByWeekFragmentPagerAdapter.java
@@ -40,7 +40,7 @@ public class EventsByWeekFragmentPagerAdapter extends BindableFragmentPagerAdapt
     @Override
     public Fragment getItem(int position) {
         EventWeekTab tab = mThisYearsWeekTabs.get(position);
-        return EventListFragment.newInstance(mYear, tab.getWeek(), tab.getMonth(), getPageTitle(position).toString(), false);
+        return EventListFragment.newInstance(mYear, tab.getEventKeys(), false);
     }
 
     public List<String> getLabels() {

--- a/android/src/main/java/com/thebluealliance/androidclient/datafeed/APICache.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/datafeed/APICache.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.androidclient.datafeed;
 
 import android.database.Cursor;
+import android.text.TextUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -216,6 +217,28 @@ public class APICache {
                   EventsTable.START);
                 List<Event> events = mDb.getEventsTable()
                   .getForQuery(null, where, new String[]{start, end});
+                observer.onNext(events);
+                observer.onCompleted();
+            } catch (Exception e) {
+                observer.onError(e);
+            }
+        });
+    }
+
+    public Observable<List<Event>> fetchEvents(List<String> eventKeys) {
+        return Observable.create((observer) -> {
+            try {
+                List<String> placeholders = new ArrayList<>();
+                for (String event : eventKeys) {
+                    placeholders.add("?");
+                }
+                String keyPlaceholder = TextUtils.join(",", placeholders);
+                String where = String.format("%1$s IN (%2$s)", EventsTable.KEY, keyPlaceholder);
+
+                List<Event> events = mDb.getEventsTable().getForQuery(
+                        null,
+                        where,
+                        eventKeys.toArray(new String[]{}));
                 observer.onNext(events);
                 observer.onCompleted();
             } catch (Exception e) {

--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/EventsByWeekFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/EventsByWeekFragment.java
@@ -86,10 +86,10 @@ public class EventsByWeekFragment
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.fragment_event_list_fragment_pager, container, false);
-        mViewPager = (ViewPager) view.findViewById(R.id.event_pager);
+        mViewPager =view.findViewById(R.id.event_pager);
         // Make this ridiculously big
         mViewPager.setOffscreenPageLimit(50);
-        mTabs = (SlidingTabs) view.findViewById(R.id.event_pager_tabs);
+        mTabs = view.findViewById(R.id.event_pager_tabs);
         ViewCompat.setElevation(mTabs, getResources().getDimension(R.dimen.toolbar_elevation));
         mViewPager.setPageMargin(Utilities.getPixelsFromDp(getActivity(), 16));
         mViewPager.addOnPageChangeListener(mFragmentBinder);

--- a/android/src/main/java/com/thebluealliance/androidclient/models/EventWeekTab.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/models/EventWeekTab.java
@@ -1,31 +1,37 @@
 package com.thebluealliance.androidclient.models;
 
+import java.util.ArrayList;
+
 public class EventWeekTab {
 
-    private int mWeek;
-    private int mMonth;
     private String mLabel;
+    private int mWeek;
+    private ArrayList<String> mEventKeys;
 
-    public EventWeekTab(int week, int month, String label) {
-        mWeek = week;
-        mMonth = month;
+    public EventWeekTab(String label, int week) {
         mLabel = label;
-    }
-
-    public int getWeek() {
-        return mWeek;
-    }
-
-    public int getMonth() {
-        return mMonth;
+        mWeek = week;
+        mEventKeys = new ArrayList<>();
     }
 
     public String getLabel() {
         return mLabel;
     }
 
+    public int getWeek() {
+        return mWeek;
+    }
+
+    public ArrayList<String> getEventKeys() {
+        return mEventKeys;
+    }
+
+    public void addEventKey(String eventKey) {
+        mEventKeys.add(eventKey);
+    }
+
     @Override
     public boolean equals(Object o) {
-        return o instanceof EventWeekTab && mWeek == ((EventWeekTab) o).getWeek();
+        return o instanceof EventWeekTab && mLabel == ((EventWeekTab) o).getLabel();
     }
 }

--- a/android/src/test/java/com/thebluealliance/androidclient/fragments/EventListFragmentTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/fragments/EventListFragmentTest.java
@@ -24,7 +24,9 @@ public class EventListFragmentTest extends BaseFragmentTest {
 
     @Before
     public void setUp() {
-        mFragment = EventListFragment.newInstance(2015, 1, -1, "Week 1");
+        ArrayList<String> eventKeys = new ArrayList<>();
+        eventKeys.add("2015cthar");
+        mFragment = EventListFragment.newInstance(2015, eventKeys, true);
         Event event = ModelMaker.getModel(Event.class, "2015cthar");
         EventRenderer renderer = new EventRenderer(null);
         mEvents = new ArrayList<>();

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriberTest.java
@@ -39,7 +39,7 @@ public class EventTabSubscriberTest {
     @Test
     public void testParsedData()  {
         int[] weeks = {0, 1, 2, 3, 4, 5, 6, 7, 9, 11, 15, 21, 25, 28, 32, 37};
-        int[] months = {-1, -1, -1, -1, -1, -1, -1, -1, -1, 4, 5, 6, 7, 8, 9, 10};
+        int[] sizes = {2, 16, 13, 18, 20, 21, 18, 3, 9, 7, 10, 4, 2, 8, 13, 5};
         String[] labels = {"Preseason Events", "Week 1", "Week 2", "Week 3", "Week 4", "Week 5",
           "Week 6", "Week 7", "Championship Event", "May Offseason Events", "Jun Offseason Events",
           "Jul Offseason Events", "Aug Offseason Events", "Sep Offseason Events",
@@ -50,7 +50,7 @@ public class EventTabSubscriberTest {
         for (int i = 0; i < tabs.size(); i++) {
             EventWeekTab tab = tabs.get(i);
             assertEquals(String.format("Tab %1$d week fail", i), weeks[i], tab.getWeek());
-            assertEquals(String.format("Tab %1$d month fail", i), months[i], tab.getMonth());
+            assertEquals(String.format("Tab %1$d count fail", i), sizes[i], tab.getEventKeys().size());
             assertEquals(String.format("Tab %1$d label fail", i), labels[i], tab.getLabel());
         }
     }


### PR DESCRIPTION
This will make the tab construction logic more resilient.

Specifically, this fixes https://github.com/the-blue-alliance/the-blue-alliance-android/issues/937 because there's a late in the season preseason event the same logical week as the first official event. Which meant the app would group them together.

The new way groups by tab label, which should make things better