### PR TITLE
Show "(est.)" indicator for predicted match times

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -212,15 +212,25 @@ fun MatchItem(
                 )
             }
         } else {
-            Box(
+            Column(
                 modifier = Modifier.weight(0.15f),
-                contentAlignment = Alignment.CenterEnd,
+                horizontalAlignment = Alignment.End,
             ) {
+                val displayTime = match.predictedTime ?: match.time
+                val isEstimate = match.predictedTime != null && match.time != null &&
+                    kotlin.math.abs(match.predictedTime - match.time) > 60
                 Text(
-                    text = formatMatchTime(match.predictedTime ?: match.time),
+                    text = formatMatchTime(displayTime),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (isEstimate) {
+                    Text(
+                        text = "(est.)",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailViewModel.kt
@@ -52,7 +52,12 @@ class MatchDetailViewModel @AssistedInject constructor(
     ) { match, event ->
         val breakdown = match?.scoreBreakdown?.let { parseBreakdown(it) }
         val videos = match?.videos?.let { parseVideos(it) } ?: emptyList()
-        val formattedTime = formatMatchTime(match?.actualTime ?: match?.predictedTime ?: match?.time)
+        val timeToDisplay = match?.actualTime ?: match?.predictedTime ?: match?.time
+        val isEstimate = match?.actualTime == null && match?.predictedTime != null &&
+            match.time != null && kotlin.math.abs(match.predictedTime - match.time) > 60
+        val formattedTime = formatMatchTime(timeToDisplay)?.let {
+            if (isEstimate) "$it (est.)" else it
+        }
         MatchDetailUiState(
             match = match,
             scoreBreakdown = breakdown,


### PR DESCRIPTION
## Summary
- When matches are running behind (or ahead of) schedule, unplayed matches now show "(est.)" below the predicted time when it differs from the scheduled time by more than 60 seconds
- Applies to both the match list and match detail screens
- Played matches (showing scores) are unaffected

## Screenshot
<img width="441" height="860" alt="image" src="https://github.com/user-attachments/assets/86d71c7e-a3e2-4c28-802b-a845a32d1eb3" />


## Test plan
- [ ] Navigate to an event with predicted times that differ from scheduled times
- [ ] Verify "(est.)" appears below the time for matches with >60s drift
- [ ] Verify "(est.)" does NOT appear for matches with ≤60s drift or no predicted time
- [ ] Verify match detail screen shows "(est.)" inline when applicable
- [ ] Verify played matches are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)