### PR TITLE
Deduplicate PREF_REGISTERED_TOKEN constant

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/DeviceRegistrationManager.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/DeviceRegistrationManager.kt
@@ -29,7 +29,7 @@ class DeviceRegistrationManager @Inject constructor(
     companion object {
         private const val TAG = "DeviceRegistration"
         private const val PREF_DEVICE_UUID = "device_uuid"
-        private const val PREF_REGISTERED_TOKEN = "registered_fcm_token"
+        internal const val PREF_REGISTERED_TOKEN = "registered_fcm_token"
     }
 
     val deviceUuid: String

--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/DeviceRegistrationWorker.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/DeviceRegistrationWorker.kt
@@ -24,7 +24,6 @@ class DeviceRegistrationWorker @AssistedInject constructor(
         const val KEY_FCM_TOKEN = "fcm_token"
         const val KEY_DEVICE_UUID = "device_uuid"
         private const val TAG = "DeviceRegWorker"
-        private const val PREF_REGISTERED_TOKEN = "registered_fcm_token"
     }
 
     override suspend fun doWork(): Result {
@@ -39,7 +38,7 @@ class DeviceRegistrationWorker @AssistedInject constructor(
                     deviceUuid = deviceUuid,
                 )
             )
-            sharedPreferences.edit().putString(PREF_REGISTERED_TOKEN, token).apply()
+            sharedPreferences.edit().putString(DeviceRegistrationManager.PREF_REGISTERED_TOKEN, token).apply()
             Log.d(TAG, "Registered device with token ${token.take(10)}...")
             Result.success()
         } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- Make `DeviceRegistrationManager.PREF_REGISTERED_TOKEN` internal instead of private
- Reference it from `DeviceRegistrationWorker` instead of duplicating the constant
- No behavior changes

## Test plan
- [x] `./gradlew :app:assembleDebug` passes
- [x] `./gradlew :app:testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)