### PR TITLE
Add workflow to close inactive issues

### DIFF
--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -1,0 +1,21 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 700
+          days-before-issue-close: 30
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had activity in over 2 years. It will be closed in 30 days if no further activity occurs."
+          close-issue-message: "This issue was closed because it has been inactive for over 2 years. If this is still relevant, please reopen it."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (copied from [the-blue-alliance](https://github.com/the-blue-alliance/the-blue-alliance/blob/master/.github/workflows/close_inactive_issues.yml)) that automatically closes stale issues
- Issues are marked stale after 700 days (~2 years) of inactivity, then closed 30 days later
- PRs are excluded from stale detection

## Test plan
- [ ] Verify workflow syntax is valid by checking the Actions tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)