### PR TITLE
Add jump-to-section sticky headers to match list

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -1,8 +1,6 @@
 package com.thebluealliance.android.ui.components
 
-import android.R.attr.level
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,15 +21,16 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.google.common.graph.ElementOrder.sorted
 import com.thebluealliance.android.domain.getGroup
 import com.thebluealliance.android.domain.getShortLabel
 import com.thebluealliance.android.domain.model.Match
 import com.thebluealliance.android.domain.model.PlayoffType
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -84,36 +83,48 @@ fun MatchList(
         }
     }
 
-    val headerKeys = remember(grouped) {
-        grouped.keys.map { "match_header_$it" }.toSet()
+    val headerInfos = remember(grouped, headerOffset) {
+        buildList {
+            var index = headerOffset
+            grouped.forEach { (group, levelMatches) ->
+                val headerKey = "match_header_${group.label}"
+                add(SectionHeaderInfo(headerKey, group.label, index))
+                index += 1 + levelMatches.size // header + items
+            }
+        }
     }
-    @Suppress("UNUSED_VARIABLE")
+
+    val headerKeys = remember(headerInfos) { headerInfos.map { it.key }.toSet() }
+
     val stuckHeaderKey by remember {
         derivedStateOf {
-            listState.layoutInfo.visibleItemsInfo
+            val stuck = listState.layoutInfo.visibleItemsInfo
                 .firstOrNull { item ->
                     val key = item.key as? String
                     key != null && key in headerKeys && item.offset <= 0
                 }?.key as? String
+            stuck ?: headerInfos.firstOrNull()?.key
         }
     }
+
+    val coroutineScope = rememberCoroutineScope()
 
     LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
         if (headerContent != null) {
             headerContent()
         }
         grouped.forEach { (group, levelMatches) ->
-            val headerKey = "match_header ${group.label}"
+            val headerKey = "match_header_${group.label}"
             stickyHeader(key = headerKey) {
-                Text(
-                    text = group.label,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(MaterialTheme.colorScheme.surface)
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                SectionHeader(
+                    label = group.label,
+                    isStuck = stuckHeaderKey == headerKey,
+                    allHeaders = headerInfos,
+                    onHeaderSelected = { info ->
+                        coroutineScope.launch {
+                            listState.animateScrollToItem(info.itemIndex)
+                        }
+                    },
                 )
             }
             items(levelMatches, key = { it.key }) { match ->

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/SectionHeader.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/SectionHeader.kt
@@ -1,0 +1,94 @@
+package com.thebluealliance.android.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+data class SectionHeaderInfo(val key: String, val label: String, val itemIndex: Int)
+
+@Composable
+fun SectionHeader(
+    label: String,
+    isStuck: Boolean,
+    allHeaders: List<SectionHeaderInfo>,
+    onHeaderSelected: (SectionHeaderInfo) -> Unit,
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .clickable(enabled = isStuck) { menuExpanded = true },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            if (isStuck) {
+                Spacer(modifier = Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Default.ArrowDropDown,
+                    contentDescription = "Jump to section",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+        ) {
+            allHeaders.forEach { info ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = info.label,
+                            fontWeight = if (info.label == label) FontWeight.Bold else FontWeight.Normal,
+                            color = if (info.label == label) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            },
+                        )
+                    },
+                    onClick = {
+                        menuExpanded = false
+                        onHeaderSelected(info)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -1,29 +1,18 @@
 package com.thebluealliance.android.ui.events
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -31,19 +20,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.ui.components.EventRow
 import com.thebluealliance.android.ui.components.FastScrollbar
+import com.thebluealliance.android.ui.components.SectionHeader
+import com.thebluealliance.android.ui.components.SectionHeaderInfo
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 
@@ -118,8 +106,6 @@ fun EventsScreen(
         }
     }
 }
-
-private data class SectionHeaderInfo(val key: String, val label: String, val itemIndex: Int)
 
 @Composable
 private fun EventsList(
@@ -240,68 +226,4 @@ private fun EventsList(
     }
 }
 
-@Composable
-private fun SectionHeader(
-    label: String,
-    isStuck: Boolean,
-    allHeaders: List<SectionHeaderInfo>,
-    onHeaderSelected: (SectionHeaderInfo) -> Unit,
-) {
-    var menuExpanded by remember { mutableStateOf(false) }
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surface)
-            .clickable(enabled = isStuck) { menuExpanded = true },
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary,
-            )
-            if (isStuck) {
-                Spacer(modifier = Modifier.width(4.dp))
-                Icon(
-                    imageVector = Icons.Default.ArrowDropDown,
-                    contentDescription = "Jump to section",
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(20.dp),
-                )
-            }
-        }
-
-        DropdownMenu(
-            expanded = menuExpanded,
-            onDismissRequest = { menuExpanded = false },
-        ) {
-            allHeaders.forEach { info ->
-                DropdownMenuItem(
-                    text = {
-                        Text(
-                            text = info.label,
-                            fontWeight = if (info.label == label) FontWeight.Bold else FontWeight.Normal,
-                            color = if (info.label == label) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurface
-                            },
-                        )
-                    },
-                    onClick = {
-                        menuExpanded = false
-                        onHeaderSelected(info)
-                    },
-                )
-            }
-        }
-    }
-}
 


### PR DESCRIPTION
## Summary
- Extract `SectionHeader` composable and `SectionHeaderInfo` data class from `EventsScreen.kt` into a shared `ui/components/SectionHeader.kt`
- Reuse `SectionHeader` in `MatchList.kt` — the stuck header now shows a dropdown arrow that lets users jump between sections (Qualifications, Rounds, Finals, etc.)
- Fix key mismatch bug in `MatchList` that prevented stuck-header detection from working (`headerKeys` used `"match_header_$it"` but `stickyHeader` used `"match_header ${group.label}"`)

## Test plan
- [x] `./gradlew :app:assembleDebug` builds clean
- [x] Navigate to event with many matches (2026test) → Matches tab — stuck header shows dropdown arrow, tap jumps to selected section
- [x] Navigate to event with playoff rounds (2025alhu) → Matches tab — multiple section headers (Qualifications, Round 1-4, Finals, Q8+) all work with jump navigation
- [x] Events List still works identically (no regression from extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)