### PR TITLE
Fix summary notifications

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/SummaryNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/SummaryNotification.java
@@ -28,23 +28,22 @@ public class SummaryNotification extends BaseNotification<Void> {
      */
     static final int MAX = 7;
 
-    private final Database mDb;
+    public static final int NOTIFICATION_ID = 1337;
 
-    public SummaryNotification(Database db) {
+    private final List<StoredNotification> mActiveNotifications;
+
+    public SummaryNotification(List<StoredNotification> activeNotifications) {
         super(NotificationTypes.SUMMARY, "");
-        mDb = db;
+        mActiveNotifications = activeNotifications;
     }
 
     @Override
     public Notification buildNotification(Context context, FollowsChecker followsChecker) {
-        NotificationsTable table = mDb.getNotificationsTable();
-
-        List<StoredNotification> active = table.getActive();
         NotificationCompat.InboxStyle style = new NotificationCompat.InboxStyle();
-        int size = active.size();
+        int size = mActiveNotifications.size();
         int count = 0;
 
-        for (StoredNotification n : active) {
+        for (StoredNotification n : mActiveNotifications) {
             if (++count > MAX) {
                 break;
             }
@@ -95,7 +94,7 @@ public class SummaryNotification extends BaseNotification<Void> {
     @Override
     public int getNotificationId() {
         /* All have the same ID so future notifications replace it */
-        return 1337;
+        return NOTIFICATION_ID;
     }
 
     @Nullable

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/SummaryNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/SummaryNotification.java
@@ -8,8 +8,6 @@ import android.content.Intent;
 import com.google.gson.JsonParseException;
 import com.thebluealliance.androidclient.R;
 import com.thebluealliance.androidclient.activities.HomeActivity;
-import com.thebluealliance.androidclient.database.Database;
-import com.thebluealliance.androidclient.database.tables.NotificationsTable;
 import com.thebluealliance.androidclient.gcm.FollowsChecker;
 import com.thebluealliance.androidclient.gcm.GCMMessageHandler;
 import com.thebluealliance.androidclient.models.StoredNotification;

--- a/android/src/main/java/com/thebluealliance/androidclient/receivers/NotificationChangedReceiver.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/receivers/NotificationChangedReceiver.java
@@ -34,15 +34,18 @@ public class NotificationChangedReceiver extends BroadcastReceiver {
         return new Intent(context, NotificationChangedReceiver.class);
     }
 
-    @Inject Database mDb;
+    @Inject
+    Database mDb;
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        ((TbaAndroid)context.getApplicationContext()).getDbComponent().inject(this);
-        if (intent.getAction().equals(ACTION_NOTIFICATION_CLICKED)) {
+        TbaLogger.i("Notification changed receiver: " + intent);
+        ((TbaAndroid) context.getApplicationContext()).getDbComponent().inject(this);
+
+        Bundle extras = intent.getExtras();
+        if (ACTION_NOTIFICATION_CLICKED.equals(intent.getAction())) {
             // Check for an intent to launch
-            Bundle extras = intent.getExtras();
-            if (extras.containsKey(EXTRA_INTENT)) {
+            if (extras != null && extras.containsKey(EXTRA_INTENT)) {
                 Intent extraIntent = extras.getParcelable(EXTRA_INTENT);
                 System.out.println("Intent: " + extraIntent.toString());
                 extraIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -51,8 +54,8 @@ public class NotificationChangedReceiver extends BroadcastReceiver {
         }
 
         // Mark all notifications as not active
-        TbaLogger.d("Notification Dismiss!");
-        NotificationsTable table = Database.getInstance(context).getNotificationsTable();
+        TbaLogger.d("Notifications Dismissed!");
+        NotificationsTable table = mDb.getNotificationsTable();
         table.dismissAll();
     }
 }

--- a/android/src/test/java/com/thebluealliance/androidclient/gcm/GCMMessageHandlerWithMocks.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/gcm/GCMMessageHandlerWithMocks.java
@@ -6,6 +6,9 @@ import android.content.Context;
 import com.thebluealliance.androidclient.TestTbaAndroid;
 import com.thebluealliance.androidclient.database.DatabaseWithMocks;
 import com.thebluealliance.androidclient.gcm.notifications.BaseNotification;
+import com.thebluealliance.androidclient.models.StoredNotification;
+
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -23,8 +26,8 @@ public class GCMMessageHandlerWithMocks extends GCMMessageHandler {
     }
 
     @Override
-    protected void notify(Context c, BaseNotification notification, Notification built) {
-        super.notify(c, notification, built);
+    protected void notify(Context c, BaseNotification notification, Notification built, List<StoredNotification> activeNotifications) {
+        super.notify(c, notification, built, activeNotifications);
         mLastNotification = notification;
     }
 
@@ -34,6 +37,6 @@ public class GCMMessageHandlerWithMocks extends GCMMessageHandler {
     }
 
     public DatabaseWithMocks getDatabase() {
-        return (DatabaseWithMocks)mDb;
+        return (DatabaseWithMocks) mDb;
     }
 }


### PR DESCRIPTION
Send summary notifications if there is more than one currently active

Do this properly, according to https://developer.android.com/training/notify-user/group

![image](https://user-images.githubusercontent.com/2754863/76172454-8db47e80-616c-11ea-90ea-6132e67e95a5.png)
