### PR TITLE
Move Share to overflow menu and add home screen shortcut

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -2,6 +2,7 @@ package com.thebluealliance.android.ui.events.detail
 
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,11 +12,14 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.NotificationsNone
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -36,9 +40,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.thebluealliance.android.R
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.domain.model.PlayoffType
 import com.thebluealliance.android.shortcuts.ReportShortcutVisitEffect
@@ -151,14 +157,43 @@ fun EventDetailScreen(
                             contentDescription = if (isFavorite) "Remove from favorites" else "Add to favorites",
                         )
                     }
-                    uiState.event?.let { event ->
-                        IconButton(onClick = {
-                            context.shareTbaUrl(
-                                title = "${event.year} ${event.name}",
-                                url = "https://www.thebluealliance.com/event/${event.key}",
-                            )
-                        }) {
-                            Icon(Icons.Filled.Share, contentDescription = "Share")
+                    var menuExpanded by remember { mutableStateOf(false) }
+                    Box {
+                        IconButton(onClick = { menuExpanded = true }) {
+                            Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                        }
+                        DropdownMenu(
+                            expanded = menuExpanded,
+                            onDismissRequest = { menuExpanded = false },
+                        ) {
+                            uiState.event?.let { event ->
+                                DropdownMenuItem(
+                                    text = { Text("Share") },
+                                    leadingIcon = { Icon(Icons.Filled.Share, contentDescription = null) },
+                                    onClick = {
+                                        menuExpanded = false
+                                        context.shareTbaUrl(
+                                            title = "${event.year} ${event.name}",
+                                            url = "https://www.thebluealliance.com/event/${event.key}",
+                                        )
+                                    },
+                                )
+                            }
+                            if (viewModel.canPinShortcuts) {
+                                DropdownMenuItem(
+                                    text = { Text("Add to home screen") },
+                                    leadingIcon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.ic_add_to_home_screen),
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    onClick = {
+                                        menuExpanded = false
+                                        viewModel.requestPinShortcut()
+                                    },
+                                )
+                            }
                         }
                     }
                 },

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
@@ -8,8 +8,10 @@ import com.thebluealliance.android.data.repository.EventRepository
 import com.thebluealliance.android.data.repository.MatchRepository
 import com.thebluealliance.android.data.repository.MyTBARepository
 import com.thebluealliance.android.data.repository.TeamRepository
+import com.thebluealliance.android.domain.model.Favorite
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.domain.model.Subscription
+import com.thebluealliance.android.shortcuts.TBAShortcutManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -38,6 +40,7 @@ class EventDetailViewModel @AssistedInject constructor(
     private val matchRepository: MatchRepository,
     private val myTBARepository: MyTBARepository,
     private val authRepository: AuthRepository,
+    private val shortcutManager: TBAShortcutManager,
 ) : ViewModel() {
 
     private val eventKey: String = navKey.eventKey
@@ -114,6 +117,16 @@ class EventDetailViewModel @AssistedInject constructor(
             } catch (_: Exception) {
                 _userMessage.emit("Failed to save notification preferences")
             }
+        }
+    }
+
+    val canPinShortcuts: Boolean = shortcutManager.canPinShortcuts()
+
+    fun requestPinShortcut() {
+        viewModelScope.launch {
+            shortcutManager.requestPinShortcut(
+                Favorite(modelKey = eventKey, modelType = ModelType.EVENT)
+            )
         }
     }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.outlined.PlayCircle
 import androidx.compose.material3.DropdownMenu
@@ -41,7 +42,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.NotificationsNone
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.AlertDialog
@@ -67,10 +67,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import com.thebluealliance.android.R
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.Media
 import com.thebluealliance.android.domain.model.ModelType
