### PR TITLE
Add editorconfig for more consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+continuation_indent_size = 8
+max_line_length = 100
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.sql]
+indent_size = 2
+


### PR DESCRIPTION
IDEs like Android Studio will pick up the configuration in `.editorconfig` to provide more consistent formatting, particularly on items like tab indentation size and line endings