### PR TITLE
Register as android-fcm client type for push notifications

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/ClientApiDtos.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/ClientApiDtos.kt
@@ -51,7 +51,7 @@ data class ModelPreferenceRequestDto(
 @Serializable
 data class RegisterDeviceRequestDto(
     @SerialName("mobile_id") val mobileId: String,
-    @SerialName("operating_system") val os: String = "android",
+    @SerialName("operating_system") val os: String = "android-fcm",
     val name: String,
     @SerialName("device_uuid") val deviceUuid: String,
 )


### PR DESCRIPTION
## Summary
- Changes device registration `operating_system` from `"android"` to `"android-fcm"`
- Server maps this to new `OS_ANDROID_FCM` client type, which is included in `FCM_CLIENTS` for push notification delivery
- One-line change in `RegisterDeviceRequestDto`

## Test plan
- [x] Debug build compiles successfully
- [ ] Integration test: install on emulator, sign in, verify server registers client as type 5 (`OS_ANDROID_FCM`)

Fixes #1010
Companion server PR: the-blue-alliance/the-blue-alliance#9020

🤖 Generated with [Claude Code](https://claude.com/claude-code)