### PR TITLE
Show headerContent in MatchList when matches are null or empty

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -46,15 +46,18 @@ fun MatchList(
     onNavigateToMatch: (String) -> Unit,
     headerContent: (LazyListScope.() -> Unit)? = null,
 ) {
-    if (matches == null) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CircularProgressIndicator()
-        }
-        return
-    }
-    if (matches.isEmpty()) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("No matches", style = MaterialTheme.typography.bodyLarge)
+    if (matches == null || matches.isEmpty()) {
+        LazyColumn(Modifier.fillMaxSize()) {
+            headerContent?.invoke(this)
+            item {
+                Box(
+                    Modifier.fillMaxWidth().padding(32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (matches == null) CircularProgressIndicator()
+                    else Text("No matches", style = MaterialTheme.typography.bodyLarge)
+                }
+            }
         }
         return
     }


### PR DESCRIPTION
## Summary
- `MatchList` previously had early returns for null/empty match lists that skipped rendering `headerContent` entirely
- This caused the Team/Event header rows on the TeamEvent detail screen to be invisible when a team had no scheduled matches
- Now `headerContent` is always rendered inside a `LazyColumn` before the loading spinner or "No matches" text

## Image
<img width="441" height="860" alt="image" src="https://github.com/user-attachments/assets/eb94d0c4-a56f-403f-83b9-bf757b550730" />

## Test plan
- [ ] Navigate to a TeamEvent page for a team with no scheduled matches — Team/Event rows should appear with "No matches" below
- [ ] Navigate to a TeamEvent page with matches — should look identical to before (header rows + match list)
- [ ] Check loading state — header rows should appear above the spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)