### PR TITLE
Fix geo intents on Android 11+

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/listeners/SocialClickListener.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/listeners/SocialClickListener.java
@@ -1,16 +1,13 @@
 package com.thebluealliance.androidclient.listeners;
 
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.view.View;
 import android.widget.Toast;
 
 import com.thebluealliance.androidclient.helpers.AnalyticsHelper;
-
-import java.util.List;
 
 import javax.inject.Inject;
 
@@ -30,23 +27,18 @@ public class SocialClickListener implements View.OnClickListener {
 
     @Override
     public void onClick(View view) {
-        PackageManager manager = mContext.getPackageManager();
         if (view.getTag() != null) {
-
             String uri = view.getTag().toString();
 
             //social button was clicked. Track the call
             AnalyticsHelper.sendSocialUpdate(mContext, uri, mModelKey);
 
             Intent i = new Intent(android.content.Intent.ACTION_VIEW, Uri.parse(uri));
-            List<ResolveInfo> handlers = manager.queryIntentActivities(i, 0);
-            if (!handlers.isEmpty()) {
-                // There is an application to handle this intent intent
+            try {
                 mContext.startActivity(i);
-            } else {
-                // No application can handle this intent
+            } catch (ActivityNotFoundException e) {
                 Toast.makeText(mContext, "No app can handle that request", Toast.LENGTH_SHORT)
-                  .show();
+                        .show();
             }
         }
     }


### PR DESCRIPTION
**Summary:** 
Trying to tap on an event's location on Android 11+ currently results in a toast that says "No app can handle that request".

This is because Android 11 and above require applications that query other packages to declare what they want to query in the manifest with `<query>` tags. See [package visibility](https://developer.android.com/training/package-visibility) for more info on this change.

The only reason we used this was to check if our links could be handled before launching them. Just launching the intent and catching any resulting `ActivityNotFoundException` has the same effect, so that's the route I went to fix.

**Test Plan:** 

Tested current behavior on Android 12L, and it works now!
I also changed the `geo:` intents to some garbage text to test the not found behavior, and confirmed the toast still displays as expected for unhandled intents.
