### PR TITLE
Strip double quotes from search queries

### DIFF
--- a/android/src/main/java/com/thebluealliance/androidclient/database/Database.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/database/Database.java
@@ -596,8 +596,9 @@ public class Database extends SQLiteOpenHelper {
     }
 
     public Cursor getMatchesForTeamQuery(String query) {
+        String sanitizedQuery = sanitizeQuery(query);
         String selection = SearchTeam.TITLES + " MATCH ?";
-        String[] selectionArgs = new String[]{query};
+        String[] selectionArgs = new String[]{sanitizedQuery};
 
         SQLiteQueryBuilder builder = new SQLiteQueryBuilder();
         builder.setTables(TABLE_SEARCH_TEAMS);
@@ -616,8 +617,9 @@ public class Database extends SQLiteOpenHelper {
     }
 
     public Cursor getMatchesForEventQuery(String query) {
+        String sanitizedQuery = sanitizeQuery(query);
         String selection = SearchEvent.TITLES + " MATCH ?";
-        String[] selectionArgs = new String[]{query};
+        String[] selectionArgs = new String[]{sanitizedQuery};
 
         SQLiteQueryBuilder builder = new SQLiteQueryBuilder();
         builder.setTables(TABLE_SEARCH_EVENTS);
@@ -633,5 +635,9 @@ public class Database extends SQLiteOpenHelper {
             return null;
         }
         return cursor;
+    }
+
+    public String sanitizeQuery(String query) {
+        return query.replace("\"", "");
     }
 }


### PR DESCRIPTION
**Summary:** 
Just strip quotes from search queries

**Issues Reference:** 
Resolves #869

**Test Plan:** 
Search for something with quotes - it no longer crashes!
