### PR TITLE
Use ellipsis for long titles in detail screen app bars

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -60,6 +61,7 @@ fun DistrictDetailScreen(
                 Text(
                     text = uiState.district?.displayName ?: "District",
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             },
             navigationIcon = {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventDetailScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -141,6 +142,7 @@ fun EventDetailScreen(
                 Text(
                     text = uiState.event?.let { "${it.year} ${it.name}" } ?: "Event",
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             },
             navigationIcon = {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -58,6 +59,7 @@ fun MatchDetailScreen(
                 Text(
                     text = uiState.match?.fullLabel ?: "Match",
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             },
             navigationIcon = {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -64,7 +65,7 @@ fun TeamEventDetailScreen(
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
             windowInsets = WindowInsets(0),
-            title = { Text(text = titleText, maxLines = 1) },
+            title = { Text(text = titleText, maxLines = 1, overflow = TextOverflow.Ellipsis) },
             navigationIcon = {
                 IconButton(onClick = onNavigateBack) {
                     Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -143,6 +144,7 @@ fun TeamDetailScreen(
                 Text(
                     text = if (team != null) "${team.number} - ${team.nickname ?: ""}" else "Team",
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             },
             navigationIcon = {


### PR DESCRIPTION
## Summary
- All detail screen TopAppBar titles used `maxLines = 1` but defaulted to `TextOverflow.Clip`, which hard-cuts text at the boundary with no visual indicator
- Added `overflow = TextOverflow.Ellipsis` so truncated titles show "..." instead
- Affected screens: Team, Event, District, TeamEvent, Match

## Before / After

**Before:** "177 - Bobcat" (hard clipped, no indication of truncation)

**After:** "177 - Bobcat Robot..." (ellipsis shows text continues)

## Test plan
- [x] Verified on Team 177 (Bobcat Robotics) — title now shows "177 - Bobcat Robot..." with ellipsis
- [x] Verify event detail with long event names (e.g. "2026 CA District San Francisco Event")
- [x] Verify district, team@event, and match detail screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)