### PR TITLE
Set Crashlytics user ID on auth state change

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/AuthRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/AuthRepository.kt
@@ -2,6 +2,7 @@ package com.thebluealliance.android.data.repository
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -15,7 +16,9 @@ class AuthRepository @Inject constructor(
 ) {
     val currentUser: Flow<FirebaseUser?> = callbackFlow {
         val listener = FirebaseAuth.AuthStateListener { auth ->
-            trySend(auth.currentUser)
+            val user = auth.currentUser
+            FirebaseCrashlytics.getInstance().setUserId(user?.uid.orEmpty())
+            trySend(user)
         }
         firebaseAuth.addAuthStateListener(listener)
         awaitClose { firebaseAuth.removeAuthStateListener(listener) }


### PR DESCRIPTION
## Summary
- Sets `FirebaseCrashlytics.setUserId()` in the `AuthStateListener` callback so crash reports are associated with the Firebase UID
- Clears the user ID (empty string) on sign-out

## Test plan
- [x] Verified crash appears in Firebase Crashlytics console (`gregmarra-tba-dev`) with correct attribution
- [x] Triggered test crash from debug Settings screen, confirmed full stack trace in Crashlytics MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)