### PR TITLE
Changes for API 33 & 34

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,7 +104,7 @@ android {
         applicationId "com.thebluealliance.androidclient"
         compileSdk 34
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode versionNum
         versionName version.toString()
         multiDexEnabled true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,10 +40,18 @@ if (localPropFile.exists()) {
 }
 
 android {
-    compileSdkVersion 34
     namespace "com.thebluealliance.androidclient"
 
     signingConfigs {
+        if (localProps.containsKey("debug.key")) {
+            debug {
+                storeFile file(localProps.getProperty("debug.key"))
+                storePassword localProps.getProperty("debug.key.password")
+                keyAlias localProps.getProperty("debug.key.alias")
+                keyPassword localProps.getProperty("debug.key.aliasPass")
+            }
+        }
+
         release {
             storeFile file(localProps.getProperty("release.key", "somefile.jks"))
             storePassword localProps.getProperty("release.key.password", "notRealPassword")
@@ -94,8 +102,9 @@ android {
 
     defaultConfig {
         applicationId "com.thebluealliance.androidclient"
+        compileSdk 34
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode versionNum
         versionName version.toString()
         multiDexEnabled true
@@ -240,7 +249,7 @@ dependencies {
     // See http://developer.android.com/google/play-services/setup.html
     implementation 'com.google.guava:guava:24.1-jre'
 //    implementation "com.google.firebase:firebase-bom:31.2.3"
-    implementation "com.google.android.gms:play-services-base:18.2.0"
+    implementation "com.google.android.gms:play-services-base:18.3.0"
     implementation "com.google.android.gms:play-services-analytics:18.0.4"
     implementation "com.google.firebase:firebase-messaging:23.4.0"
     implementation "com.google.android.gms:play-services-auth:20.7.0"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <!-- This is not needed with android 6.0 (API 23) anymore, since we only need this to
          interact with our own Authenticator to create a TBA system account
          https://developer.android.com/reference/android/Manifest.permission.html#GET_ACCOUNTS -->

--- a/android/src/main/java/com/thebluealliance/androidclient/activities/settings/SettingsActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/settings/SettingsActivity.java
@@ -121,18 +121,19 @@ public class SettingsActivity extends AppCompatActivity {
             Preference tbaLink = findPreference("tba_link");
             tbaLink.setIntent(new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.thebluealliance.com")));
 
-            final SwitchPreference mytbaEnabled = (SwitchPreference) findPreference("mytba_enabled");
+            final SwitchPreference mytbaEnabled = findPreference("mytba_enabled");
             final Activity activity = getActivity();
             if (mytbaEnabled != null) {
                 mytbaEnabled.setChecked(mAccountController.isMyTbaEnabled());
-                mytbaEnabled.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-                    @Override
-                    public boolean onPreferenceChange(Preference preference, Object newValue) {
-                        boolean enabled = mAccountController.isMyTbaEnabled();
-                        TbaLogger.d("myTBA is: " + enabled);
+                mytbaEnabled.setOnPreferenceChangeListener((preference, newValue) -> {
+                    boolean enabled = mAccountController.isMyTbaEnabled();
+                    TbaLogger.d("myTBA is: " + enabled);
+                    if (!enabled) {
                         activity.startActivity(new Intent(getActivity(), MyTBAOnboardingActivity.class));
-                        return true;
+                    } else {
+                        mAccountController.setMyTbaEnabled(false);
                     }
+                    return true;
                 });
             }
 

--- a/android/src/main/java/com/thebluealliance/androidclient/adapters/MyTBAOnboardingPagerAdapter.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/adapters/MyTBAOnboardingPagerAdapter.java
@@ -1,19 +1,27 @@
 package com.thebluealliance.androidclient.adapters;
 
+import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.RequiresApi;
 import androidx.viewpager.widget.PagerAdapter;
 
 import com.thebluealliance.androidclient.R;
 
 public class MyTBAOnboardingPagerAdapter extends PagerAdapter {
 
-    private int mCount = 5;
-    private ViewGroup mView;
+    private final int mCount;
+    private final ViewGroup mView;
 
     public MyTBAOnboardingPagerAdapter(ViewGroup view) {
         mView = view;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // Starting with API 33, there is an additional page to request notification permissions
+            mCount = 6;
+        } else {
+            mCount = 5;
+        }
     }
 
     @Override
@@ -21,9 +29,21 @@ public class MyTBAOnboardingPagerAdapter extends PagerAdapter {
         return mCount;
     }
 
+    public int getLoginPageId() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return mCount - 2;
+        } else {
+            return mCount - 1;
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    public int getNotificationPermissionPageId() {
+        return mCount - 1;
+    }
+
     @Override
     public Object instantiateItem(ViewGroup collection, int position) {
-
         int resId = 0;
         switch (position) {
             case 0:
@@ -40,6 +60,9 @@ public class MyTBAOnboardingPagerAdapter extends PagerAdapter {
                 break;
             case 4:
                 resId = R.id.page_five;
+                break;
+            case 5:
+                resId = R.id.page_six;
                 break;
         }
         return mView.findViewById(resId);

--- a/android/src/main/java/com/thebluealliance/androidclient/auth/AuthModule.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/auth/AuthModule.java
@@ -8,6 +8,7 @@ import com.thebluealliance.androidclient.accounts.AccountController;
 import com.thebluealliance.androidclient.accounts.AccountModule;
 import com.thebluealliance.androidclient.auth.firebase.FirebaseAuthProvider;
 import com.thebluealliance.androidclient.auth.google.GoogleAuthProvider;
+import com.thebluealliance.androidclient.mytba.MyTbaOnboardingController;
 
 import javax.annotation.Nullable;
 import javax.inject.Named;
@@ -45,5 +46,11 @@ public class AuthModule {
     public AuthProvider provideFirebaseAuthProvider(@Nullable FirebaseAuth firebaseAuth,
                                                     GoogleAuthProvider googleAuthProvider) {
         return new FirebaseAuthProvider(firebaseAuth, googleAuthProvider);
+    }
+
+    @Provides
+    public MyTbaOnboardingController provideMyTbaOnbordingController(@Named("firebase_auth") AuthProvider authProvider,
+                                                                     AccountController accountController) {
+        return new MyTbaOnboardingController(authProvider, accountController);
     }
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/auth/AuthProvider.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/auth/AuthProvider.java
@@ -8,10 +8,6 @@ import rx.Observable;
 
 public interface AuthProvider {
 
-    void onStart();
-
-    void onStop();
-
     /**
      * Check if a user is currently signed in
      */
@@ -32,7 +28,7 @@ public interface AuthProvider {
     @Nullable
     Intent buildSignInIntent();
 
-    Observable<? extends User> userFromSignInResult(int requestCode, int resultCode, Intent data);
+    Observable<? extends User> userFromSignInResult(int resultCode, Intent data);
 
     Observable<? extends User> signInLegacyUser();
 }

--- a/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/gcm/GCMMessageHandler.java
@@ -1,8 +1,10 @@
 package com.thebluealliance.androidclient.gcm;
 
+import android.Manifest;
 import android.app.Notification;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 
@@ -214,6 +216,11 @@ public class GCMMessageHandler extends FirebaseMessagingService implements Follo
     protected void notify(Context c, BaseNotification notification, Notification built, List<StoredNotification> activeNotifications) {
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(c);
         int id = notification.getNotificationId();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && ContextCompat.checkSelfPermission(c, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            TbaLogger.w("Notification permission not granted! Skipping posting notifications...");
+            return;
+        }
 
         setNotificationParams(built, c, notification.getNotificationType(), mPrefs);
         TbaLogger.i("Notifying: " + id);

--- a/android/src/main/java/com/thebluealliance/androidclient/mytba/MyTbaOnboardingController.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/mytba/MyTbaOnboardingController.java
@@ -1,0 +1,97 @@
+package com.thebluealliance.androidclient.mytba;
+
+import static android.app.Activity.RESULT_CANCELED;
+import static android.app.Activity.RESULT_OK;
+
+import android.Manifest;
+import android.content.Intent;
+import android.os.Build;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes;
+import com.google.android.gms.common.api.Status;
+import com.thebluealliance.androidclient.R;
+import com.thebluealliance.androidclient.TbaLogger;
+import com.thebluealliance.androidclient.accounts.AccountController;
+import com.thebluealliance.androidclient.auth.AuthProvider;
+import com.thebluealliance.androidclient.auth.User;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import rx.Observable;
+
+public class MyTbaOnboardingController {
+
+    final AuthProvider mAuthProvider;
+    final AccountController mAccountController;
+
+    ActivityResultLauncher<Intent> mSignInLauncher;
+    ActivityResultLauncher<String> mNotificationPermissionLauncher;
+
+    @Inject
+    public MyTbaOnboardingController(
+            @Named("firebase_auth") AuthProvider authProvider,
+            AccountController accountController
+    ) {
+        mAuthProvider = authProvider;
+        mAccountController = accountController;
+    }
+
+    public void registerActivityCallbacks(AppCompatActivity activity, MyTbaOnboardingCallbacks callbacks) {
+        mSignInLauncher = activity.registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+            onSignInResult(activity, callbacks, result.getResultCode(), result.getData());
+        });
+        mNotificationPermissionLauncher =
+                activity.registerForActivityResult(new ActivityResultContracts.RequestPermission(), callbacks::onPermissionResult);
+    }
+
+    private void onSignInResult(AppCompatActivity activity, MyTbaOnboardingCallbacks callbacks, int resultCode, Intent data) {
+        if (resultCode == RESULT_OK) {
+            Observable<? extends User> observable = mAuthProvider.userFromSignInResult(resultCode, data);
+            observable.subscribe(user -> {
+                TbaLogger.d("User logged in: " + user.getEmail());
+                mAccountController.onAccountConnect(activity, user);
+                callbacks.onLoginSuccess();
+            }, throwable -> {
+                TbaLogger.e("Error logging in", throwable);
+                mAccountController.setMyTbaEnabled(false);
+                callbacks.onLoginFailed();
+            });
+        } else if (resultCode == RESULT_CANCELED) {
+            Status signInStatus = (Status)data.getExtras().get("googleSignInStatus");
+            String errorReason = GoogleSignInStatusCodes.getStatusCodeString(signInStatus.getStatusCode());
+            Toast.makeText(activity, "Google sign in error: " + errorReason, Toast.LENGTH_LONG).show();
+            TbaLogger.w("Google sign in error: " + errorReason);
+            callbacks.onLoginFailed();
+        }
+    }
+
+    public void launchSignIn(AppCompatActivity activity) {
+        Intent signInIntent = mAuthProvider.buildSignInIntent();
+        if (signInIntent == null) {
+            Toast.makeText(activity, R.string.mytba_no_signin_intent, Toast.LENGTH_SHORT).show();
+            TbaLogger.e("Unable to get login Intent");
+            return;
+        }
+
+        mSignInLauncher.launch(signInIntent);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    public void launchNotificationPermissionRequest(AppCompatActivity activity) {
+        TbaLogger.i("Requesting notification permission");
+        mNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+    }
+
+    public interface MyTbaOnboardingCallbacks {
+        void onLoginSuccess();
+        void onLoginFailed();
+        void onPermissionResult(boolean isGranted);
+    }
+}

--- a/android/src/main/res/layout/mytba_onboarding_view_pager.xml
+++ b/android/src/main/res/layout/mytba_onboarding_view_pager.xml
@@ -168,6 +168,71 @@
                 android:layout_margin="16dp" />
 
         </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/page_six"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:id="@+id/enable_notifications_call_to_action"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_marginTop="16dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/enable_notifications_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="16dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:gravity="center_horizontal"
+                    android:text="@string/mytba_enable_notifications_title"
+                    android:textColor="@color/white"
+                    android:textSize="36sp" />
+
+                <TextView
+                    android:id="@+id/enable_notifications_subtitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:gravity="center_horizontal"
+                    android:text="@string/mytba_enable_notifications_description"
+                    android:textColor="@color/white"
+                    android:textSize="24sp" />
+
+                <TextView
+                    android:id="@+id/enable_notifications_clarification"
+                    android:visibility="gone"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:gravity="center_horizontal"
+                    android:text="@string/mytba_enable_notifications_clarification"
+                    android:textColor="@color/white"
+                    android:textSize="24sp" />
+            </LinearLayout>
+
+
+            <Button
+                android:id="@+id/enable_notifications_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_centerHorizontal="true"
+                android:layout_margin="16dp"
+                android:text="@string/mytba_enable_notifications"
+                android:textColor="@color/black"
+                app:backgroundTint="@color/md_grey_200"
+                style="?attr/materialButtonOutlinedStyle"/>
+        </RelativeLayout>
+
     </androidx.viewpager.widget.ViewPager>
 
     <me.relex.circleindicator.CircleIndicator

--- a/android/src/main/res/values/strings_onboarding.xml
+++ b/android/src/main/res/values/strings_onboarding.xml
@@ -18,6 +18,10 @@
     <string name="mytba_yellow_button_description">You can use myTBA anywhere you see this yellow button.</string>
     <string name="mytba_get_started_title">Ready to get started with myTBA?</string>
     <string name="mytba_login_prompt">Sign in with your Google account so we can save and sync your data.</string>
+    <string name="mytba_enable_notifications">Enable Notifications</string>
+    <string name="mytba_enable_notifications_title">Enable Push Notifications</string>
+    <string name="mytba_enable_notifications_description">In order to receive updates about your favorite teams and events, you\'ll need to allow The Blue Alliance to trigger notifications on your device</string>
+    <string name="mytba_enable_notifications_clarification">Without granting the notification permission, you will not receive updates about ongoing events. You can always enable this later in settings.</string>
     <string name="mytba_login_success">Success!</string>
     <string name="mytba_login_success_subtitle">Enjoy using myTBA.</string>
     <string name="mytba_no_signin_intent">Unable to complete login</string>
@@ -48,6 +52,10 @@
     <string name="mytba_prompt_message">You can always enable it later in Settings.</string>
     <string name="mytba_prompt_yes">Enable Now</string>
     <string name="mytba_prompt_cancel">Maybe Later</string>
+
+    <!-- Notification prompt dialog -->
+    <string name="mytba_prompt_notif_permission">Do you want to enable notifications?</string>
+    <string name="mytba_prompt_notif_permission_message">You will not receive realtime updates until you do, but you can always enable it later in settings</string>
 
     <!-- Status Messages -->
     <string name="loading_config">Loading app configuration</string>

--- a/android/src/main/res/values/strings_settings.xml
+++ b/android/src/main/res/values/strings_settings.xml
@@ -5,6 +5,7 @@
     <string name="pref_header_notifications">Notifications</string>
     <string name="pref_header_general">General</string>
     <string name="pref_header_privacy">Privacy</string>
+    <string name="pref_header_permissions">Permissions</string>
     <string name="pref_header_account">Account</string>
 
     <!-- Account -->
@@ -65,6 +66,7 @@
     <string name="select_led_color">Select LED Color</string>
 
     <string name="pref_notification_headsup">Heads Up Notifications</string>
+    <string name="pref_notification_permission_granted">Notification Permission Granted</string>
 
     <!-- Dark Mode Settings -->
     <string name="pref_dark_mode">App Theme</string>

--- a/android/src/main/res/xml/notification_preferences.xml
+++ b/android/src/main/res/xml/notification_preferences.xml
@@ -23,12 +23,5 @@
             android:dependency="enable_notifications"
             android:summary="@string/pref_notification_led_enabled_summary"
             android:title="@string/pref_notification_led_enabled" />
-        <com.thebluealliance.spectrum.SpectrumPreference
-            android:defaultValue="@color/md_indigo_500"
-            android:key="notification_led_color"
-            android:dependency="notification_led_enabled"
-            android:title="@string/pref_notification_led_color"
-            android:negativeButtonText="@string/cancel"
-            app:spectrum_colors="@array/led_colors" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/android/src/main/res/xml/notification_preferences_tiramisu.xml
+++ b/android/src/main/res/xml/notification_preferences_tiramisu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <PreferenceCategory android:title="@string/pref_header_permissions">
+        <SwitchPreference
+            android:key="notification_permission_enabled"
+            app:persistent="false"
+            android:title="@string/pref_notification_permission_granted" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/android/src/test/java/com/thebluealliance/androidclient/auth/firebase/FirebaseAuthProviderTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/auth/firebase/FirebaseAuthProviderTest.java
@@ -36,18 +36,6 @@ public class FirebaseAuthProviderTest {
     }
 
     @Test
-    public void onStart() {
-        mFirebaseAuthProvider.onStart();
-        verify(mGoogleAuthProvider).onStart();
-    }
-
-    @Test
-    public void onStop() {
-        mFirebaseAuthProvider.onStop();
-        verify(mGoogleAuthProvider).onStop();
-    }
-
-    @Test
     public void isUserSignedIn() {
         assertFalse(mFirebaseAuthProvider.isUserSignedIn());
 

--- a/android/src/test/java/com/thebluealliance/androidclient/gcm/GCMMessageHandlerTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/gcm/GCMMessageHandlerTest.java
@@ -3,6 +3,8 @@ package com.thebluealliance.androidclient.gcm;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import android.Manifest;
+import android.app.Application;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -30,6 +32,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.android.controller.ServiceController;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowApplication;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -62,9 +65,12 @@ public class GCMMessageHandlerTest {
 
         @Before
         public void setUp() {
-            Context applicationContext = ApplicationProvider.getApplicationContext();
+            Application applicationContext = ApplicationProvider.getApplicationContext();
             mNotificationManager = (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
             mService = buildAndStartService();
+
+            ShadowApplication shadowApplication = Shadows.shadowOf(applicationContext);
+            shadowApplication.grantPermissions(Manifest.permission.POST_NOTIFICATIONS);
         }
 
         @ParameterizedRobolectricTestRunner.Parameters(name = "NotificationType = {0}")
@@ -129,9 +135,12 @@ public class GCMMessageHandlerTest {
 
         @Before
         public void setUp() {
-            Context applicationContext = ApplicationProvider.getApplicationContext();
+            Application applicationContext = ApplicationProvider.getApplicationContext();
             mNotificationManager = (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
             mService = buildAndStartService();
+
+            ShadowApplication shadowApplication = Shadows.shadowOf(applicationContext);
+            shadowApplication.grantPermissions(Manifest.permission.POST_NOTIFICATIONS);
         }
 
         @Test


### PR DESCRIPTION
**Summary:** 
Breaking Changes:
 - https://developer.android.com/about/versions/13/behavior-changes-13
 - https://developer.android.com/about/versions/14/behavior-changes-14

The biggest thing is notification permissions being moved to a runtime thing. This means we need to extend the onboarding flow to include requesting the permission. Some other things:

 - centralize the logic for login/etc in `MyTbaOnboardingController`, since there's two entry points for this
 - stop using `startActivityForResult` in favor of the new [`ActivityResultLauncher`](https://developer.android.com/training/basics/intents/result)
 - skip posting notifications if we don't have the permission
 - Add a toggle in settings to re-request the permission if needed