### PR TITLE
Add gradle-play-publisher for automated alpha releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.jks
 *.keystore
 .signing/
+play-service-account.json
 
 # Local Properties
 android/src/main/assets/tba.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.aboutlibraries)
+    alias(libs.plugins.play.publisher)
 }
 
 val localProperties = Properties().apply {
@@ -113,6 +114,12 @@ android {
             it.useJUnitPlatform()
         }
     }
+}
+
+play {
+    serviceAccountCredentials.set(rootProject.file(localProperties.getProperty("play.service.account.key", "play-service-account.json")))
+    track.set("alpha")
+    defaultToAppBundles.set(true)
 }
 
 room {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
     alias(libs.plugins.room) apply false
     alias(libs.plugins.aboutlibraries) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
+    alias(libs.plugins.play.publisher) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ junit = "5.11.4"
 turbine = "1.2.0"
 robolectric = "4.14.1"
 mockk = "1.13.13"
+play-publisher = "4.0.0"
 
 [libraries]
 # Compose
@@ -123,3 +124,4 @@ google-services = { id = "com.google.gms.google-services", version.ref = "google
 room = { id = "androidx.room", version.ref = "room" }
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics-plugin" }
+play-publisher = { id = "com.github.triplet.play", version.ref = "play-publisher" }


### PR DESCRIPTION
## Summary
- Add Triple-T gradle-play-publisher (v4.0.0) plugin for automated Play Store publishing
- Configure to publish release AABs to the closed alpha track
- Service account credentials read from `local.properties` (gitignored)
- Add `play-service-account.json` to `.gitignore`

## Test plan
- [x] `./gradlew tasks --group publishing` lists all publishing tasks
- [x] `./gradlew publishReleaseBundle` successfully uploaded v10090004 to alpha track

## Usage
```bash
# Publish to alpha
./gradlew publishReleaseBundle

# Promote from alpha to production
./gradlew promoteReleaseArtifact --from-track alpha --to-track production
```

Requires `play.service.account.key` in `local.properties` pointing to a Google Play service account JSON key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)