### PR TITLE
Use default M3 bottom nav colors

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBABottomBar.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBABottomBar.kt
@@ -1,19 +1,15 @@
 package com.thebluealliance.android.ui.components
 
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavKey
 import com.thebluealliance.android.navigation.Screen
 import com.thebluealliance.android.ui.TOP_LEVEL_DESTINATIONS
-import com.thebluealliance.android.ui.theme.TBABlue
 
 @Composable
 fun TBABottomBar(
@@ -27,7 +23,6 @@ fun TBABottomBar(
 
     NavigationBar(
         modifier = modifier,
-        containerColor = MaterialTheme.colorScheme.surface,
     ) {
         TOP_LEVEL_DESTINATIONS.forEach { dest ->
             val selected = currentRoute == dest.key || (dest.key == Screen.More && isOnMoreSubScreen)
@@ -47,13 +42,6 @@ fun TBABottomBar(
                     )
                 },
                 label = { Text(dest.label) },
-                colors = NavigationBarItemDefaults.colors(
-                    selectedIconColor = Color.White,
-                    selectedTextColor = TBABlue,
-                    indicatorColor = TBABlue,
-                    unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
             )
         }
     }


### PR DESCRIPTION
## Summary

- Remove custom `NavigationBarItem` colors (solid TBA blue indicator + white icon)
- Remove explicit `containerColor` override on `NavigationBar`
- Let Material 3 use its defaults: `secondaryContainer` indicator, `onSecondaryContainer` icon, `onSurface` text
- Much less visually heavy — the bold TBA blue is reserved for the TopAppBar

## Test plan

- [ ] Bottom nav shows subtle indicator pill on selected tab
- [ ] Selected icon and text are readable but not overpowering
- [ ] Dark mode uses appropriate dark tonal variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)