### PR TITLE
Add Firebase Crashlytics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.room)
     alias(libs.plugins.google.services)
+    alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.aboutlibraries)
 }
 
@@ -147,6 +148,7 @@ dependencies {
     implementation(libs.firebase.auth)
     implementation(libs.firebase.config)
     implementation(libs.firebase.messaging)
+    implementation(libs.firebase.crashlytics)
 
     // Credentials (Google Sign-In)
     implementation(libs.credentials)

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -4,6 +4,11 @@
 
     <application
         android:networkSecurityConfig="@xml/network_security_config"
-        tools:replace="android:networkSecurityConfig" />
+        tools:replace="android:networkSecurityConfig">
+
+        <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="false" />
+        <meta-data android:name="firebase_crashlytics_auto_collection_enabled" android:value="false" />
+
+    </application>
 
 </manifest>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,5 @@ plugins {
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.room) apply false
     alias(libs.plugins.aboutlibraries) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ aboutlibraries = "14.0.0-b02"
 
 firebase-bom = "33.7.0"
 google-services = "4.4.2"
+firebase-crashlytics-plugin = "3.0.3"
 credentials = "1.5.0"
 googleid = "1.1.1"
 
@@ -121,3 +122,4 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
 room = { id = "androidx.room", version.ref = "room" }
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics-plugin" }


### PR DESCRIPTION
## Summary
- Wire up the Firebase Crashlytics Gradle plugin and SDK dependency (already declared in version catalog)
- Disable Crashlytics collection entirely in debug builds via manifest `meta-data` flags
- Release builds get automatic crash reporting to the `tbatv-prod-hrd` Firebase project

## Changes
- `gradle/libs.versions.toml` — add plugin version + plugin alias
- `build.gradle.kts` — declare plugin with `apply false`
- `app/build.gradle.kts` — apply plugin + add dependency
- `app/src/debug/AndroidManifest.xml` — disable collection and auto-collection in debug

## Test plan
- [x] `./gradlew :app:assembleDebug` builds successfully
- [x] `./gradlew :app:testDebugUnitTest` all tests pass
- [x] App launches on emulator without crashes
- [x] Logcat confirms Crashlytics initializes but does not collect in debug

🤖 Generated with [Claude Code](https://claude.com/claude-code)