### PR TITLE
Fix crash: max dynamic shortcuts exceeded

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/shortcuts/TBAShortcutManager.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/shortcuts/TBAShortcutManager.kt
@@ -58,7 +58,7 @@ class TBAShortcutManager @Inject constructor(
                     val shortcuts = favorites
                         .take(ShortcutManagerCompat.getMaxShortcutCountPerActivity(context))
                         .mapNotNull { it.getShortcutInfo() }
-                    ShortcutManagerCompat.addDynamicShortcuts(context, shortcuts)
+                    ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
                 }
         }
     }


### PR DESCRIPTION
## Summary
- Replace `addDynamicShortcuts` with `setDynamicShortcuts` in `TBAShortcutManager` — the add variant appends and can exceed the system limit, while set replaces atomically

Fixes #1143

## Test plan
- [ ] Add >15 favorites in myTBA, verify no crash on app relaunch
- [ ] Verify shortcuts appear correctly on home screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)