### PR TITLE
Fix crash: empty back stack in NavigationState.currentRoute

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/NavigationState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/NavigationState.kt
@@ -118,8 +118,8 @@ class NavigationState(
 
     val currentStack: NavBackStack<NavKey>
         get() = backStacks[topLevelRoute] ?: error("Stack for $topLevelRoute not found")
-    val currentRoute: NavKey
-        get() = currentStack.last()
+    val currentRoute: NavKey?
+        get() = currentStack.lastOrNull()
 }
 
 @Composable

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -257,13 +257,14 @@ fun TBANavigation(
             ),
         )
 
-        if (showBottomBar) {
+        val currentRoute = navState.currentRoute
+        if (showBottomBar && currentRoute != null) {
             TBABottomBar(
-                currentRoute = navState.currentRoute,
+                currentRoute = currentRoute,
                 onNavigate = { navigator.navigate(it) },
                 onReselect = {
                     coroutineScope.launch {
-                        tabReselectFlows[navState.currentRoute]?.emit(Unit)
+                        tabReselectFlows[currentRoute]?.emit(Unit)
                     }
                 },
             )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/TBAApp.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/TBAApp.kt
@@ -61,6 +61,7 @@ private fun FirebaseAnalyticsEffect(
     LaunchedEffect(navState) {
         snapshotFlow { navState.currentRoute }
             .collectLatest { currentRoute ->
+                if (currentRoute == null) return@collectLatest
                 val screenName = when (currentRoute) {
                     Screen.Events -> "Events"
                     Screen.Teams -> "Teams"


### PR DESCRIPTION
## Summary
- Change `NavigationState.currentRoute` from `.last()` to `.lastOrNull()`, returning `NavKey?` instead of `NavKey`
- Update `FirebaseAnalyticsEffect` to skip logging when the route is null
- Guard the `TBABottomBar` call with a null check on the current route

Fixes #1148

## Test plan
- [ ] Navigate between screens rapidly, verify no crash
- [ ] Check logcat for `screen_view` events still being logged correctly
- [ ] Cold launch the app, verify analytics events fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)