### PR TITLE
Fix red alliance team color on match detail

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -266,7 +266,7 @@ private fun AllianceTeams(
             Text(
                 text = key.removePrefix("frc"),
                 style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.primary,
+                color = color,
                 modifier = Modifier
                     .clickable { onTeamClick(key) }
                     .padding(start = 8.dp, top = 2.dp),


### PR DESCRIPTION
## Summary
- Red alliance team numbers on the match detail screen were displayed in blue (the default `primary` color) instead of red
- The `AllianceTeams` composable already accepted a `color` parameter and used it for the section title, but individual team numbers were hardcoded to `MaterialTheme.colorScheme.primary`
- Now uses the passed-in alliance color for team numbers too

## Test plan
- [x] Open match detail for any played match — red alliance teams show in red, blue alliance teams show in blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)