### PR TITLE
Don't pop the back stack if we have nothing left to pop

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/Navigator.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/Navigator.kt
@@ -52,7 +52,7 @@ class Navigator(
         // If we're at the base of the current route, go back to the start route stack.
         if (state.currentRoute == state.topLevelRoute) {
             state.topLevelRoute = state.startRoute
-        } else {
+        } else if (state.currentStack.size > 1){
             state.currentStack.removeLastOrNull()
         }
     }
@@ -92,7 +92,7 @@ class Navigator(
             activity.finish()
             // trigger restart
             builder.startActivities()
-        } else {
+        } else if (size > 1) {
             removeLastOrNull()
         }
     }


### PR DESCRIPTION
Alternative to #1149  to fix #1148 

If we have nothing left on the stack to pop, don't try to pop the back stack.

I'm still not wholly satisfied because I haven't been able to reproduce locally, but I'm hopeful this gets a little closer to the true root cause. My hunch is that perhaps the user was able to hit the back button twice before the first press had actually finished popping the stack.