### PR TITLE
Rearrange event info tab and show webcast dates

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/mappers/Mappers.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/mappers/Mappers.kt
@@ -80,7 +80,7 @@ fun EventEntity.toDomain() = Event(
     webcasts = webcasts?.let { raw ->
         try {
             json.decodeFromString<List<WebcastDto>>(raw).map {
-                Webcast(type = it.type, channel = it.channel, file = it.file)
+                Webcast(type = it.type, channel = it.channel, file = it.file, date = it.date)
             }
         } catch (_: Exception) { emptyList() }
     } ?: emptyList(),

--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/EventDto.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/EventDto.kt
@@ -33,4 +33,5 @@ data class WebcastDto(
     val type: String,
     val channel: String,
     val file: String? = null,
+    val date: String? = null,
 )

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/Event.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/Event.kt
@@ -30,6 +30,7 @@ data class Webcast(
     val type: String,
     val channel: String,
     val file: String?,
+    val date: String?,
 )
 
 enum class PlayoffType(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -55,16 +55,6 @@ fun EventInfoTab(event: Event?) {
                 )
             }
         }
-        if (event.locationName != null) {
-            item {
-                Text(
-                    text = event.locationName,
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(top = 4.dp),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
         val dateRange = formatEventDateRange(event.startDate, event.endDate)
         if (dateRange != null) {
             item {
@@ -94,30 +84,14 @@ fun EventInfoTab(event: Event?) {
             }
         }
 
-        // Website (clickable)
-        if (event.website != null) {
+        if (event.locationName != null) {
             item {
-                Row(
-                    modifier = Modifier
-                        .padding(top = 8.dp)
-                        .clickable {
-                            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(event.website)))
-                        },
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        Icons.Outlined.Language,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text(
-                        text = event.website,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
+                Text(
+                    text = event.locationName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(top = 4.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
         }
 
@@ -146,6 +120,33 @@ fun EventInfoTab(event: Event?) {
                     Spacer(Modifier.width(8.dp))
                     Text(
                         text = event.address,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+
+        // Website (clickable)
+        if (event.website != null) {
+            item {
+                Row(
+                    modifier = Modifier
+                        .padding(top = 8.dp)
+                        .clickable {
+                            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(event.website)))
+                        },
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        Icons.Outlined.Language,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = event.website,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.primary,
                     )
@@ -201,10 +202,24 @@ private fun webcastUrl(webcast: Webcast): String? = when (webcast.type) {
     else -> null
 }
 
-private fun webcastLabel(webcast: Webcast): String = when (webcast.type) {
-    "twitch" -> "Watch on Twitch"
-    "youtube" -> "Watch on YouTube"
-    "livestream" -> "Watch on Livestream"
-    else -> "Watch (${webcast.type})"
+private fun webcastLabel(webcast: Webcast): String {
+    val base = when (webcast.type) {
+        "twitch" -> "Watch on Twitch"
+        "youtube" -> "Watch on YouTube"
+        "livestream" -> "Watch on Livestream"
+        else -> "Watch (${webcast.type})"
+    }
+    val dateSuffix = webcast.date?.let { formatWebcastDate(it) } ?: ""
+    return if (dateSuffix.isNotEmpty()) "$base $dateSuffix" else base
+}
+
+private fun formatWebcastDate(dateStr: String): String {
+    return try {
+        val date = java.time.LocalDate.parse(dateStr)
+        val formatter = java.time.format.DateTimeFormatter.ofPattern("(EEE, MMM d)", java.util.Locale.US)
+        date.format(formatter)
+    } catch (_: Exception) {
+        ""
+    }
 }
 


### PR DESCRIPTION
## Summary
- Reorders the Event Info tab: location name and address now appear together, website moves below address
- Adds `date` field to the Webcast model (from TBA API v3.8) and displays it on webcast links as e.g. "Watch on YouTube (Sat, Feb 21)" so users can distinguish webcasts for different days

**New Info tab order:** Event name, Location, Date range, Week, District, Location name, Address, Website, Webcasts

## Test plan
- [x] `./gradlew :app:assembleDebug` passes
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] Release build installed and verified on emulator — webcast dates display correctly on Becker Week Zero event

🤖 Generated with [Claude Code](https://claude.com/claude-code)