### PR TITLE
Remove Multidex declaration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -109,7 +109,6 @@ android {
         targetSdkVersion 35
         versionCode versionNum
         versionName version.toString()
-        multiDexEnabled true
 
         testInstrumentationRunner "com.thebluealliance.androidclient.testing.TbaInstrumentationRunner"
 
@@ -148,9 +147,9 @@ android {
 
     android.applicationVariants.all { variant ->
         variant.outputs.each { output ->
-            def apkName = "tba-android-";
-            apkName += "v" + version.tagName;
-            apkName += "-" + variant.buildType.name + ".apk";
+            def apkName = "tba-android-"
+            apkName += "v" + version.tagName
+            apkName += "-" + variant.buildType.name + ".apk"
             output.outputFileName = apkName
         }
     }
@@ -237,7 +236,6 @@ dependencies {
     implementation 'androidx.core:core:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
-    implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.preference:preference:1.2.1'
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
@@ -307,7 +305,6 @@ dependencies {
     testImplementation 'androidx.test.ext:junit:1.1.5'
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation "org.robolectric:robolectric:${robolectricVersion}"
-    testImplementation "org.robolectric:shadows-multidex:${robolectricVersion}"
     testAnnotationProcessor "com.google.dagger:dagger-compiler:${daggerVersion}"
 
     // instrumentation

--- a/android/src/main/java/com/thebluealliance/androidclient/TbaAndroid.java
+++ b/android/src/main/java/com/thebluealliance/androidclient/TbaAndroid.java
@@ -2,6 +2,7 @@ package com.thebluealliance.androidclient;
 
 import static com.thebluealliance.androidclient.gcm.notifications.BaseNotification.NOTIFICATION_CHANNEL;
 
+import android.app.Application;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.os.Build;
@@ -10,7 +11,6 @@ import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.hilt.work.HiltWorkerFactory;
-import androidx.multidex.MultiDexApplication;
 import androidx.work.Configuration;
 
 import com.facebook.stetho.Stetho;
@@ -22,7 +22,7 @@ import javax.inject.Inject;
 import dagger.hilt.android.HiltAndroidApp;
 
 @HiltAndroidApp
-public class TbaAndroid extends MultiDexApplication implements Configuration.Provider {
+public class TbaAndroid extends Application implements Configuration.Provider {
 
     @Inject TBAStatusController mStatusController;
     @Inject AppConfig mAppConfig;


### PR DESCRIPTION
Since the min SDK is 24, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l