### PR TITLE
Add Team@Event detail screen

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavHost.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavHost.kt
@@ -17,6 +17,7 @@ import com.thebluealliance.android.ui.more.MoreScreen
 import com.thebluealliance.android.ui.more.ThanksScreen
 import com.thebluealliance.android.ui.mytba.MyTBAScreen
 import com.thebluealliance.android.ui.settings.SettingsScreen
+import com.thebluealliance.android.ui.teamevent.TeamEventDetailScreen
 import com.thebluealliance.android.ui.teams.TeamDetailScreen
 import com.thebluealliance.android.ui.teams.TeamsScreen
 
@@ -114,6 +115,9 @@ fun TBANavHost(
                     navController.navigate(Screen.MatchDetail(matchKey))
                 },
                 onNavigateToMyTBA = { navController.navigate(Screen.MyTBA) },
+                onNavigateToTeamEvent = { teamKey, eventKey ->
+                    navController.navigate(Screen.TeamEventDetail(teamKey, eventKey))
+                },
             )
         }
         composable<Screen.MatchDetail>(
@@ -153,6 +157,23 @@ fun TBANavHost(
                     navController.navigate(Screen.EventDetail(eventKey))
                 },
                 onNavigateToMyTBA = { navController.navigate(Screen.MyTBA) },
+                onNavigateToTeamEvent = { teamKey, eventKey ->
+                    navController.navigate(Screen.TeamEventDetail(teamKey, eventKey))
+                },
+            )
+        }
+        composable<Screen.TeamEventDetail> {
+            TeamEventDetailScreen(
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToMatch = { matchKey ->
+                    navController.navigate(Screen.MatchDetail(matchKey))
+                },
+                onNavigateToTeam = { teamKey ->
+                    navController.navigate(Screen.TeamDetail(teamKey))
+                },
+                onNavigateToEvent = { eventKey ->
+                    navController.navigate(Screen.EventDetail(eventKey))
+                },
             )
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -13,6 +13,7 @@ sealed interface Screen {
     @Serializable data class EventDetail(val eventKey: String) : Screen
     @Serializable data class TeamDetail(val teamKey: String) : Screen
     @Serializable data class MatchDetail(val matchKey: String) : Screen
+    @Serializable data class TeamEventDetail(val teamKey: String, val eventKey: String) : Screen
     @Serializable data class DistrictDetail(val districtKey: String) : Screen
     @Serializable data object MyTBA : Screen
     @Serializable data object Search : Screen

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/TBAApp.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/TBAApp.kt
@@ -83,6 +83,7 @@ fun TBAApp(activity: MainActivity? = null) {
                     destination.hasRoute(Screen.EventDetail::class) -> "EventDetail"
                     destination.hasRoute(Screen.TeamDetail::class) -> "TeamDetail"
                     destination.hasRoute(Screen.MatchDetail::class) -> "MatchDetail"
+                    destination.hasRoute(Screen.TeamEventDetail::class) -> "TeamEventDetail"
                     destination.hasRoute(Screen.DistrictDetail::class) -> "DistrictDetail"
                     destination.hasRoute(Screen.MyTBA::class) -> "MyTBA"
                     destination.hasRoute(Screen.Search::class) -> "Search"

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -1,0 +1,197 @@
+package com.thebluealliance.android.ui.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.thebluealliance.android.domain.model.Match
+import com.thebluealliance.android.domain.model.shortLabel
+
+private val compLevelOrder = mapOf("qm" to 0, "ef" to 1, "qf" to 2, "sf" to 3, "f" to 4)
+private val compLevelNames = mapOf("qm" to "Quals", "ef" to "Eighths", "qf" to "Quarters", "sf" to "Semis", "f" to "Finals")
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun MatchList(
+    matches: List<Match>?,
+    onNavigateToMatch: (String) -> Unit,
+    headerContent: (LazyListScope.() -> Unit)? = null,
+) {
+    if (matches == null) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+        return
+    }
+    if (matches.isEmpty()) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("No matches", style = MaterialTheme.typography.bodyLarge)
+        }
+        return
+    }
+
+    val sorted = matches.sortedWith(
+        compareBy({ compLevelOrder[it.compLevel] ?: 99 }, { it.setNumber }, { it.matchNumber })
+    )
+    val grouped = sorted.groupBy { it.compLevel }
+
+    // Calculate index of first unplayed match for auto-scroll
+    // When headerContent is present, it adds items before the match groups
+    val headerOffset = if (headerContent != null) 2 else 0
+    val firstUnplayedIndex = run {
+        var index = headerOffset
+        for ((_, levelMatches) in grouped) {
+            index++ // group header
+            for (match in levelMatches) {
+                if (match.redScore < 0) return@run index
+                index++
+            }
+        }
+        -1
+    }
+    // Scroll so the last few played matches are visible above the first unplayed
+    val scrollTarget = if (firstUnplayedIndex > 2) firstUnplayedIndex - 2 else 0
+    val listState = rememberLazyListState()
+    LaunchedEffect(scrollTarget) {
+        if (scrollTarget > 0) {
+            listState.scrollToItem(scrollTarget)
+        }
+    }
+
+    val headerKeys = remember(grouped) {
+        grouped.keys.map { "match_header_$it" }.toSet()
+    }
+    @Suppress("UNUSED_VARIABLE")
+    val stuckHeaderKey by remember {
+        derivedStateOf {
+            listState.layoutInfo.visibleItemsInfo
+                .firstOrNull { item ->
+                    val key = item.key as? String
+                    key != null && key in headerKeys && item.offset <= 0
+                }?.key as? String
+        }
+    }
+
+    LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+        if (headerContent != null) {
+            headerContent()
+        }
+        grouped.forEach { (level, levelMatches) ->
+            val headerKey = "match_header_$level"
+            stickyHeader(key = headerKey) {
+                Text(
+                    text = compLevelNames[level] ?: level.uppercase(),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surface)
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+            items(levelMatches, key = { it.key }) { match ->
+                MatchItem(match, onClick = { onNavigateToMatch(match.key) })
+                HorizontalDivider()
+            }
+        }
+    }
+}
+
+@Composable
+fun MatchItem(match: Match, onClick: () -> Unit) {
+    val label = match.shortLabel
+    val isPlayed = match.redScore >= 0
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(0.15f),
+        )
+        Column(modifier = Modifier.weight(0.35f)) {
+            Text(
+                text = match.redTeamKeys.joinToString(", ") { it.removePrefix("frc") },
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = if (match.winningAlliance == "red") FontWeight.Bold else FontWeight.Normal,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Text(
+                text = match.blueTeamKeys.joinToString(", ") { it.removePrefix("frc") },
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = if (match.winningAlliance == "blue") FontWeight.Bold else FontWeight.Normal,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        if (isPlayed) {
+            Column(
+                modifier = Modifier.weight(0.15f),
+                horizontalAlignment = Alignment.End,
+            ) {
+                Text(
+                    text = match.redScore.toString(),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = if (match.winningAlliance == "red") FontWeight.Bold else FontWeight.Normal,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                Text(
+                    text = match.blueScore.toString(),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = if (match.winningAlliance == "blue") FontWeight.Bold else FontWeight.Normal,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        } else {
+            Box(
+                modifier = Modifier.weight(0.15f),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Text(
+                    text = formatMatchTime(match.time),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+private val matchTimeFormat = java.time.format.DateTimeFormatter.ofPattern(
+    "EEE h:mma", java.util.Locale.US,
+)
+
+fun formatMatchTime(epochSeconds: Long?): String {
+    if (epochSeconds == null) return "\u2014"
+    val instant = java.time.Instant.ofEpochSecond(epochSeconds)
+    return matchTimeFormat.format(instant.atZone(java.time.ZoneId.systemDefault()))
+        .replace("AM", "a").replace("PM", "p")
+}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -1,0 +1,166 @@
+package com.thebluealliance.android.ui.teamevent
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.thebluealliance.android.domain.model.Award
+import com.thebluealliance.android.ui.components.EventRow
+import com.thebluealliance.android.ui.components.MatchList
+import com.thebluealliance.android.ui.components.TeamRow
+import kotlinx.coroutines.launch
+
+private val TABS = listOf("Matches", "Awards")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TeamEventDetailScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToMatch: (String) -> Unit,
+    onNavigateToTeam: (String) -> Unit,
+    onNavigateToEvent: (String) -> Unit,
+    viewModel: TeamEventDetailViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
+    val pagerState = rememberPagerState(pageCount = { TABS.size })
+    val coroutineScope = rememberCoroutineScope()
+
+    val team = uiState.team
+    val event = uiState.event
+    val titleText = if (team != null && event != null) {
+        "${team.number} @ ${event.shortName ?: event.name}"
+    } else {
+        "Team @ Event"
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            windowInsets = WindowInsets(0),
+            title = { Text(text = titleText, maxLines = 1) },
+            navigationIcon = {
+                IconButton(onClick = onNavigateBack) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                }
+            },
+        )
+
+        PrimaryScrollableTabRow(
+            selectedTabIndex = pagerState.currentPage,
+            edgePadding = 0.dp,
+        ) {
+            TABS.forEachIndexed { index, title ->
+                Tab(
+                    selected = pagerState.currentPage == index,
+                    onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
+                    text = { Text(title) },
+                )
+            }
+        }
+
+        PullToRefreshBox(
+            isRefreshing = isRefreshing,
+            onRefresh = viewModel::refreshAll,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize(),
+            ) { page ->
+                when (page) {
+                    0 -> MatchList(
+                        matches = uiState.matches,
+                        onNavigateToMatch = onNavigateToMatch,
+                        headerContent = {
+                            val evt = uiState.event
+                            if (evt != null) {
+                                item(key = "header_event") {
+                                    EventRow(
+                                        event = evt,
+                                        onClick = { onNavigateToEvent(evt.key) },
+                                        showYear = true,
+                                    )
+                                }
+                            }
+                            val tm = uiState.team
+                            if (tm != null) {
+                                item(key = "header_team") {
+                                    TeamRow(
+                                        team = tm,
+                                        onClick = { onNavigateToTeam(tm.key) },
+                                    )
+                                }
+                            }
+                        },
+                    )
+                    1 -> AwardsTab(uiState.awards)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AwardsTab(awards: List<Award>?) {
+    if (awards == null) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+        return
+    }
+    if (awards.isEmpty()) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("No awards", style = MaterialTheme.typography.bodyLarge)
+        }
+        return
+    }
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(awards, key = { "${it.awardType}_${it.awardee.orEmpty()}" }) { award ->
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            ) {
+                Text(
+                    text = award.name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                )
+                if (award.awardee != null) {
+                    Text(
+                        text = award.awardee,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailUiState.kt
@@ -1,0 +1,15 @@
+package com.thebluealliance.android.ui.teamevent
+
+import com.thebluealliance.android.domain.model.Award
+import com.thebluealliance.android.domain.model.Event
+import com.thebluealliance.android.domain.model.Match
+import com.thebluealliance.android.domain.model.Ranking
+import com.thebluealliance.android.domain.model.Team
+
+data class TeamEventDetailUiState(
+    val team: Team? = null,
+    val event: Event? = null,
+    val ranking: Ranking? = null,
+    val matches: List<Match>? = null,
+    val awards: List<Award>? = null,
+)

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailViewModel.kt
@@ -1,0 +1,77 @@
+package com.thebluealliance.android.ui.teamevent
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.thebluealliance.android.data.repository.EventRepository
+import com.thebluealliance.android.data.repository.MatchRepository
+import com.thebluealliance.android.data.repository.TeamRepository
+import com.thebluealliance.android.navigation.Screen
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TeamEventDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val teamRepository: TeamRepository,
+    private val eventRepository: EventRepository,
+    private val matchRepository: MatchRepository,
+) : ViewModel() {
+
+    private val route = savedStateHandle.toRoute<Screen.TeamEventDetail>()
+    val teamKey: String = route.teamKey
+    val eventKey: String = route.eventKey
+
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    val uiState: StateFlow<TeamEventDetailUiState> = combine(
+        teamRepository.observeTeam(teamKey),
+        eventRepository.observeEvent(eventKey),
+        eventRepository.observeEventRankings(eventKey).map { rankings ->
+            rankings.firstOrNull { it.teamKey == teamKey }
+        },
+        matchRepository.observeEventMatches(eventKey).map { matches ->
+            matches.filter { m -> teamKey in m.redTeamKeys || teamKey in m.blueTeamKeys }
+        },
+        eventRepository.observeEventAwards(eventKey).map { awards ->
+            awards.filter { it.teamKey == teamKey }
+        },
+    ) { team, event, ranking, matches, awards ->
+        TeamEventDetailUiState(
+            team = team,
+            event = event,
+            ranking = ranking,
+            matches = matches,
+            awards = awards,
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), TeamEventDetailUiState())
+
+    init {
+        refreshAll()
+    }
+
+    fun refreshAll() {
+        viewModelScope.launch {
+            _isRefreshing.value = true
+            try {
+                launch { try { teamRepository.refreshTeam(teamKey) } catch (_: Exception) {} }
+                launch { try { eventRepository.refreshEvent(eventKey) } catch (_: Exception) {} }
+                launch { try { matchRepository.refreshEventMatches(eventKey) } catch (_: Exception) {} }
+                launch { try { eventRepository.refreshEventRankings(eventKey) } catch (_: Exception) {} }
+                launch { try { eventRepository.refreshEventAwards(eventKey) } catch (_: Exception) {} }
+            } finally {
+                _isRefreshing.value = false
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -80,6 +80,7 @@ fun TeamDetailScreen(
     onNavigateBack: () -> Unit,
     onNavigateToEvent: (String) -> Unit,
     onNavigateToMyTBA: () -> Unit = {},
+    onNavigateToTeamEvent: (teamKey: String, eventKey: String) -> Unit = { _, _ -> },
     viewModel: TeamDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -212,7 +213,11 @@ fun TeamDetailScreen(
                         selectedYear = selectedYear,
                         yearsParticipated = yearsParticipated,
                         onYearSelected = viewModel::selectYear,
-                        onNavigateToEvent = onNavigateToEvent,
+                        onNavigateToEvent = { eventKey ->
+                            val teamKey = uiState.team?.key
+                            if (teamKey != null) onNavigateToTeamEvent(teamKey, eventKey)
+                            else onNavigateToEvent(eventKey)
+                        },
                     )
                     2 -> MediaTab(uiState.media)
                 }


### PR DESCRIPTION
## Summary
- Adds a **TeamEvent detail screen** that shows a team's matches and awards at a specific event
- Tapping a team from the event's Teams or Rankings tab (or an event from the team's Events tab) now navigates to this combined view
- The Matches tab shows an **EventRow** and **TeamRow** inline at the top for context, followed by the match list — no extra Summary tab to tap through
- Extracts a shared `MatchList` composable from `EventDetailScreen` to avoid duplication
- No share button on this screen since there is no equivalent page on thebluealliance.com

Fixes #1009

## Test plan
- [x] Navigate to an event → Teams tab → tap a team → lands on TeamEvent with Matches tab showing EventRow + TeamRow header above matches
- [x] Tap EventRow → navigates to EventDetail
- [x] Tap TeamRow → navigates to TeamDetail
- [x] Tap a match → navigates to MatchDetail
- [x] Awards tab still works
- [x] Navigate to a team → Events tab → tap an event → same TeamEvent screen
- [x] Event Rankings tab → tap a ranking row → navigates to TeamEvent
- [x] EventDetail Matches tab still works unchanged (no header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)