### PR TITLE
Fix for crash when viewing team@event for a B team

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/helpers/TeamHelper.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/helpers/TeamHelper.java
@@ -60,10 +60,12 @@ public final class TeamHelper {
         if (key == null) return -1;
 
         Matcher teamNumberMatcher = Pattern.compile("^frc(\\d{1,4})[a-zA-Z]?$").matcher(key);
-        if (!teamNumberMatcher.matches() || teamNumberMatcher.groupCount() < 2) return -1;
 
         // 0th group is the full matching string, 1st is our capture group for the number
+        // The 0th group is not included in groupCount()
+        if (!teamNumberMatcher.matches() || teamNumberMatcher.groupCount() < 1) return -1;
         String teamNumberString = teamNumberMatcher.group(1);
+
         if (teamNumberString == null) return -1;
         return Integer.parseInt(teamNumberString);
     }

--- a/android/src/main/java/com/thebluealliance/androidclient/helpers/TeamHelper.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/helpers/TeamHelper.java
@@ -2,6 +2,9 @@ package com.thebluealliance.androidclient.helpers;
 
 import androidx.annotation.Nullable;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Helper class used to verify team keys.
  *
@@ -55,6 +58,13 @@ public final class TeamHelper {
      */
     public static int getTeamNumber(@Nullable String key) {
         if (key == null) return -1;
-        return Integer.parseInt(key.substring(3));
+
+        Matcher teamNumberMatcher = Pattern.compile("^frc(\\d{1,4})[a-zA-Z]?$").matcher(key);
+        if (!teamNumberMatcher.matches() || teamNumberMatcher.groupCount() < 2) return -1;
+
+        // 0th group is the full matching string, 1st is our capture group for the number
+        String teamNumberString = teamNumberMatcher.group(1);
+        if (teamNumberString == null) return -1;
+        return Integer.parseInt(teamNumberString);
     }
 }

--- a/android/src/test/java/com/thebluealliance/androidclient/helpers/TeamHelperTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/helpers/TeamHelperTest.java
@@ -54,5 +54,7 @@ public class TeamHelperTest {
         assertEquals(-1, TeamHelper.getTeamNumber(null));
         assertEquals(1124, TeamHelper.getTeamNumber("frc1124"));
         assertEquals(254, TeamHelper.getTeamNumber("frc254"));
+        assertEquals(254, TeamHelper.getTeamNumber("frc254A"));
+        assertEquals(254, TeamHelper.getTeamNumber("frc254b"));
     }
 }


### PR DESCRIPTION
**Summary:** 

When trying to view a Team@Event page for a B team, the app crashes with
```
Caused by: java.lang.NumberFormatException: For input string: "114B"
  at java.lang.Integer.parseInt(Integer.java:797)
  at java.lang.Integer.parseInt(Integer.java:915)
  at com.thebluealliance.androidclient.helpers.TeamHelper.getTeamNumber(TeamHelper.java:61)
```

Easy steps to reproduce:
 1. Go to the 2023 Madtown Throwdown event page (Nov 10-12, 2023)
 2. Go to the rankings tab
 3. Expand 114B's rankings
 4. Click "more"
 5. 💣 💥 

To fix this we just need to adjust our `getTeamNumber()` logic to properly extract team numbers for B teams.

**Test Plan:** 
New unit test assertions for B teams, and confirmed the previously broken flow now works.

**Screenshots:**
The summary tab isn't great, but the matches tab works!
|Matches|Summary|
|-|-|
|![114b_matches](https://github.com/the-blue-alliance/the-blue-alliance-android/assets/3267925/19ffcc34-e6e2-445c-9f96-083e096b59b9)|![114_b_summary](https://github.com/the-blue-alliance/the-blue-alliance-android/assets/3267925/63d80692-b4d9-4e87-8440-4ac8608dd819)|
