### PR TITLE
Bump Firebase BOM 33.7.0 → 34.9.0, remove KTX modules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,7 +1,1 @@
 # Add project specific ProGuard rules here.
-
-# Firebase component registrars are instantiated via reflection.
-# R8 strips their no-arg constructors without this rule.
--keep class com.google.firebase.** implements com.google.firebase.components.ComponentRegistrar {
-    <init>();
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ datastore = "1.1.1"
 coil = "2.7.0"
 aboutlibraries = "14.0.0-b02"
 
-firebase-bom = "33.7.0"
+firebase-bom = "34.9.0"
 google-services = "4.4.2"
 firebase-crashlytics-plugin = "3.0.3"
 credentials = "1.5.0"
@@ -85,11 +85,11 @@ aboutlibraries-compose-m3 = { group = "com.mikepenz", name = "aboutlibraries-com
 
 # Firebase
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
-firebase-auth = { group = "com.google.firebase", name = "firebase-auth-ktx" }
-firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging-ktx" }
-firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
-firebase-config = { group = "com.google.firebase", name = "firebase-config-ktx" }
-firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics-ktx" }
+firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+firebase-config = { group = "com.google.firebase", name = "firebase-config" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 
 # Credentials
 credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }


### PR DESCRIPTION
## Summary
- Bump Firebase BOM from 33.7.0 to 34.9.0
- Migrate all Firebase dependencies from deprecated `-ktx` modules to main artifacts (KTX extensions are now included in the main modules as of BOM 34.0.0)
- Remove the `ComponentRegistrar` ProGuard keep rule — firebase-crashlytics 20.0.4 (in BOM 34.9.0) ships proper R8 full mode consumer rules, so the workaround from #1030 is no longer needed

## Why
BOM 33.7.0 shipped firebase-crashlytics 19.3.0, whose consumer ProGuard rules didn't account for R8 full mode (AGP 9 default) stripping `ComponentRegistrar` no-arg constructors. BOM 34.9.0 ships firebase-crashlytics 20.0.4 which fixes this upstream.

## Test plan
- [x] Release build compiles cleanly
- [x] Crashlytics 20.0.4 initializes without keep rule (verified in logcat)
- [x] Unit tests pass
- [ ] Verify Crashlytics reports after next alpha publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)