### PR TITLE
Fix white flash when switching tabs in dark mode

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -1,11 +1,13 @@
 package com.thebluealliance.android.navigation
 
 import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.entryProvider
@@ -60,7 +62,8 @@ fun TBANavigation(
         NavDisplay(
             modifier = Modifier
                 .weight(1f)
-                .fillMaxSize(),
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
             onBack = { navigator.goBack() },
             entries = navState.toEntries(
                 entryProvider = entryProvider {


### PR DESCRIPTION
## Summary
- Fixes #1112
- Added `.background(MaterialTheme.colorScheme.background)` to the `NavDisplay` modifier so the container uses the theme background color during fade transitions instead of defaulting to white

## Test plan
- [x] Build and install debug APK
- [x] Enable dark mode on emulator, switch between bottom nav tabs — no white flash during transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)