### PR TITLE
Add Media tab to Team@Event screen

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MediaGrid.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MediaGrid.kt
@@ -4,12 +4,18 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.PlayCircle
@@ -24,6 +30,9 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.thebluealliance.android.domain.model.Media
+import com.thebluealliance.android.ui.common.EmptyBox
+import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.util.openUrl
 
 /**
@@ -134,6 +143,51 @@ fun MediaGridRow(
             if (rowItems.size == 1) {
                 Spacer(modifier = Modifier.weight(1f))
             }
+        }
+    }
+}
+
+/**
+ * A full-screen tab that displays a team's media in a 2-column grid.
+ * Shared between Team detail and Team@Event detail screens.
+ */
+@Composable
+fun MediaTab(
+    media: List<Media>?,
+    innerPadding: PaddingValues = PaddingValues.Zero,
+) {
+    if (media == null) {
+        LoadingBox(modifier = Modifier.padding(innerPadding))
+        return
+    }
+    val filtered = media.filter { it.type != "avatar" }
+    if (filtered.isEmpty()) {
+        EmptyBox(
+            modifier = Modifier.padding(innerPadding),
+            message = "No media"
+        )
+        return
+    }
+    val gridItems = filtered.mapNotNull { item ->
+        if (mediaUrl(item.type, item.foreignKey) != null) {
+            MediaGridItem(type = item.type, foreignKey = item.foreignKey)
+        } else null
+    }
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = innerPadding,
+    ) {
+        items(gridItems, key = { "${it.type}_${it.foreignKey}" }) { item ->
+            MediaItem(
+                type = item.type,
+                foreignKey = item.foreignKey,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -53,12 +53,13 @@ import com.thebluealliance.android.ui.events.detail.EventDetailTabs
 import com.thebluealliance.android.ui.components.EventRow
 import com.thebluealliance.android.ui.components.MatchItem
 import com.thebluealliance.android.ui.components.MatchList
+import com.thebluealliance.android.ui.components.MediaTab
 import com.thebluealliance.android.ui.components.TBATabRow
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.TeamRow
 import kotlinx.coroutines.launch
 
-private val TABS = listOf("Summary", "Matches", "Stats", "Awards")
+private val TABS = listOf("Summary", "Matches", "Media", "Stats", "Awards")
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -208,12 +209,16 @@ fun TeamEventDetailScreen(
                             innerPadding = innerPadding,
                         )
                     }
-                    2 -> StatsTab(
+                    2 -> MediaTab(
+                        media = uiState.media,
+                        innerPadding = innerPadding,
+                    )
+                    3 -> StatsTab(
                         teamKey = viewModel.teamKey,
                         oprs = uiState.oprs,
                         innerPadding = innerPadding,
                     )
-                    3 -> {
+                    4 -> {
                         val tm = uiState.team
                         AwardsTab(
                             awards = uiState.awards,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailUiState.kt
@@ -5,6 +5,7 @@ import com.thebluealliance.android.domain.model.Award
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.EventOPRs
 import com.thebluealliance.android.domain.model.Match
+import com.thebluealliance.android.domain.model.Media
 import com.thebluealliance.android.domain.model.Ranking
 import com.thebluealliance.android.domain.model.Team
 
@@ -16,4 +17,5 @@ data class TeamEventDetailUiState(
     val awards: List<Award>? = null,
     val oprs: EventOPRs? = null,
     val alliances: List<Alliance>? = null,
+    val media: List<Media>? = null,
 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailViewModel.kt
@@ -5,6 +5,10 @@ import androidx.lifecycle.viewModelScope
 import com.thebluealliance.android.data.repository.EventRepository
 import com.thebluealliance.android.data.repository.MatchRepository
 import com.thebluealliance.android.data.repository.TeamRepository
+import com.thebluealliance.android.domain.model.Alliance
+import com.thebluealliance.android.domain.model.Award
+import com.thebluealliance.android.domain.model.EventOPRs
+import com.thebluealliance.android.domain.model.Media
 import com.thebluealliance.android.navigation.Screen
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -20,6 +24,13 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+private data class TeamEventExtras(
+    val awards: List<Award>,
+    val oprs: EventOPRs?,
+    val alliances: List<Alliance>,
+    val media: List<Media>,
+)
+
 @HiltViewModel(assistedFactory = TeamEventDetailViewModel.Factory::class)
 class TeamEventDetailViewModel @AssistedInject constructor(
     @Assisted val navKey: Screen.TeamEventDetail,
@@ -30,6 +41,7 @@ class TeamEventDetailViewModel @AssistedInject constructor(
 
     val teamKey: String = navKey.teamKey
     val eventKey: String = navKey.eventKey
+    private val year: Int = eventKey.substring(0, 4).toIntOrNull() ?: 0
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
@@ -49,17 +61,18 @@ class TeamEventDetailViewModel @AssistedInject constructor(
             },
             eventRepository.observeEventOPRs(eventKey),
             eventRepository.observeEventAlliances(eventKey),
-        ) { awards, oprs, alliances -> Triple(awards, oprs, alliances) },
+            teamRepository.observeTeamMedia(teamKey, year),
+        ) { awards, oprs, alliances, media -> TeamEventExtras(awards, oprs, alliances, media) },
     ) { team, event, ranking, matches, extras ->
-        val (awards, oprs, alliances) = extras
         TeamEventDetailUiState(
             team = team,
             event = event,
             ranking = ranking,
             matches = matches,
-            awards = awards,
-            oprs = oprs,
-            alliances = alliances,
+            awards = extras.awards,
+            oprs = extras.oprs,
+            alliances = extras.alliances,
+            media = extras.media,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), TeamEventDetailUiState())
 
@@ -79,6 +92,7 @@ class TeamEventDetailViewModel @AssistedInject constructor(
                     launch { try { eventRepository.refreshEventAwards(eventKey) } catch (_: Exception) {} }
                     launch { try { eventRepository.refreshEventOPRs(eventKey) } catch (_: Exception) {} }
                     launch { try { eventRepository.refreshEventAlliances(eventKey) } catch (_: Exception) {} }
+                    launch { try { teamRepository.refreshTeamMedia(teamKey, year) } catch (_: Exception) {} }
                 }
             } finally {
                 _isRefreshing.value = false

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -21,9 +21,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -81,12 +78,10 @@ import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.common.shareTbaUrl
 import com.thebluealliance.android.ui.components.EventRow
-import com.thebluealliance.android.ui.components.MediaGridItem
-import com.thebluealliance.android.ui.components.MediaItem
+import com.thebluealliance.android.ui.components.MediaTab
 import com.thebluealliance.android.ui.components.NotificationPreferencesSheet
 import com.thebluealliance.android.ui.components.TBATabRow
 import com.thebluealliance.android.ui.components.TBATopAppBar
-import com.thebluealliance.android.ui.components.mediaUrl
 import kotlinx.coroutines.launch
 
 private val TABS = listOf("Info", "Events", "Media")
@@ -464,49 +459,6 @@ private fun EventsTab(
                     EventRow(event = event, onClick = { onNavigateToEvent(event.key) })
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun MediaTab(
-    media: List<Media>?,
-    innerPadding: PaddingValues = PaddingValues.Zero,
-) {
-    if (media == null) {
-        LoadingBox(
-            modifier = Modifier.padding(innerPadding)
-        )
-        return
-    }
-    val filtered = media.filter { it.type != "avatar" }
-    if (filtered.isEmpty()) {
-        EmptyBox(
-            modifier = Modifier.padding(innerPadding),
-            message = "No media"
-        )
-        return
-    }
-    val gridItems = filtered.mapNotNull { item ->
-        if (mediaUrl(item.type, item.foreignKey) != null) {
-            MediaGridItem(type = item.type, foreignKey = item.foreignKey)
-        } else null
-    }
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(2),
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        contentPadding = innerPadding,
-    ) {
-        items(gridItems, key = { "${it.type}_${it.foreignKey}" }) { item ->
-            MediaItem(
-                type = item.type,
-                foreignKey = item.foreignKey,
-                modifier = Modifier.fillMaxWidth(),
-            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extract shared `MediaTab` composable from `TeamDetailScreen` into `MediaGrid.kt` so both Team detail and Team@Event detail can reuse it
- Add a Media tab to the Team@Event screen (between Matches and Stats)
- Wire up team media observation and refresh in `TeamEventDetailViewModel`

## Screenshot
<img width="441" height="860" alt="image" src="https://github.com/user-attachments/assets/d6629cd1-d109-455c-aa6b-2ddefdf596ff" />

## Test plan
- [x] Open a Team@Event page (e.g. deep link to `2026test`)
- [x] Verify the Media tab appears between Matches and Stats
- [x] Verify media loads and displays in a 2-column grid
- [x] Verify Team detail Media tab still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)