### PR TITLE
Show friendly names in notification preference sheet titles

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/NotificationPreferencesSheet.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/NotificationPreferencesSheet.kt
@@ -23,7 +23,7 @@ import com.thebluealliance.android.domain.model.NotificationType
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationPreferencesSheet(
-    modelKey: String,
+    displayName: String,
     modelType: Int,
     isFavorite: Boolean,
     currentNotifications: List<String>,
@@ -43,7 +43,7 @@ fun NotificationPreferencesSheet(
     ) {
         Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
             Text(
-                text = "Notifications for $modelKey",
+                text = "Notifications for $displayName",
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(bottom = 16.dp),
             )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventDetailScreen.kt
@@ -121,9 +121,8 @@ fun EventDetailScreen(
     }
 
     if (showNotificationSheet) {
-        val eventKey = uiState.event?.key ?: ""
         NotificationPreferencesSheet(
-            modelKey = eventKey,
+            displayName = uiState.event?.let { "${it.year} ${it.name}" } ?: "Event",
             modelType = ModelType.EVENT,
             isFavorite = isFavorite,
             currentNotifications = subscription?.notifications ?: emptyList(),

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -122,9 +122,8 @@ fun TeamDetailScreen(
     }
 
     if (showNotificationSheet) {
-        val teamKey = uiState.team?.key ?: ""
         NotificationPreferencesSheet(
-            modelKey = teamKey,
+            displayName = uiState.team?.let { "Team ${it.number}" + (it.nickname?.let { n -> " - $n" } ?: "") } ?: "Team",
             modelType = ModelType.TEAM,
             isFavorite = isFavorite,
             currentNotifications = subscription?.notifications ?: emptyList(),


### PR DESCRIPTION
## Summary
- Display human-readable names instead of raw model keys (e.g. `2026test`, `frc604`) in the notification preferences bottom sheet title
- Events show "Notifications for 2026 North Pole Regional" instead of "Notifications for 2026test"
- Teams show "Notifications for Team 604 - Quixilver" instead of "Notifications for frc604"

Fixes #1017

## Test plan
- [ ] Open an event detail screen, tap the notification bell, verify the sheet title shows the event year + name
- [ ] Open a team detail screen, tap the notification bell, verify the sheet title shows "Team {number} - {nickname}"

🤖 Generated with [Claude Code](https://claude.com/claude-code)