### PR TITLE
Run Notification Processing via JobScheduler API

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -230,7 +230,10 @@
             android:name=".receivers.NotificationChangedReceiver"
             android:exported="false" />
 
-        <service android:name=".gcm.GCMMessageHandler" />
+        <service
+            android:name=".gcm.GCMMessageHandler"
+            android:exported="false"
+            android:permission="android.permission.BIND_JOB_SERVICE"/>
         <service
             android:name=".accounts.AccountAuthenticatorService"
             android:exported="false">

--- a/android/src/main/java/com/thebluealliance/androidclient/di/components/NotificationComponent.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/di/components/NotificationComponent.java
@@ -3,6 +3,7 @@ package com.thebluealliance.androidclient.di.components;
 import com.thebluealliance.androidclient.config.ConfigModule;
 import com.thebluealliance.androidclient.datafeed.gce.GceModule;
 import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
+import com.thebluealliance.androidclient.gcm.GcmModule;
 import com.thebluealliance.androidclient.renderers.RendererModule;
 
 import javax.inject.Singleton;
@@ -11,7 +12,7 @@ import dagger.Component;
 
 @Singleton
 @Component(
-  modules = {GceModule.class, RendererModule.class, ConfigModule.class},
+  modules = {GceModule.class, RendererModule.class, ConfigModule.class, GcmModule.class},
   dependencies = ApplicationComponent.class)
 public interface NotificationComponent {
   void inject(GCMMessageHandler gcmMessageHandler);

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMBroadcastReceiver.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMBroadcastReceiver.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.androidclient.gcm;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -8,15 +9,11 @@ import androidx.legacy.content.WakefulBroadcastReceiver;
 
 import com.thebluealliance.androidclient.TbaLogger;
 
-public class GCMBroadcastReceiver extends WakefulBroadcastReceiver {
+public class GCMBroadcastReceiver extends BroadcastReceiver {
+
     @Override
     public void onReceive(Context context, Intent intent) {
         TbaLogger.d("Got GCM Message. " + intent);
-        // Explicitly specify that GcmIntentService will handle the intent.
-        ComponentName comp = new ComponentName(context.getPackageName(),
-                GCMMessageHandler.class.getName());
-        // Start the service, keeping the device awake while it is launching.
-        startWakefulService(context, intent.setComponent(comp));
-        setResultCode(Activity.RESULT_OK);
+        GCMMessageHandler.enqueueWork(context, intent);
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMBroadcastReceiver.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMBroadcastReceiver.java
@@ -1,11 +1,8 @@
 package com.thebluealliance.androidclient.gcm;
 
-import android.app.Activity;
 import android.content.BroadcastReceiver;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import androidx.legacy.content.WakefulBroadcastReceiver;
 
 import com.thebluealliance.androidclient.TbaLogger;
 

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
@@ -8,6 +8,9 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.JobIntentService;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 
@@ -55,7 +58,7 @@ import org.greenrobot.eventbus.EventBus;
 
 import javax.inject.Inject;
 
-public class GCMMessageHandler extends IntentService implements FollowsChecker {
+public class GCMMessageHandler extends JobIntentService implements FollowsChecker {
 
     /**
      * Stack (bundle) notifications together into a Group for better UX on Nougat+ and Android Wear
@@ -74,6 +77,9 @@ public class GCMMessageHandler extends IntentService implements FollowsChecker {
     /** If grouping won't work, use this ID to make each notification replace its predecessor. */
     public static final int SINGULAR_NOTIFICATION_ID = 363;
 
+    public static final int JOB_ID = 254;
+
+    @Inject GoogleCloudMessaging mCloudMessaging;
     @Inject MyTbaDatafeed mMyTbaDatafeed;
     @Inject DatabaseWriter mWriter;
     @Inject SharedPreferences mPrefs;
@@ -85,14 +91,6 @@ public class GCMMessageHandler extends IntentService implements FollowsChecker {
     @Inject AppConfig mAppConfig;
 
     private NotificationComponent mComponenet;
-
-    public GCMMessageHandler() {
-        this("GCMMessageHandler");
-    }
-
-    public GCMMessageHandler(String name) {
-        super(name);
-    }
 
     @Override
     public void onCreate() {
@@ -109,6 +107,7 @@ public class GCMMessageHandler extends IntentService implements FollowsChecker {
                     .datafeedModule(application.getDatafeedModule())
                     .rendererModule(new RendererModule())
                     .authModule(application.getAuthModule())
+                    .gcmModule(application.getGcmModule())
                     .build();
         }
     }
@@ -131,14 +130,19 @@ public class GCMMessageHandler extends IntentService implements FollowsChecker {
                 || subTable.hasNotificationType(teamAtEventInterestKey, notificationType);
     }
 
+    public static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, GCMMessageHandler.class, JOB_ID, work);
+    }
+
     @Override
-    protected void onHandleIntent(Intent intent) {
-
+    protected void onHandleWork(Intent intent) {
         Bundle extras = intent.getExtras();
+        if (extras == null) {
+            TbaLogger.w("Intent with no extras!");
+            return;
+        }
 
-        GoogleCloudMessaging gcm = GoogleCloudMessaging.getInstance(this);
-
-        String messageType = gcm.getMessageType(intent);
+        String messageType = mCloudMessaging.getMessageType(intent);
         TbaLogger.d("GCM Message type: " + messageType);
         TbaLogger.d("Intent extras: " + extras.toString());
 
@@ -148,8 +152,6 @@ public class GCMMessageHandler extends IntentService implements FollowsChecker {
         handleMessage(getApplicationContext(), type, data);
 
         TbaLogger.i("Received : (" + type + ")  " + data);
-
-        GCMBroadcastReceiver.completeWakefulIntent(intent);
     }
 
     public void handleMessage(Context c, String messageType, String messageData) {
@@ -255,7 +257,7 @@ public class GCMMessageHandler extends IntentService implements FollowsChecker {
             }
         } catch (Exception e) {
             // We probably tried to post a null notification or something like that. Oops...
-            e.printStackTrace();
+            TbaLogger.e("Error parsing notification", e);
         }
     }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
@@ -1,6 +1,5 @@
 package com.thebluealliance.androidclient.gcm;
 
-import android.app.IntentService;
 import android.app.Notification;
 import android.content.Context;
 import android.content.Intent;
@@ -9,7 +8,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 
-import androidx.annotation.NonNull;
 import androidx.core.app.JobIntentService;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;

--- a/android/src/test/java/com/thebluealliance/androidclient/TestTbaAndroid.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/TestTbaAndroid.java
@@ -29,7 +29,6 @@ public class TestTbaAndroid extends TbaAndroid {
     @Override
     public void onCreate() {
         disableStetho();
-        FirebaseApp.initializeApp(this);
         super.onCreate();
     }
 

--- a/android/src/test/java/com/thebluealliance/androidclient/TestTbaAndroid.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/TestTbaAndroid.java
@@ -1,6 +1,5 @@
 package com.thebluealliance.androidclient;
 
-import com.google.firebase.FirebaseApp;
 import com.thebluealliance.androidclient.di.DaggerMockApplicationComponent;
 import com.thebluealliance.androidclient.di.DaggerMockDatafeedComponent;
 import com.thebluealliance.androidclient.di.MockAccountModule;

--- a/android/src/test/java/com/thebluealliance/androidclient/gcm/TestGCMBroadcastReceiver.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/gcm/TestGCMBroadcastReceiver.java
@@ -1,0 +1,50 @@
+package com.thebluealliance.androidclient.gcm;
+
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.Context;
+import android.content.Intent;
+
+import com.google.gson.JsonObject;
+import com.thebluealliance.androidclient.datafeed.framework.ModelMaker;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Nullable;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(AndroidJUnit4.class)
+public class TestGCMBroadcastReceiver {
+
+    private Context mApplicationContext;
+    private JobScheduler mJobScheduler;
+
+    @Before
+    public void setUp() {
+        mApplicationContext = ApplicationProvider.getApplicationContext();
+        mJobScheduler = (JobScheduler) mApplicationContext.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+    }
+
+    @Test
+    public void testSchedulesJob() {
+        Intent intent = buildIntent();
+        mApplicationContext.sendBroadcast(intent);
+
+        @Nullable JobInfo job = mJobScheduler.getPendingJob(GCMMessageHandler.JOB_ID);
+        assertNotNull(job);
+    }
+
+    private Intent buildIntent() {
+        JsonObject notificationData = ModelMaker.getModel(JsonObject.class, "notification_upcoming_match");
+        Intent intent = new Intent("com.google.android.c2dm.intent.RECEIVE");
+        intent.putExtra("notification_type", "upcoming_match");
+        intent.putExtra("message_data", notificationData.toString());
+        return intent;
+    }
+}

--- a/scripts/test_notification.py
+++ b/scripts/test_notification.py
@@ -46,7 +46,7 @@ def notify(message_type, json_data):
         --es message_data '%s'"""
     command = template % (message_type, json_text)
 
-    print "\nSending " + message_type + " broadcast"
+    print("\nSending " + message_type + " broadcast")
 
     subprocess.call(["adb", "shell", command])
 


### PR DESCRIPTION
This should fix crahes like 
```
Caused by java.lang.IllegalStateException
Not allowed to start service Intent { act=com.google.android.c2dm.intent.RECEIVE flg=0x1000010 pkg=com.thebluealliance.androidclient cmp=com.thebluealliance.androidclient/.gcm.GCMMessageHandler (has extras) }: app is in background uid UidRecord{ca22e23 u0a206 RCVR bg:+6m20s802ms idle change:uncached procs:1 seq(0,0,0)}
```

Because newer versions of android are more strict about running things in the background