### PR TITLE
Fix crash: duplicate webcast key in EventInfoTab LazyColumn

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.LocationOn
@@ -167,7 +168,7 @@ fun EventInfoTab(
                     fontWeight = FontWeight.Bold,
                 )
             }
-            items(event.webcasts, key = { "${it.type}_${it.channel}" }) { webcast ->
+            itemsIndexed(event.webcasts, key = { index, it -> "${it.type}_${it.channel}_$index" }) { _, webcast ->
                 val url = webcastUrl(webcast)
                 val label = webcastLabel(webcast)
                 if (url != null) {


### PR DESCRIPTION
## Summary

- Fixes a crash (5 events, 2 users on v11.0.0) where an event has duplicate webcasts with the same type + channel — e.g. `twitch_FIRSTOntario4` appearing twice — causing a `LazyColumn` key collision (`IllegalArgumentException`)
- Appends the list index to the webcast key to guarantee uniqueness

## Test plan

- [x] Builds successfully
- [ ] Verify EventInfoTab renders correctly for events with webcasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)