### PR TITLE
Fix Crashlytics not initializing due to R8 stripping constructors

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,1 +1,7 @@
 # Add project specific ProGuard rules here.
+
+# Firebase component registrars are instantiated via reflection.
+# R8 strips their no-arg constructors without this rule.
+-keep class com.google.firebase.** implements com.google.firebase.components.ComponentRegistrar {
+    <init>();
+}


### PR DESCRIPTION
## Summary
- R8 (AGP 9) aggressively removes no-arg constructors that aren't directly referenced in code
- Firebase discovers `CrashlyticsRegistrar` via reflection, so the constructor gets stripped and Crashlytics **silently fails to initialize**
- This explains why the 10.9.0 alpha has **zero Crashlytics telemetry** despite users actively running it
- Fix: ProGuard keep rule for all Firebase `ComponentRegistrar` constructors

## Evidence
Logcat from the release build before fix:
```
W ComponentDiscovery: Could not instantiate com.google.firebase.crashlytics.CrashlyticsRegistrar
W ComponentDiscovery: Caused by: java.lang.NoSuchMethodException: CrashlyticsRegistrar.<init> []
```

After fix:
```
I FirebaseCrashlytics: Initializing Firebase Crashlytics 19.3.0 for com.thebluealliance.androidclient
```

## Test plan
- [x] Verified Crashlytics init failure in logcat before fix
- [x] Verified Crashlytics initializes successfully after fix
- [ ] Publish new alpha and confirm crash data appears in Firebase Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)