### PR TITLE
Fix "current" week calculation outside the regular season

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/fragments/EventsByWeekFragment.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/fragments/EventsByWeekFragment.java
@@ -197,7 +197,7 @@ public class EventsByWeekFragment
         List<EventWeekTab> tabs = ((EventsByWeekFragmentPagerAdapter) mViewPager.getAdapter())
                 .getTabs();
         for (int i = 0; i < tabs.size(); i++) {
-            if (tabs.get(i).getWeek() >= week) {
+            if (tabs.get(i).includesWeek(week)) {
                 return i;
             }
         }

--- a/android/src/main/java/com/thebluealliance/androidclient/models/EventWeekTab.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/models/EventWeekTab.java
@@ -5,12 +5,14 @@ import java.util.ArrayList;
 public class EventWeekTab {
 
     private String mLabel;
-    private int mWeek;
+    private int mStartWeek = Integer.MAX_VALUE;
+
+    private int mEndWeek = Integer.MIN_VALUE;
+
     private ArrayList<String> mEventKeys;
 
-    public EventWeekTab(String label, int week) {
+    public EventWeekTab(String label) {
         mLabel = label;
-        mWeek = week;
         mEventKeys = new ArrayList<>();
     }
 
@@ -18,16 +20,24 @@ public class EventWeekTab {
         return mLabel;
     }
 
-    public int getWeek() {
-        return mWeek;
+    public boolean includesWeek(int week) {
+        return week >= mStartWeek && week <= mEndWeek;
     }
 
     public ArrayList<String> getEventKeys() {
         return mEventKeys;
     }
 
-    public void addEventKey(String eventKey) {
-        mEventKeys.add(eventKey);
+    public void addEvent(Event event) {
+        mEventKeys.add(event.getKey());
+
+        int eventWeek = event.getWeek() != null ? event.getWeek() : -1;
+        if (mStartWeek > eventWeek) {
+            mStartWeek = eventWeek;
+        }
+        if (mEndWeek < eventWeek) {
+            mEndWeek = eventWeek;
+        }
     }
 
     @Override

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriber.java
@@ -4,7 +4,6 @@ import com.thebluealliance.androidclient.comparators.EventSortByDateComparator;
 import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.models.Event;
 import com.thebluealliance.androidclient.models.EventWeekTab;
-import com.thebluealliance.androidclient.types.EventType;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriber.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriber.java
@@ -4,6 +4,7 @@ import com.thebluealliance.androidclient.comparators.EventSortByDateComparator;
 import com.thebluealliance.androidclient.helpers.EventHelper;
 import com.thebluealliance.androidclient.models.Event;
 import com.thebluealliance.androidclient.models.EventWeekTab;
+import com.thebluealliance.androidclient.types.EventType;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,19 +30,16 @@ public class EventTabSubscriber extends BaseAPISubscriber<List<Event>, List<Even
 
         LinkedHashMap<String, EventWeekTab> eventTabs = new LinkedHashMap<>();
         for (Event event : mAPIData) {
-            int eventWeek = event.getWeek() != null
-                    ? event.getWeek()
-                    : -1;
             String label = EventHelper.generateLabelForEvent(event);
             if (!eventTabs.containsKey(label)) {
-                eventTabs.put(label, new EventWeekTab(label, eventWeek));
+                eventTabs.put(label, new EventWeekTab(label));
             }
 
             EventWeekTab tab = eventTabs.get(label);
             if (tab == null) {
                 throw new RuntimeException("Expected to find event tab, but can't!");
             }
-            tab.addEventKey(event.getKey());
+            tab.addEvent(event);
         }
 
         for (Map.Entry<String, EventWeekTab> tab : eventTabs.entrySet()) {

--- a/android/src/test/java/com/thebluealliance/androidclient/models/EventWeekTabTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/models/EventWeekTabTest.java
@@ -1,0 +1,46 @@
+package com.thebluealliance.androidclient.models;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class EventWeekTabTest {
+
+  @Test
+  public void addEventSetsStartEndWeek() {
+    EventWeekTab tab = new EventWeekTab("label");
+    Event event = new Event();
+    event.setWeek(5);
+    tab.addEvent(event);
+
+    assertFalse(tab.includesWeek(4));
+    assertTrue(tab.includesWeek(5));
+    assertFalse(tab.includesWeek(6));
+  }
+
+  @Test
+  public void addMultipleEvents_multipleWeeks() {
+    EventWeekTab tab = new EventWeekTab("label");
+
+    Event event = new Event();
+    event.setWeek(5);
+    tab.addEvent(event);
+
+    Event event2 = new Event();
+    event2.setWeek(7);
+    tab.addEvent(event2);
+
+    assertFalse(tab.includesWeek(4));
+    assertTrue(tab.includesWeek(5));
+    assertTrue(tab.includesWeek(6));
+    assertTrue(tab.includesWeek(7));
+    assertFalse(tab.includesWeek(8));
+  }
+}

--- a/android/src/test/java/com/thebluealliance/androidclient/models/EventWeekTabTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/models/EventWeekTabTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/android/src/test/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriberTest.java
+++ b/android/src/test/java/com/thebluealliance/androidclient/subscribers/EventTabSubscriberTest.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.androidclient.subscribers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -52,7 +53,8 @@ public class EventTabSubscriberTest {
         assertEquals(tabs.size(), 16);
         for (int i = 0; i < tabs.size(); i++) {
             EventWeekTab tab = tabs.get(i);
-            assertEquals(String.format("Tab %1$d week fail", i), weeks[i], tab.getWeek());
+            int week = weeks[i];
+            assertTrue(String.format("Tab %1$d week fail", i), tab.includesWeek(week));
             assertEquals(String.format("Tab %1$d count fail", i), sizes[i], tab.getEventKeys().size());
             assertEquals(String.format("Tab %1$d label fail", i), labels[i], tab.getLabel());
         }


### PR DESCRIPTION
**Summary:** 
Our previous "current" week calculation doesn't really work outside the regular season because we are comparing the current week number of the year to tabs that represent an entire month.

For example, if the season ends on "week 7" (let's ignore pre-season for the sake of this example), then the following month is "week 8" and two months later is "week 9". But going by the calendar, we are on like week 20 by that point. 

Instead, our `EventWeekTab` now represents a _range_ of actual calendar weeks so we can find the correct tab for the current week.

**Issues Reference:** 
Fixes #981

**Test Plan:** 
New unit tests! 
Also confirmed November is now correctly selected by default instead of December ✅ 
