### PR TITLE
Fix notifications without icons

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -33,6 +33,16 @@
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
+
+        <!-- Configure FCM notification defaults - these will be used if FCM shows a notification
+         (because the notification doesn't get processed by us due to a problem such as a crash) -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_notification" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/primary" />
+
         <!--
         Don't load analytics from xml. See #303
         <meta-data

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/UpcomingMatchNotification.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/notifications/UpcomingMatchNotification.java
@@ -195,10 +195,13 @@ public class UpcomingMatchNotification extends BaseNotification<UpcomingMatchNot
                                                                          webcastType,
                                                                          webcastJson,
                                                                          0);
-                watchIntent = PendingIntent.getActivity(context,
-                                                        (int)System.currentTimeMillis(),
-                                                        webcastIntent,
-                                                        0);
+                int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0;
+                watchIntent = PendingIntent.getActivity(
+                        context,
+                        (int)System.currentTimeMillis(),
+                        webcastIntent,
+                        flags
+                );
             }
         }
 


### PR DESCRIPTION
**Summary:** 
Two pronged approach to fixing the upcoming match notifications without icons:
 * Most immediate problem was a missing `FLAG_IMMUTABLE` on the webcast action intent.
 * But this also adds a default notification icon and color for FCM when FCM itself is showing the intent (e.g. due to an app crash from a missing pending intent 😉 )

**Issues Reference:** 
Resolves #965 

**Test Plan:** 
Tested locally by sending myself a notification in my dev TBA Firebase instance. I was able to easily recreate the broken upcoming match notification and see the crash. Now it works! 

