### PR TITLE
Fix team event navigation sometimes loading the wrong event data

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/activities/TeamAtEventActivity.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/activities/TeamAtEventActivity.java
@@ -227,7 +227,7 @@ public class TeamAtEventActivity extends MyTBASettingsActivity
     public void updateEventsParticipated(List<Event> events) {
         mEventsParticipated = ImmutableList.copyOf(events);
 
-        int requestedEventIndex = 0;
+        int requestedEventIndex = -1;
         for (int i = 0; i < mEventsParticipated.size(); i++) {
             if (mEventsParticipated.get(i).getKey().equals(mEventKey)) {
                 requestedEventIndex = i;


### PR DESCRIPTION
**Summary:** 
Navigating to a Team at Event page from the team event list would sometimes load data from the incorrect event.

This occured due to a combinatino of two things:
 * Something wonky is happening between the API response, HTTP cache, and DB cache resulting in `updateEventsParticipated()` getting called multiple times with different event lists.
 * When searching for our currently selected event in that event list, we default to an index of 0, and if the event is not in the list we merrily proceed with that default 0 index, resulting in us showing the incorrect data.

**Issues Reference:** 
Fixes #973

**Test Plan:** 
Repro steps in #973 mostly worked for me; note that there's some odd cache behavior happening here that needs to happen. When I observed this occurring we had database-cached responses that had a different set of events for the team than the API provided. The reproduction steps weren't 100% consistent, but consistent enough.

In theory this should self-resolve, but the API responses were coming from our HTTP cache and we explicitly don't write to the DB cache if the API response is coming from the HTTP cache. There's a lot to unpack there still.
