### PR TITLE
Fix crash: ActivityNotFoundException when opening URLs

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MediaGrid.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MediaGrid.kt
@@ -1,7 +1,5 @@
 package com.thebluealliance.android.ui.components
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -26,6 +24,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.thebluealliance.android.util.openUrl
 
 /**
  * Data class for a media item to display in a media grid.
@@ -79,7 +78,7 @@ fun MediaItem(
             .then(
                 if (linkUrl != null) {
                     Modifier.clickable {
-                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(linkUrl)))
+                        context.openUrl(linkUrl)
                     }
                 } else {
                     Modifier

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -1,6 +1,5 @@
 package com.thebluealliance.android.ui.events.detail.tabs
 
-import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.PaddingValues
@@ -29,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.Webcast
 import com.thebluealliance.android.ui.common.LoadingBox
+import com.thebluealliance.android.util.openUrl
 import com.thebluealliance.android.ui.components.formatEventDateRange
 
 @Composable
@@ -109,12 +109,8 @@ fun EventInfoTab(
                     modifier = Modifier
                         .padding(top = 8.dp)
                         .clickable {
-                            val intent = if (event.gmapsUrl != null) {
-                                Intent(Intent.ACTION_VIEW, Uri.parse(event.gmapsUrl))
-                            } else {
-                                Intent(Intent.ACTION_VIEW, Uri.parse("geo:0,0?q=${Uri.encode(event.address)}"))
-                            }
-                            context.startActivity(intent)
+                            val url = event.gmapsUrl ?: "geo:0,0?q=${Uri.encode(event.address)}"
+                            context.openUrl(url)
                         },
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -141,7 +137,7 @@ fun EventInfoTab(
                     modifier = Modifier
                         .padding(top = 8.dp)
                         .clickable {
-                            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(event.website)))
+                            context.openUrl(event.website)
                         },
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -179,7 +175,7 @@ fun EventInfoTab(
                         modifier = Modifier
                             .padding(top = 4.dp)
                             .clickable {
-                                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                                context.openUrl(url)
                             },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/ThanksScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/ThanksScreen.kt
@@ -1,7 +1,5 @@
 package com.thebluealliance.android.ui.more
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -45,6 +43,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import com.thebluealliance.android.ui.components.TBATopAppBar
+import com.thebluealliance.android.util.openUrl
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -127,7 +126,7 @@ private fun ContributorRow(contributor: GitHubContributorDto) {
         modifier = Modifier
             .fillMaxWidth()
             .clickable {
-                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(contributor.htmlUrl)))
+                context.openUrl(contributor.htmlUrl)
             }
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/kotlin/com/thebluealliance/android/util/UrlUtils.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/util/UrlUtils.kt
@@ -1,0 +1,18 @@
+package com.thebluealliance.android.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+
+/**
+ * Opens a URL in an external app. Shows a Toast if no app can handle the intent.
+ */
+fun Context.openUrl(url: String) {
+    try {
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+    } catch (_: ActivityNotFoundException) {
+        Toast.makeText(this, "No app available to open this link", Toast.LENGTH_SHORT).show()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Context.openUrl()` extension that wraps `startActivity(ACTION_VIEW)` in a try-catch for `ActivityNotFoundException`, showing a Toast on failure
- Apply at all 5 call sites in the Compose UI: MediaGrid, EventInfoTab (address, website, webcast), ThanksScreen

Fixes #1145

## Test plan
- [ ] Tap a media item on a team detail page — verify it opens in browser
- [ ] Tap event address, website, and webcast links — verify they open correctly
- [ ] Tap a contributor on the Thanks screen — verify GitHub profile opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)