### PR TITLE
Style myTBA profile photo and tab bar

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -185,7 +185,10 @@ fun MyTBAScreen(
                 AsyncImage(
                     model = uiState.userPhotoUrl,
                     contentDescription = "Profile photo",
-                    modifier = Modifier.size(40.dp).clip(CircleShape),
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
                     placeholder = personIcon,
                     error = personIcon,
                     fallback = personIcon,
@@ -229,7 +232,7 @@ fun MyTBAScreen(
             PrimaryScrollableTabRow(
                 selectedTabIndex = pagerState.currentPage,
                 edgePadding = 0.dp,
-                containerColor = TBABlue,
+                containerColor = Color(0xFF5C6BC0),
                 contentColor = Color.White,
                 divider = {
                     HorizontalDivider(color = Color.White.copy(alpha = 0.12f))
@@ -249,7 +252,8 @@ fun MyTBAScreen(
                         text = {
                             Text(
                                 text = title,
-                                color = Color.White
+                                color = Color.White,
+                                fontWeight = FontWeight.Bold,
                             )
                         },
                     )


### PR DESCRIPTION
## Summary
- Add `surfaceVariant` background to default profile photo so the person icon is visible in dark mode
- Use lighter indigo (`#5C6BC0`) for the Favorites/Notifications tab bar, matching the SectionHeader style used for match level headers like "Qualifications"
- Bold tab text to match SectionHeader typography

## Test plan
- [ ] Open myTBA while signed in — profile photo placeholder has visible gray circle background
- [ ] Favorites/Notifications tab bar is lighter indigo than the TopAppBar above
- [ ] Tab text is bold white

🤖 Generated with [Claude Code](https://claude.com/claude-code)