### PR TITLE
Squeeze a few more dp out of the cargo ship breakdowns

### DIFF
--- a/android/src/main/res/layout/match_breakdown_2019.xml
+++ b/android/src/main/res/layout/match_breakdown_2019.xml
@@ -144,23 +144,23 @@
                 android:id="@+id/breakdown2019_red_cargo_ship_null_panels"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingRight="10dp"
-                android:drawablePadding="3dp"
+                android:paddingRight="4dp"
+                android:drawablePadding="2dp"
                 android:drawableLeft="@drawable/breakdown2019_null_hatch_panel"
                 tools:text="2"/>
             <TextView
                 android:id="@+id/breakdown2019_red_cargo_ship_panels"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingRight="10dp"
-                android:drawablePadding="3dp"
+                android:paddingRight="4dp"
+                android:drawablePadding="2dp"
                 android:drawableLeft="@drawable/breakdown2019_hatch_panel"
                 tools:text="2"/>
             <TextView
                 android:id="@+id/breakdown2019_red_cargo_ship_cargo"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:drawablePadding="3dp"
+                android:drawablePadding="2dp"
                 android:drawableLeft="@drawable/breakdown2019_cargo"
                 tools:text="2"/>
         </LinearLayout>
@@ -174,23 +174,23 @@
                 android:id="@+id/breakdown2019_blue_cargo_ship_null_panels"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingRight="10dp"
-                android:drawablePadding="3dp"
+                android:paddingRight="4dp"
+                android:drawablePadding="2dp"
                 android:drawableLeft="@drawable/breakdown2019_null_hatch_panel"
                 tools:text="2"/>
             <TextView
                 android:id="@+id/breakdown2019_blue_cargo_ship_panels"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingRight="10dp"
-                android:drawablePadding="3dp"
+                android:paddingRight="4dp"
+                android:drawablePadding="2dp"
                 android:drawableLeft="@drawable/breakdown2019_hatch_panel"
                 tools:text="3"/>
             <TextView
                 android:id="@+id/breakdown2019_blue_cargo_ship_cargo"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:drawablePadding="3dp"
+                android:drawablePadding="2dp"
                 android:drawableLeft="@drawable/breakdown2019_cargo"
                 tools:text="1"/>
         </LinearLayout>


### PR DESCRIPTION
**Summary:** 
Cargo ship breakdowns were getting clipped on super small screens.
In a perfect world we would use a smarter layout that breaks to multiple lines, but I suspect not many folks are looking at 2019 scores anyway. So I just squeezed ~24dp out of the padding.

**Issues Reference:** 
Fixes #898 

**Screenshots:**
![image](https://github.com/user-attachments/assets/380bb275-6513-435c-b5e7-10e91352f9f8)

