### PR TITLE
Add monochrome icon

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
Android 13 introduced support for monochrome app icons, where the icon takes on coloring from the user's system-wide theme.

This PR adds support for monochrome icons by simply re-using our foreground icon vector. 

|On a device with icon theming|Device without theming|
|-|-|
|<img height="600" src="https://github.com/user-attachments/assets/ee36b81e-bb01-4db3-84ce-5d09d7a97086" />|<img height="600" src="https://github.com/user-attachments/assets/7d81f762-6837-456c-b79e-5f0b209f1b5f" />|
