### PR TITLE
Remove dead Error variants and unused UiState fields

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -122,17 +121,6 @@ fun DistrictsScreen(
                     is DistrictsUiState.Loading -> {
                         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                             CircularProgressIndicator()
-                        }
-                    }
-
-                    is DistrictsUiState.Error -> {
-                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Text(state.message, style = MaterialTheme.typography.bodyLarge)
-                                Button(onClick = viewModel::refreshDistricts) {
-                                    Text("Retry")
-                                }
-                            }
                         }
                     }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsUiState.kt
@@ -5,5 +5,4 @@ import com.thebluealliance.android.domain.model.District
 sealed interface DistrictsUiState {
     data object Loading : DistrictsUiState
     data class Success(val districts: List<District>) : DistrictsUiState
-    data class Error(val message: String) : DistrictsUiState
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailUiState.kt
@@ -16,6 +16,4 @@ data class EventDetailUiState(
     val alliances: List<Alliance>? = null,
     val awards: List<Award>? = null,
     val districtPoints: List<EventDistrictPoints>? = null,
-    val isRefreshing: Boolean = false,
-    val error: String? = null,
 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsScreen.kt
@@ -2,7 +2,6 @@ package com.thebluealliance.android.ui.teams
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -12,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -84,17 +82,6 @@ fun TeamsScreen(
                 is TeamsUiState.Loading -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         CircularProgressIndicator()
-                    }
-                }
-
-                is TeamsUiState.Error -> {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(state.message, style = MaterialTheme.typography.bodyLarge)
-                            Button(onClick = viewModel::refreshTeams) {
-                                Text("Retry")
-                            }
-                        }
                     }
                 }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsUiState.kt
@@ -8,5 +8,4 @@ sealed interface TeamsUiState {
         val teams: List<Team>,
         val favoriteTeamKeys: Set<String> = emptySet(),
     ) : TeamsUiState
-    data class Error(val message: String) : TeamsUiState
 }


### PR DESCRIPTION
## Summary
- Delete unreachable `TeamsUiState.Error` and `DistrictsUiState.Error` variants and their corresponding screen branches (never produced by ViewModels)
- Remove unused `isRefreshing` and `error` fields from `EventDetailUiState` (screen reads `isRefreshing` from a separate ViewModel StateFlow; `error` is never referenced)
- No behavior changes

## Test plan
- [x] `./gradlew :app:assembleDebug` passes
- [x] `./gradlew :app:testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)