### PR TITLE
Add week headers to district events list

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailUiState.kt
@@ -2,10 +2,10 @@ package com.thebluealliance.android.ui.districts
 
 import com.thebluealliance.android.domain.model.District
 import com.thebluealliance.android.domain.model.DistrictRanking
-import com.thebluealliance.android.domain.model.Event
+import com.thebluealliance.android.ui.events.EventSection
 
 data class DistrictDetailUiState(
     val district: District? = null,
-    val events: List<Event>? = null,
+    val eventSections: List<EventSection>? = null,
     val rankings: List<DistrictRanking>? = null,
 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.thebluealliance.android.data.repository.DistrictRepository
 import com.thebluealliance.android.data.repository.EventRepository
 import com.thebluealliance.android.navigation.Screen
+import com.thebluealliance.android.ui.events.buildEventSections
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -36,7 +37,7 @@ class DistrictDetailViewModel @AssistedInject constructor(
     ) { district, events, rankings ->
         DistrictDetailUiState(
             district = district,
-            events = events,
+            eventSections = if (events.isEmpty()) null else buildEventSections(events),
             rankings = rankings,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DistrictDetailUiState())

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsViewModel.kt
@@ -101,33 +101,3 @@ class EventsViewModel @Inject constructor(
         }
     }
 }
-
-private data class SectionKey(val sortOrder: Int, val label: String)
-
-private fun eventSectionKey(event: Event): SectionKey {
-    return when (event.type) {
-        100 -> SectionKey(-1, "Preseason")
-        0, 1, 2, 5 -> {
-            val week = event.week ?: return SectionKey(9999, "Other events")
-            SectionKey(week, "Week ${week + 1}")
-        }
-        3, 4 -> SectionKey(1000, "Championship")
-        99 -> SectionKey(2000, "Offseason")
-        else -> {
-            // Unknown type but has a week — group with regular weeks
-            if (event.week != null) {
-                SectionKey(event.week, "Week ${event.week + 1}")
-            } else {
-                SectionKey(9999, "Other events")
-            }
-        }
-    }
-}
-
-private fun buildEventSections(events: List<Event>): List<EventSection> {
-    return events
-        .groupBy { eventSectionKey(it) }
-        .entries
-        .sortedBy { it.key.sortOrder }
-        .map { (key, sectionEvents) -> EventSection(key.label, sectionEvents) }
-}


### PR DESCRIPTION
## Summary
- District events were shown as a flat list with no week grouping or navigation
- Reuse the same `buildEventSections()` logic from the main Events tab to group district events by week
- Render with sticky `SectionHeader` composables that support tap-to-jump between weeks
- Extracted `buildEventSections()` from `EventsViewModel` to `EventsUiState.kt` for shared use

Closes #1101

## Test plan
- [ ] Navigate to Districts > tap a district — events should be grouped by week (Week 1, Week 2, etc.)
- [ ] Sticky headers should pin at the top when scrolling
- [ ] Tapping a pinned header should show a dropdown to jump to other weeks
- [ ] Main Events tab should still work identically (same grouping logic, just shared now)
- [ ] Pull to refresh still works on the district detail screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)