### PR TITLE
Fix Match Key Validation for Double Elim SFs

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/helpers/MatchHelper.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/helpers/MatchHelper.java
@@ -28,7 +28,7 @@ public final class MatchHelper {
     public static boolean validateMatchKey(String key) {
         if (key == null || key.isEmpty()) return false;
 
-        return key.matches("^[1-9]\\d{3}[a-z,0-9]+_(?:qm|ef\\dm|qf\\dm|sf\\dm|f\\dm)\\d+$");
+        return key.matches("^[1-9]\\d{3}[a-z,0-9]+_(?:qm|ef\\d+m|qf\\d+m|sf\\d+m|f\\d+m)\\d+$");
     }
 
     public static String getEventKeyFromMatchKey(String matchKey) {

--- a/android/src/test/java/com/thebluealliance/androidclient/helpers/MatchHelperTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/helpers/MatchHelperTest.java
@@ -2,6 +2,7 @@ package com.thebluealliance.androidclient.helpers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +45,15 @@ public class MatchHelperTest {
     public void testGetScore() {
         assertEquals(43, Match.getRedScore(mMatch.getAlliances()).intValue());
         assertEquals(0, Match.getBlueScore(mMatch.getAlliances()).intValue());
+    }
+
+    @Test
+    public void testValidateMatchKey() {
+        assertTrue(MatchHelper.validateMatchKey("2016cthar_qm1"));
+        assertTrue(MatchHelper.validateMatchKey("2016cmpmi_ef1m2"));
+        assertTrue(MatchHelper.validateMatchKey("2016cmpmi_sf1m3"));
+        assertTrue(MatchHelper.validateMatchKey("2016cthar_qf1m2"));
+        assertTrue(MatchHelper.validateMatchKey("2023cmptx_sf10m1"));
     }
 
     @Test


### PR DESCRIPTION
**Summary:** 
I can't believe nobody actively reported this (or that I didn't notice it in the crash logs before)...

The app's match key validation doesn't handle set numbers with two digits, so it crashes

We get this crash:

```
Fatal Exception: java.lang.IllegalArgumentException
Invalid match key 2023cmptx_sf11m1
com.thebluealliance.androidclient.fragments.match.MatchInfoFragment.onCreate (MatchInfoFragment.java:6) 
```

Added some tests to cover this

**Screenshots:**

![image](https://github.com/the-blue-alliance/the-blue-alliance-android/assets/2754863/fd2bdd92-2794-4bad-a5bb-78a0a91b073f)

