### PR TITLE
Fix double status bar inset on detail screens

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
@@ -3,6 +3,7 @@ package com.thebluealliance.android.ui.districts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -54,6 +55,7 @@ fun DistrictDetailScreen(
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
+            windowInsets = WindowInsets(0),
             title = {
                 Text(
                     text = uiState.district?.displayName ?: "District",

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventDetailScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -139,6 +140,7 @@ fun EventDetailScreen(
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
+            windowInsets = WindowInsets(0),
             title = {
                 Text(
                     text = uiState.event?.let { "${it.year} ${it.name}" } ?: "Event",

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -52,6 +53,7 @@ fun MatchDetailScreen(
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
+            windowInsets = WindowInsets(0),
             title = {
                 Text(
                     text = uiState.match?.fullLabel ?: "Match",

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/search/SearchScreen.kt
@@ -1,6 +1,7 @@
 package com.thebluealliance.android.ui.search
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -47,6 +48,7 @@ fun SearchScreen(
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
+            windowInsets = WindowInsets(0),
             title = {
                 TextField(
                     value = uiState.query,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -3,6 +3,7 @@ package com.thebluealliance.android.ui.teams
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -128,6 +129,7 @@ fun TeamDetailScreen(
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
+            windowInsets = WindowInsets(0),
             title = {
                 val team = uiState.team
                 Text(


### PR DESCRIPTION
## Summary

- Detail screens (Event, Team, Match, District, Search) nest their own `TopAppBar` inside the `Scaffold`'s content area, which already handles status bar insets
- The nested `TopAppBar` was applying status bar padding again by default, creating a visible gap between the status bar and the app bar title
- Fix: set `windowInsets = WindowInsets(0)` on all nested `TopAppBar`s

## Test plan
- [x] Verified on emulator — Event Detail screen gap is gone, matches main screen spacing
- [ ] Check all detail screens (Team, Match, District, Search) for consistent top spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)