### PR TITLE
Add MyTBA profile photo, overflow menu, and sign-out confirmation

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -5,33 +5,51 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
 import com.thebluealliance.android.domain.model.Favorite
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.domain.model.Subscription
@@ -70,15 +88,44 @@ fun MyTBAScreen(
         }
     }
 
+    var showSignOutDialog by remember { mutableStateOf(false) }
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    if (showSignOutDialog) {
+        AlertDialog(
+            onDismissRequest = { showSignOutDialog = false },
+            title = { Text("Sign out?") },
+            text = { Text("You will no longer receive notifications for your favorites and subscriptions.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showSignOutDialog = false
+                    viewModel.signOut()
+                }) { Text("Sign out") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSignOutDialog = false }) { Text("Cancel") }
+            },
+        )
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Column {
+            val personIcon = rememberVectorPainter(Icons.Default.Person)
+            AsyncImage(
+                model = uiState.userPhotoUrl,
+                contentDescription = "Profile photo",
+                modifier = Modifier.size(40.dp).clip(CircleShape),
+                placeholder = personIcon,
+                error = personIcon,
+                fallback = personIcon,
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = uiState.userName ?: "Signed in",
                     style = MaterialTheme.typography.bodyLarge,
@@ -91,8 +138,25 @@ fun MyTBAScreen(
                     )
                 }
             }
-            OutlinedButton(onClick = viewModel::signOut) {
-                Text("Sign out")
+            Box {
+                IconButton(onClick = { menuExpanded = true }) {
+                    Icon(
+                        imageVector = Icons.Default.MoreVert,
+                        contentDescription = "More options",
+                    )
+                }
+                DropdownMenu(
+                    expanded = menuExpanded,
+                    onDismissRequest = { menuExpanded = false },
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("Sign out") },
+                        onClick = {
+                            menuExpanded = false
+                            showSignOutDialog = true
+                        },
+                    )
+                }
             }
         }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAUiState.kt
@@ -7,6 +7,7 @@ data class MyTBAUiState(
     val isSignedIn: Boolean = false,
     val userName: String? = null,
     val userEmail: String? = null,
+    val userPhotoUrl: String? = null,
     val favorites: List<Favorite> = emptyList(),
     val subscriptions: List<Subscription> = emptyList(),
 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
@@ -36,6 +36,7 @@ class MyTBAViewModel @Inject constructor(
             isSignedIn = user != null,
             userName = user?.displayName,
             userEmail = user?.email,
+            userPhotoUrl = user?.photoUrl?.toString(),
             favorites = favorites,
             subscriptions = subscriptions,
         )


### PR DESCRIPTION
## Summary
- Show Google profile photo as circular avatar on MyTBA screen, with person-icon fallback for loading/error/null states
- Move "Sign out" behind overflow (MoreVert) dropdown menu
- Add confirmation dialog before signing out ("You will no longer receive notifications for your favorites and subscriptions.")

## Test plan
- [ ] Sign in to MyTBA — verify profile photo loads (or person icon shows as fallback)
- [ ] Tap overflow menu — verify "Sign out" option appears
- [ ] Tap "Sign out" — verify confirmation dialog appears with Cancel/Sign out buttons
- [ ] Tap Cancel — verify dialog dismisses without signing out
- [ ] Tap Sign out — verify user is signed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)