### PR TITLE
Fix MatchList auto-scroll using hardcoded header offset

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -45,6 +45,7 @@ fun MatchList(
     playoffType: PlayoffType,
     onNavigateToMatch: (String) -> Unit,
     headerContent: (LazyListScope.() -> Unit)? = null,
+    headerItemCount: Int = 0,
 ) {
     if (matches == null || matches.isEmpty()) {
         LazyColumn(Modifier.fillMaxSize()) {
@@ -70,8 +71,7 @@ fun MatchList(
     }
 
     // Calculate index of first unplayed match for auto-scroll
-    // When headerContent is present, it adds items before the match groups
-    val headerOffset = if (headerContent != null) 2 else 0
+    val headerOffset = headerItemCount
     val firstUnplayedIndex = run {
         var index = headerOffset
         for ((_, levelMatches) in grouped) {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -113,31 +113,35 @@ fun TeamEventDetailScreen(
                 ) { page ->
                     val evt = uiState.event
                     when (page) {
-                        0 -> MatchList(
-                            matches = uiState.matches,
-                            playoffType = evt?.playoffType ?: PlayoffType.OTHER,
-                            onNavigateToMatch = onNavigateToMatch,
-                            headerContent = {
-                                if (evt != null) {
-                                    item(key = "header_event") {
-                                        EventRow(
-                                            event = evt,
-                                            onClick = { onNavigateToEvent(evt.key) },
-                                            showYear = true,
-                                        )
+                        0 -> {
+                            val tm = uiState.team
+                            val headerCount = (if (evt != null) 1 else 0) + (if (tm != null) 1 else 0)
+                            MatchList(
+                                matches = uiState.matches,
+                                playoffType = evt?.playoffType ?: PlayoffType.OTHER,
+                                onNavigateToMatch = onNavigateToMatch,
+                                headerItemCount = headerCount,
+                                headerContent = {
+                                    if (evt != null) {
+                                        item(key = "header_event") {
+                                            EventRow(
+                                                event = evt,
+                                                onClick = { onNavigateToEvent(evt.key) },
+                                                showYear = true,
+                                            )
+                                        }
                                     }
-                                }
-                                val tm = uiState.team
-                                if (tm != null) {
-                                    item(key = "header_team") {
-                                        TeamRow(
-                                            team = tm,
-                                            onClick = { onNavigateToTeam(tm.key) },
-                                        )
+                                    if (tm != null) {
+                                        item(key = "header_team") {
+                                            TeamRow(
+                                                team = tm,
+                                                onClick = { onNavigateToTeam(tm.key) },
+                                            )
+                                        }
                                     }
-                                }
-                            },
-                        )
+                                },
+                            )
+                        }
                         1 -> AwardsTab(uiState.awards)
                     }
                 }


### PR DESCRIPTION
## Summary
- `MatchList` hardcoded `headerOffset = 2` when `headerContent` was present, assuming it always added exactly 2 items
- `TeamEventDetailScreen`'s header conditionally adds 0, 1, or 2 items depending on whether event/team data has loaded yet
- When matches arrived before event/team data, the auto-scroll target and section header indices were off
- Replaced the hardcoded guess with an explicit `headerItemCount` parameter that the caller sets

## Test plan
- [ ] Open a Team@Event page — verify auto-scroll to first unplayed match still works correctly
- [ ] Verify section header jump navigation targets the correct positions
- [ ] Event Matches tab (no header content) should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)