### PR TITLE
Remove abbreviation subtitle from district rows

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsScreen.kt
@@ -151,21 +151,13 @@ private fun DistrictItem(
     district: District,
     onClick: () -> Unit,
 ) {
-    Column(
+    Text(
+        text = district.displayName,
+        style = MaterialTheme.typography.bodyLarge,
+        fontWeight = FontWeight.Medium,
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp),
-    ) {
-        Text(
-            text = district.displayName,
-            style = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.Medium,
-        )
-        Text(
-            text = district.abbreviation.uppercase(),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
+    )
 }


### PR DESCRIPTION
## Summary
- Remove the abbreviation subtitle (e.g. "FMA", "NE") from each district row on the Districts screen
- All 15 districts now fit on a typical phone screen without scrolling

## Screenshot
<img width="441" height="860" alt="image" src="https://github.com/user-attachments/assets/a9b19d11-dbb5-43e2-8445-1ff50f5a5fa8" />

## Test plan
- [ ] Open Districts tab — verify all districts visible without scrolling
- [ ] Tap a district — verify navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)