### PR TITLE
Bump serialization 1.9.0 and migrate hiltViewModel to new package

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -147,6 +147,7 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
+    implementation(libs.hilt.lifecycle.viewmodel.compose)
 
     // WorkManager
     implementation(libs.work.runtime)

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.DistrictRanking
 import com.thebluealliance.android.domain.model.Event

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.District
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.ui.components.EventRow

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.ui.common.shareTbaUrl

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.Match
 import com.thebluealliance.android.domain.model.fullLabel

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/ThanksScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/ThanksScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.thebluealliance.android.data.remote.dto.GitHubContributorDto
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.thebluealliance.android.domain.model.Favorite

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/search/SearchScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.ui.components.EventRow
 import com.thebluealliance.android.ui.components.TeamRow

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.Award
 import com.thebluealliance.android.ui.components.EventRow

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -61,7 +61,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.thebluealliance.android.domain.model.Event

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.Team
 import com.thebluealliance.android.ui.components.FastScrollbar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ hilt-navigation-compose = "1.3.0"
 lifecycle = "2.10.0"
 core-ktx = "1.17.0"
 coroutines = "1.10.2"
-serialization = "1.7.3"
+serialization = "1.9.0"
 
 retrofit = "3.0.0"
 okhttp = "5.3.2"
@@ -58,6 +58,7 @@ navigation-compose = { group = "androidx.navigation", name = "navigation-compose
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
+hilt-lifecycle-viewmodel-compose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hilt-navigation-compose" }
 
 # Coroutines
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary
- Bumps kotlinx-serialization from 1.7.3 to 1.9.0 (max compatible with Kotlin 2.3.x; 1.10.0 requires Kotlin 2.3.0 compiler plugin changes)
- Adds `hilt-lifecycle-viewmodel-compose` artifact and migrates all `hiltViewModel()` imports to the new package (`androidx.hilt.lifecycle.viewmodel.compose`), eliminating deprecation warnings from hilt-navigation-compose 1.3.0

The other version bumps originally in this PR (activity, navigation, lifecycle, hilt-navigation-compose, googleid) were merged via Dependabot PRs.

### hiltViewModel migration
hilt-navigation-compose 1.3.0 moved `hiltViewModel()` to a new standalone artifact (`androidx.hilt:hilt-lifecycle-viewmodel-compose`). This decouples Hilt's Compose ViewModel support from the Navigation library. All 11 screen files updated.

## Test plan
- [x] `./gradlew :app:assembleDebug` passes
- [x] `./gradlew :app:testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)