### PR TITLE
Add keep.xml to preserve AboutLibraries resource in release builds

### DIFF
--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@raw/aboutlibraries" />


### PR DESCRIPTION
## Summary
- Adds a `keep.xml` resource rule so R8 doesn't strip the `@raw/aboutlibraries` resource in release builds
- The AboutLibraries library references this resource at runtime, but without a static reference R8 removes it, causing the open-source licenses screen to be empty

## Test plan
- [ ] Build release APK and verify the "About" / open-source licenses screen shows library entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)