### PR TITLE
Improve Team@Event navigation to full Team and Event pages

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/EventRow.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/EventRow.kt
@@ -2,11 +2,16 @@ package com.thebluealliance.android.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -20,34 +25,45 @@ fun EventRow(
     event: Event,
     onClick: () -> Unit,
     showYear: Boolean = false,
+    showChevron: Boolean = false,
 ) {
-    Column(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        val name = if (showYear) "${event.year} ${event.name}" else event.name
-        Text(
-            text = name,
-            style = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.Medium,
-        )
-        val location = listOfNotNull(event.city, event.state, event.country)
-            .joinToString(", ")
-        if (location.isNotEmpty()) {
+        Column(modifier = Modifier.weight(1f)) {
+            val name = if (showYear) "${event.year} ${event.name}" else event.name
             Text(
-                text = location,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = name,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
             )
+            val location = listOfNotNull(event.city, event.state, event.country)
+                .joinToString(", ")
+            if (location.isNotEmpty()) {
+                Text(
+                    text = location,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            val dateRange = formatEventDateRange(event.startDate, event.endDate)
+            if (dateRange != null) {
+                Text(
+                    text = dateRange,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
-        val dateRange = formatEventDateRange(event.startDate, event.endDate)
-        if (dateRange != null) {
-            Text(
-                text = dateRange,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+        if (showChevron) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/TeamRow.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/TeamRow.kt
@@ -2,11 +2,16 @@ package com.thebluealliance.android.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -16,24 +21,35 @@ import com.thebluealliance.android.domain.model.Team
 fun TeamRow(
     team: Team,
     onClick: () -> Unit,
+    showChevron: Boolean = false,
 ) {
-    Column(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = "${team.number} - ${team.nickname ?: team.name ?: ""}",
-            style = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.Medium,
-        )
-        val location = listOfNotNull(team.city, team.state, team.country).joinToString(", ")
-        if (location.isNotEmpty()) {
+        Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = location,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = "${team.number} - ${team.nickname ?: team.name ?: ""}",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            val location = listOfNotNull(team.city, team.state, team.country).joinToString(", ")
+            if (location.isNotEmpty()) {
+                Text(
+                    text = location,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        if (showChevron) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -1,7 +1,9 @@
 package com.thebluealliance.android.ui.teamevent
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -34,7 +37,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.Award
+import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.PlayoffType
+import com.thebluealliance.android.domain.model.Team
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.components.EventRow
@@ -63,22 +68,43 @@ fun TeamEventDetailScreen(
 
     val team = uiState.team
     val event = uiState.event
-    val titleText = if (team != null && event != null) {
-        "${team.number} @ ${event.shortName ?: event.name}"
-    } else {
-        "Team @ Event"
-    }
 
     Scaffold(
         topBar = {
             Column {
                 TBATopAppBar(
                     title = {
-                        Text(
-                            text = titleText,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
+                        if (team != null && event != null) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = "${team.number}",
+                                    maxLines = 1,
+                                    modifier = Modifier.clickable { onNavigateToTeam(team.key) },
+                                    style = MaterialTheme.typography.titleLarge,
+                                )
+                                Text(
+                                    text = " @ ",
+                                    maxLines = 1,
+                                    style = MaterialTheme.typography.titleLarge,
+                                )
+                                Text(
+                                    text = event.shortName ?: event.name,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f).clickable { onNavigateToEvent(event.key) },
+                                    style = MaterialTheme.typography.titleLarge,
+                                )
+                            }
+                        } else {
+                            Text(
+                                text = "Team @ Event",
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
                     },
                     navigationIcon = {
                         IconButton(onClick = onNavigateUp) {
@@ -126,7 +152,8 @@ fun TeamEventDetailScreen(
                 when (page) {
                     0 -> {
                         val tm = uiState.team
-                        val headerCount = (if (evt != null) 1 else 0) + (if (tm != null) 1 else 0)
+                        val hasBoth = evt != null && tm != null
+                        val headerCount = (if (evt != null) 1 else 0) + (if (hasBoth) 1 else 0) + (if (tm != null) 1 else 0)
                         MatchList(
                             matches = uiState.matches,
                             playoffType = evt?.playoffType ?: PlayoffType.OTHER,
@@ -139,14 +166,19 @@ fun TeamEventDetailScreen(
                                             event = evt,
                                             onClick = { onNavigateToEvent(evt.key) },
                                             showYear = true,
+                                            showChevron = true,
                                         )
                                     }
+                                }
+                                if (evt != null && tm != null) {
+                                    item(key = "header_divider") { HorizontalDivider() }
                                 }
                                 if (tm != null) {
                                     item(key = "header_team") {
                                         TeamRow(
                                             team = tm,
                                             onClick = { onNavigateToTeam(tm.key) },
+                                            showChevron = true,
                                         )
                                     }
                                 }
@@ -154,10 +186,17 @@ fun TeamEventDetailScreen(
                             innerPadding = innerPadding,
                         )
                     }
-                    1 -> AwardsTab(
-                        awards = uiState.awards,
-                        innerPadding = innerPadding,
-                    )
+                    1 -> {
+                        val tm = uiState.team
+                        AwardsTab(
+                            awards = uiState.awards,
+                            event = evt,
+                            team = tm,
+                            onNavigateToEvent = onNavigateToEvent,
+                            onNavigateToTeam = onNavigateToTeam,
+                            innerPadding = innerPadding,
+                        )
+                    }
                 }
             }
         }
@@ -167,6 +206,10 @@ fun TeamEventDetailScreen(
 @Composable
 private fun AwardsTab(
     awards: List<Award>?,
+    event: Event?,
+    team: Team?,
+    onNavigateToEvent: (String) -> Unit,
+    onNavigateToTeam: (String) -> Unit,
     innerPadding: PaddingValues = PaddingValues.Zero,
 ) {
     if (awards == null) {
@@ -175,17 +218,40 @@ private fun AwardsTab(
         )
         return
     }
-    if (awards.isEmpty()) {
-        EmptyBox(
-            modifier = Modifier.padding(innerPadding),
-            message = "No awards"
-        )
-        return
-    }
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = innerPadding,
     ) {
+        if (event != null) {
+            item(key = "header_event") {
+                EventRow(
+                    event = event,
+                    onClick = { onNavigateToEvent(event.key) },
+                    showYear = true,
+                    showChevron = true,
+                )
+            }
+        }
+        if (event != null && team != null) {
+            item(key = "header_divider") { HorizontalDivider() }
+        }
+        if (team != null) {
+            item(key = "header_team") {
+                TeamRow(
+                    team = team,
+                    onClick = { onNavigateToTeam(team.key) },
+                    showChevron = true,
+                )
+            }
+        }
+        if (awards.isEmpty()) {
+            item {
+                EmptyBox(
+                    message = "No awards",
+                    modifier = Modifier.padding(top = 24.dp),
+                )
+            }
+        }
         items(awards, key = { "${it.awardType}_${it.awardee.orEmpty()}" }) { award ->
             Column(
                 modifier = Modifier


### PR DESCRIPTION
## Summary
- TopBar team number and event short are both tappable (though not indicated - underline felt messy)
- Add chevron (>) indicators on EventRow and TeamRow headers in Team@Event screens to make it visually clear they're tap targets for navigating to full detail pages
- Show Event and Team navigation headers on the Awards tab too — previously they only appeared on the Matches tab, leaving no way to navigate out from Awards
- Add a divider between EventRow and TeamRow headers to reinforce they're separate tap targets

Addresses user feedback about difficulty navigating from Team@Event pages to full Team and Event detail pages.

### Before / After — Matches tab
| Before | After |
|--------|-------|
| No visual indicator rows are tappable | Chevron + divider make it clear |
||<img width="441" height="860" alt="image" src="https://github.com/user-attachments/assets/8f818062-da86-46e8-aeac-547f674bfc34" />|

### After — Awards tab
Now shows navigation headers even when there are no awards.

## Test plan
- [ ] Open a Team@Event page from an Event's Teams tab
- [ ] Verify chevron appears on both EventRow and TeamRow headers on Matches tab
- [ ] Verify divider separates the two header rows
- [ ] Tap chevron rows — confirm they navigate to full Event and Team pages
- [ ] Switch to Awards tab — verify same headers appear with chevrons
- [ ] Verify "No awards" message appears with padding below headers when team has no awards
- [ ] Verify team/event lists elsewhere (Event Teams tab, Events screen, Search) do NOT show chevrons

🤖 Generated with [Claude Code](https://claude.com/claude-code)