### PR TITLE
Rename "Subscriptions" to "Notifications" in user-facing UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Blue Alliance is built by volunteers. We'd love your help!
 - **Teams** -- Browse teams, view team details with year-by-year event participation and media
 - **Districts** -- Browse district listings and rankings
 - **Search** -- Find teams and events across all of TBA
-- **myTBA** -- Sign in with Google to save favorite teams and events, and subscribe to push notifications for match scores, upcoming matches, schedule changes, and more
+- **myTBA** -- Sign in with Google to save favorite teams and events, and set up push notifications for match scores, upcoming matches, schedule changes, and more
 - **Deep linking** -- Open thebluealliance.com links directly in the app
 - **Push notifications** -- Receive alerts for match scores, upcoming matches, event updates, and more via Firebase Cloud Messaging
 
@@ -60,7 +60,7 @@ This starts:
 
 To import data into your local server, visit `http://localhost:8080/local/bootstrap` in a browser.
 
-Running the local backend is the easiest way to test logged-in features like myTBA favorites and subscriptions, since the Docker Compose setup includes a Firebase Auth emulator that handles sign-in without any additional configuration.
+Running the local backend is the easiest way to test logged-in features like myTBA favorites and notifications, since the Docker Compose setup includes a Firebase Auth emulator that handles sign-in without any additional configuration.
 
 > **Tip:** If you'd rather skip running the backend locally, you can point the app at the production API by adding this to `local.properties`:
 > ```

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -39,6 +39,12 @@ All UI strings use **sentence case**: capitalize only the first word and proper 
 - Acronyms (RP, BCVI)
 - Data from the server (event names, team names, etc.)
 
+## Terminology
+
+| Preferred (user-facing)  | Avoid (user-facing)      | Notes                                                |
+|--------------------------|--------------------------|------------------------------------------------------|
+| Notifications            | Subscriptions            | Users configure what they get *notified* about. The internal code still uses `Subscription` as a domain/data model name — this guideline only applies to UI strings. |
+
 ## Brand colors
 
 These match the TBA web server CSS variables (`tba_variables.less`).

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -55,7 +55,7 @@ import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.domain.model.Subscription
 import kotlinx.coroutines.launch
 
-private val TABS = listOf("Favorites", "Subscriptions")
+private val TABS = listOf("Favorites", "Notifications")
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -77,13 +77,13 @@ fun MyTBAScreen(
     val pagerState = rememberPagerState(pageCount = { TABS.size })
     val coroutineScope = rememberCoroutineScope()
     val favoritesListState = rememberLazyListState()
-    val subscriptionsListState = rememberLazyListState()
+    val notificationsListState = rememberLazyListState()
 
     LaunchedEffect(scrollToTopTrigger) {
         if (scrollToTopTrigger > 0) {
             when (pagerState.currentPage) {
                 0 -> favoritesListState.animateScrollToItem(0)
-                1 -> subscriptionsListState.animateScrollToItem(0)
+                1 -> notificationsListState.animateScrollToItem(0)
             }
         }
     }
@@ -95,7 +95,7 @@ fun MyTBAScreen(
         AlertDialog(
             onDismissRequest = { showSignOutDialog = false },
             title = { Text("Sign out?") },
-            text = { Text("You will no longer receive notifications for your favorites and subscriptions.") },
+            text = { Text("Your favorites and notifications won't apply to the app anymore.") },
             confirmButton = {
                 TextButton(onClick = {
                     showSignOutDialog = false
@@ -184,7 +184,7 @@ fun MyTBAScreen(
             ) { page ->
                 when (page) {
                     0 -> FavoritesTab(uiState.favorites, onNavigateToTeam, onNavigateToEvent, favoritesListState)
-                    1 -> SubscriptionsTab(uiState.subscriptions, onNavigateToTeam, onNavigateToEvent, subscriptionsListState)
+                    1 -> NotificationsTab(uiState.subscriptions, onNavigateToTeam, onNavigateToEvent, notificationsListState)
                 }
             }
         }
@@ -273,7 +273,7 @@ private fun FavoriteItem(favorite: Favorite, onClick: () -> Unit) {
 }
 
 @Composable
-private fun SubscriptionsTab(
+private fun NotificationsTab(
     subscriptions: List<Subscription>,
     onNavigateToTeam: (String) -> Unit,
     onNavigateToEvent: (String) -> Unit,
@@ -281,7 +281,7 @@ private fun SubscriptionsTab(
 ) {
     if (subscriptions.isEmpty()) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("No subscriptions yet", style = MaterialTheme.typography.bodyLarge)
+            Text("No notifications yet", style = MaterialTheme.typography.bodyLarge)
         }
         return
     }


### PR DESCRIPTION
## Summary
- Renames the myTBA tab from "Subscriptions" to "Notifications" — clearer for users who are configuring what they get notified about
- Updates empty state, sign-out dialog, README, and style guide terminology section
- Internal code (domain model `Subscription`, entity, DAO, repository) is unchanged

## Test plan
- [x] `./gradlew :app:assembleDebug` passes
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] Visually confirmed tab says "Notifications"
- [x] Visually confirmed empty state says "No notifications yet"
- [x] Visually confirmed sign-out dialog says "Your favorites and notifications won't apply to the app anymore."

🤖 Generated with [Claude Code](https://claude.com/claude-code)