### PR TITLE
Add support for deep linking events/{year}

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/MainActivity.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/MainActivity.kt
@@ -55,7 +55,7 @@ class MainActivity : ComponentActivity() {
 
         val startRoute = getNotificationDestination()
             ?: getDeeplinkDestination()
-            ?: Screen.Events
+            ?: Screen.Events()
 
         setContent {
             TBAApp(

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/DeeplinkMatcher.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/DeeplinkMatcher.kt
@@ -25,7 +25,7 @@ class DeeplinkMatcher {
 
         // https://www.thebluealliance.com/events or /events/{year}
         if (segments[0] == "events") {
-            return Screen.Events
+            return Screen.Events(year = segments.getOrNull(1)?.toIntOrNull())
         }
 
         // https://www.thebluealliance.com/teams or /teams/{page}
@@ -36,4 +36,3 @@ class DeeplinkMatcher {
         return null
     }
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/NavigationKeys.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/NavigationKeys.kt
@@ -4,7 +4,7 @@ import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 
 sealed interface Screen : NavKey {
-    @Serializable data object Events : Screen
+    @Serializable data class Events(val year: Int? = null) : Screen
     @Serializable data object Teams : Screen
     @Serializable data object Districts : Screen
     @Serializable data object More : Screen
@@ -19,4 +19,3 @@ sealed interface Screen : NavKey {
     @Serializable data object About : Screen
     @Serializable data object Thanks : Screen
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/Navigator.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/Navigator.kt
@@ -44,8 +44,8 @@ class Navigator(
      * See https://developer.android.com/guide/navigation/principles
      */
     fun goBack() {
-        // If we're at the base of the current route, go back to the start route stack.
-        if (state.currentRoute == state.topLevelRoute) {
+        // If we're at the base of the current tab, go back to the start route tab.
+        if (state.currentStack.size == 1) {
             state.topLevelRoute = state.startRoute
         } else {
             state.currentStack.removeLastOrNull()
@@ -76,7 +76,7 @@ class Navigator(
          */
         if (size == 1) {
             // All deeplinks currently use Screen.Events as their parent
-            val deeplinkKey = Screen.Events
+            val deeplinkKey = Screen.Events()
 
             /**
              * create a [androidx.core.app.TaskStackBuilder] that will restart the

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -40,11 +40,12 @@ fun TBANavigation(
         onBack = { navigator.goBack() },
         entries = navState.toEntries(
             entryProvider = entryProvider {
-                entry<Screen.Events> {
+                entry<Screen.Events> { events ->
                     EventsScreen(
                         onNavigateToEvent = { eventKey ->
                             navigator.navigate(Screen.EventDetail(eventKey))
                         },
+                        initialYear = events.year,
                         scrollToTopTrigger = scrollToTopTrigger,
                         onYearState = onEventsYearState,
                     )
@@ -197,4 +198,3 @@ fun TBANavigation(
         ),
     )
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/TBAApp.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/TBAApp.kt
@@ -64,7 +64,7 @@ data class TopLevelDestination(
 )
 
 val TOP_LEVEL_DESTINATIONS = listOf(
-    TopLevelDestination(Screen.Events, "Events", Icons.Filled.CalendarMonth, Icons.Outlined.CalendarMonth),
+    TopLevelDestination(Screen.Events(), "Events", Icons.Filled.CalendarMonth, Icons.Outlined.CalendarMonth),
     TopLevelDestination(Screen.Teams, "Teams", Icons.Filled.Groups, Icons.Outlined.Groups),
     TopLevelDestination(Screen.Districts, "Districts", Icons.Filled.Map, Icons.Outlined.Map),
     TopLevelDestination(Screen.More, "More", Icons.Filled.Menu, Icons.Outlined.Menu),
@@ -111,7 +111,7 @@ fun TBAApp(
 
         val moreSubScreens = listOf(Screen.MyTBA, Screen.Settings, Screen.About, Screen.Thanks)
         val isOnMoreSubScreen = moreSubScreens.any { it == currentRoute }
-        val showBottomBar = TOP_LEVEL_DESTINATIONS.any { dest -> currentRoute == dest.key } || isOnMoreSubScreen
+        val showBottomBar = TOP_LEVEL_DESTINATIONS.any { dest -> currentRoute::class == dest.key::class } || isOnMoreSubScreen
 
         Scaffold(
             topBar = {
@@ -125,7 +125,7 @@ fun TBAApp(
                             }
                         },
                         title = {
-                            val isEvents = currentRoute == Screen.Events
+                            val isEvents = currentRoute is Screen.Events
                             val isDistricts = currentRoute == Screen.Districts
                             if (isOnMoreSubScreen) {
                                 val title = when (currentRoute) {
@@ -209,7 +209,7 @@ fun TBAApp(
                 if (showBottomBar) {
                     NavigationBar {
                         TOP_LEVEL_DESTINATIONS.forEach { dest ->
-                            val selected = currentRoute == dest.key || (dest.key == Screen.More && isOnMoreSubScreen)
+                            val selected = currentRoute::class == dest.key::class || (dest.key is Screen.More && isOnMoreSubScreen)
                             NavigationBarItem(
                                 selected = selected,
                                 onClick = dropUnlessResumed {
@@ -263,7 +263,7 @@ private fun FirebaseAnalyticsEffect(
         snapshotFlow { navState.currentRoute }
             .collectLatest { currentRoute ->
                 val screenName = when (currentRoute) {
-                    Screen.Events -> "Events"
+                    is Screen.Events -> "Events"
                     Screen.Teams -> "Teams"
                     Screen.Districts -> "Districts"
                     Screen.More -> "More"

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -40,6 +40,7 @@ import java.time.LocalDate
 @Composable
 fun EventsScreen(
     onNavigateToEvent: (String) -> Unit,
+    initialYear: Int? = null,
     scrollToTopTrigger: Int = 0,
     onYearState: (selectedYear: Int, maxYear: Int, onYearSelected: (Int) -> Unit) -> Unit = { _, _, _ -> },
     viewModel: EventsViewModel = hiltViewModel(),
@@ -49,6 +50,10 @@ fun EventsScreen(
     val maxYear by viewModel.maxYear.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
+
+    LaunchedEffect(Unit) {
+        initialYear?.let { viewModel.setInitialYear(it) }
+    }
 
     LaunchedEffect(selectedYear, maxYear) {
         onYearState(selectedYear, maxYear, viewModel::selectYear)
@@ -229,5 +234,3 @@ private fun EventsList(
         }
     }
 }
-
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsViewModel.kt
@@ -40,6 +40,20 @@ class EventsViewModel @Inject constructor(
 
     private val _hasLoaded = MutableStateFlow(false)
 
+    private var _hasExplicitYear = false
+
+    /**
+     * Set the initial year from a deep link. This prevents [fetchMaxYear] from overriding
+     * the user's intended year. Only takes effect on the first call.
+     */
+    fun setInitialYear(year: Int) {
+        if (!_hasExplicitYear) {
+            _hasExplicitYear = true
+            _selectedYear.value = year
+            refreshEvents()
+        }
+    }
+
     val uiState: StateFlow<EventsUiState> = _selectedYear
         .flatMapLatest { year ->
             _hasLoaded.value = false
@@ -72,8 +86,8 @@ class EventsViewModel @Inject constructor(
             try {
                 val status = tbaApi.getStatus()
                 _maxYear.value = status.maxSeason
-                // If current selection is below max, update to max
-                if (_selectedYear.value < status.maxSeason) {
+                // If current selection is below max, update to max (unless year was set explicitly)
+                if (!_hasExplicitYear && _selectedYear.value < status.maxSeason) {
                     _selectedYear.value = status.maxSeason
                 }
             } catch (_: Exception) {


### PR DESCRIPTION
**Summary:**
Add support for deep linking `events/{year}`

Copilot did some help on this one, so more detailed 👀 would be great.

**Issues Reference:**
Closes #1084 

**Test Plan:**
- Tested locally with the following:
```bash
# Open events for a specific year
adb shell am start -a android.intent.action.VIEW -d "https://www.thebluealliance.com/events/2024"

# Open events with no year (should default to current year)
adb shell am start -a android.intent.action.VIEW -d "https://www.thebluealliance.com/events"

# Try an invalid year (should be ignored, defaulting to current year)
adb shell am start -a android.intent.action.VIEW -d "https://www.thebluealliance.com/events/abc"
```

**Screenshots:**
N/A