### PR TITLE
Remove duplicate settings screen header

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/settings/SettingsScreen.kt
@@ -25,8 +25,6 @@ fun SettingsScreen() {
             .fillMaxSize()
             .padding(16.dp),
     ) {
-        Text("Settings", style = MaterialTheme.typography.headlineSmall)
-
         if (BuildConfig.DEBUG) {
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
             Text(


### PR DESCRIPTION
The settings screen currently has a duplicate title, now it doesn't!

|Before|After|
|-|-|
|<img height="600" src="https://github.com/user-attachments/assets/8c6822b7-2a28-4643-ae51-483b4b4bfd80" />|<img height="600" src="https://github.com/user-attachments/assets/4c76d18c-0add-4cc0-acae-93f72968734d" />|