### PR TITLE
Fix crash when Crashlytics is not initialized

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/AuthRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/AuthRepository.kt
@@ -17,7 +17,9 @@ class AuthRepository @Inject constructor(
     val currentUser: Flow<FirebaseUser?> = callbackFlow {
         val listener = FirebaseAuth.AuthStateListener { auth ->
             val user = auth.currentUser
-            FirebaseCrashlytics.getInstance().setUserId(user?.uid.orEmpty())
+            try {
+                FirebaseCrashlytics.getInstance().setUserId(user?.uid.orEmpty())
+            } catch (_: Exception) { }
             trySend(user)
         }
         firebaseAuth.addAuthStateListener(listener)


### PR DESCRIPTION
## Summary
- Wraps `Crashlytics.setUserId()` in a try/catch in `AuthRepository` to prevent crashes when Crashlytics is disabled or not yet initialized (e.g. debug builds without Crashlytics collection enabled)

## Test plan
- [ ] Verify debug build launches without crashing on auth state change
- [ ] Verify Crashlytics user ID is still set in release builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)