### PR TITLE
Fix team deep links from thebluealliance.com URLs

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailViewModel.kt
@@ -39,7 +39,11 @@ class TeamDetailViewModel @Inject constructor(
     private val tbaApi: TbaApi,
 ) : ViewModel() {
 
-    private val teamKey: String = savedStateHandle.toRoute<Screen.TeamDetail>().teamKey
+    private val teamKey: String = savedStateHandle.toRoute<Screen.TeamDetail>().teamKey.let { key ->
+        // Deep links from thebluealliance.com use /team/177 (number only),
+        // but the API/DB key format is "frc177".
+        if (key.all { it.isDigit() }) "frc$key" else key
+    }
 
     private val _selectedYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
     val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()


### PR DESCRIPTION
## Summary
- Deep links from thebluealliance.com use `/team/177` (number only), but the API and database expect `frc177` format
- `TeamDetailViewModel` now normalizes numeric-only team keys by prepending `frc`
- Without this fix, tapping a team deep link loads an empty screen

## Test plan
- [ ] Open `https://www.thebluealliance.com/team/177` deep link — should load Team 177
- [ ] Open `https://www.thebluealliance.com/team/254` deep link — should load Team 254
- [ ] Navigate to a team via in-app flow (already uses `frc` prefix) — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)