### PR TITLE
Cleanup data tags in manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,21 +26,17 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https"
-                    android:host="www.thebluealliance.com"
-                    android:pathPrefix="/event/" />
-                <data android:scheme="https"
-                    android:host="www.thebluealliance.com"
-                    android:pathPrefix="/events" />
-                <data android:scheme="https"
-                    android:host="www.thebluealliance.com"
-                    android:pathPrefix="/match/" />
-                <data android:scheme="https"
-                    android:host="www.thebluealliance.com"
-                    android:pathPrefix="/team/" />
-                <data android:scheme="https"
-                    android:host="www.thebluealliance.com"
-                    android:pathPrefix="/teams" />
+
+
+                <data android:scheme="https" />
+                <data android:host="www.thebluealliance.com" />
+                <data android:host="thebluealliance.com" />
+
+                <data android:pathPrefix="/event/" />
+                <data android:pathPrefix="/events" />
+                <data android:pathPrefix="/match/" />
+                <data android:pathPrefix="/team/" />
+                <data android:pathPrefix="/teams" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
The current manifest was triggering the `IntentFilterUniqueDataAttributes` lint warning because each `<data>` tag repeated the `scheme` and `host` attributes.

All `<data>` tags in an `<intent-filter>` contribute to the same set of supported paths, so defining a single `<data android:scheme="https" />` is sufficient to declare that we support the https scheme for all paths defined in other data tags. The same goes for the host.

Additionally this PR adds support for the apex domain (`theblualliance.com`).