### PR TITLE
Remove search icon from event detail screen

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -169,7 +169,6 @@ fun TBANavigation(
                             onNavigateToTeamEvent = { teamKey, eventKey ->
                                 navigator.navigate(Screen.TeamEventDetail(teamKey, eventKey))
                             },
-                            onNavigateToSearch = { navigator.navigate(Screen.Search) },
                         )
                     }
                     entry<Screen.MatchDetail> { matchDetail ->

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
@@ -64,7 +63,6 @@ fun EventDetailScreen(
     onNavigateToMatch: (String) -> Unit = {},
     onNavigateToMyTBA: () -> Unit = {},
     onNavigateToTeamEvent: (teamKey: String, eventKey: String) -> Unit = { _, _ -> },
-    onNavigateToSearch: () -> Unit,
     viewModel: EventDetailViewModel,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -134,9 +132,6 @@ fun EventDetailScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = onNavigateToSearch) {
-                        Icon(Icons.Default.Search, contentDescription = "Search")
-                    }
                     IconButton(onClick = {
                         if (!viewModel.isSignedIn()) {
                             showSignInDialog = true


### PR DESCRIPTION
## Summary
- Removes the search icon from the event detail top bar to reduce clutter
- The top bar had four action icons (search, notifications, favorite, share) which was too crowded
- Search remains accessible from all top-level screens (Events, Teams, Districts, etc.)

## Test plan
- [ ] Open an event detail page, verify search icon is gone
- [ ] Verify notifications, favorite, and share icons still work
- [ ] Verify search is still accessible from top-level screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)