@@ -164,10 +166,6 @@ fun TeamDetailScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = onNavigateToSearch) {
-                        Icon(Icons.Default.Search, contentDescription = "Search")
-                    }
-
                     IconButton(onClick = {
                         if (!viewModel.isSignedIn()) {
                             showSignInDialog = true
@@ -187,14 +185,43 @@ fun TeamDetailScreen(
                             contentDescription = if (isFavorite) "Remove from favorites" else "Add to favorites",
                         )
                     }
-                    uiState.team?.let { team ->
-                        IconButton(onClick = {
-                            context.shareTbaUrl(
-                                title = "Team ${team.number} - ${team.nickname ?: ""}",
-                                url = "https://www.thebluealliance.com/team/${team.number}",
-                            )
-                        }) {
-                            Icon(Icons.Filled.Share, contentDescription = "Share")
+                    var menuExpanded by remember { mutableStateOf(false) }
+                    Box {
+                        IconButton(onClick = { menuExpanded = true }) {
+                            Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                        }
+                        DropdownMenu(
+                            expanded = menuExpanded,
+                            onDismissRequest = { menuExpanded = false },
+                        ) {
+                            uiState.team?.let { team ->
+                                DropdownMenuItem(
+                                    text = { Text("Share") },
+                                    leadingIcon = { Icon(Icons.Filled.Share, contentDescription = null) },
+                                    onClick = {
+                                        menuExpanded = false
+                                        context.shareTbaUrl(
+                                            title = "Team ${team.number} - ${team.nickname ?: ""}",
+                                            url = "https://www.thebluealliance.com/team/${team.number}",
+                                        )
+                                    },
+                                )
+                            }
+                            if (viewModel.canPinShortcuts) {
+                                DropdownMenuItem(
+                                    text = { Text("Add to home screen") },
+                                    leadingIcon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.ic_add_to_home_screen),
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    onClick = {
+                                        menuExpanded = false
+                                        viewModel.requestPinShortcut()
+                                    },
+                                )
+                            }
                         }
                     }
                 },

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailViewModel.kt
@@ -7,8 +7,10 @@ import com.thebluealliance.android.data.repository.AuthRepository
 import com.thebluealliance.android.data.repository.EventRepository
 import com.thebluealliance.android.data.repository.MyTBARepository
 import com.thebluealliance.android.data.repository.TeamRepository
+import com.thebluealliance.android.domain.model.Favorite
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.domain.model.Subscription
+import com.thebluealliance.android.shortcuts.TBAShortcutManager
 import com.thebluealliance.android.navigation.Screen
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -38,6 +40,7 @@ class TeamDetailViewModel @AssistedInject constructor(
     private val myTBARepository: MyTBARepository,
     private val authRepository: AuthRepository,
     private val tbaApi: TbaApi,
+    private val shortcutManager: TBAShortcutManager,
 ) : ViewModel() {
 
     private val teamKey: String = navKey.teamKey.let { key ->
@@ -148,6 +151,16 @@ class TeamDetailViewModel @AssistedInject constructor(
             } catch (_: Exception) {
                 _userMessage.emit("Failed to save notification preferences")
             }
+        }
+    }
+
+    val canPinShortcuts: Boolean = shortcutManager.canPinShortcuts()
+
+    fun requestPinShortcut() {
+        viewModelScope.launch {
+            shortcutManager.requestPinShortcut(
+                Favorite(modelKey = teamKey, modelType = ModelType.TEAM)
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace the standalone Share icon button on Event Detail and Team Detail screens with a three-dot overflow menu
- Overflow menu contains "Share" and "Add to home screen" (pin shortcut) options
- Remove Search icon from Team Detail top bar to reduce clutter
- Reuses existing `TBAShortcutManager.requestPinShortcut()` for the home screen shortcut functionality

## Test plan
- [ ] Event Detail: verify three-dot menu shows "Share" and "Add to home screen"
- [ ] Team Detail: verify same overflow menu
- [ ] Tap "Share" — verify share sheet opens
- [ ] Tap "Add to home screen" — verify system shortcut dialog appears
- [ ] Tap pinned shortcut — verify it opens the correct event/team

🤖 Generated with [Claude Code](https://claude.com/claude-code)