### PR TITLE
Refresh favorites from server on Teams and Events tabs

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsViewModel.kt
@@ -3,6 +3,7 @@ package com.thebluealliance.android.ui.events
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.thebluealliance.android.data.remote.TbaApi
+import com.thebluealliance.android.data.repository.AuthRepository
 import com.thebluealliance.android.data.repository.EventRepository
 import com.thebluealliance.android.data.repository.MyTBARepository
 import com.thebluealliance.android.domain.model.ModelType
@@ -27,6 +28,7 @@ class EventsViewModel @Inject constructor(
     private val eventRepository: EventRepository,
     private val tbaApi: TbaApi,
     private val myTBARepository: MyTBARepository,
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     private val _maxYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
@@ -65,6 +67,14 @@ class EventsViewModel @Inject constructor(
     init {
         fetchMaxYear()
         refreshEvents()
+        refreshFavorites()
+    }
+
+    private fun refreshFavorites() {
+        viewModelScope.launch {
+            if (!authRepository.isSignedIn()) return@launch
+            try { myTBARepository.refreshFavorites() } catch (_: Exception) {}
+        }
     }
 
     private fun fetchMaxYear() {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsViewModel.kt
@@ -2,6 +2,7 @@ package com.thebluealliance.android.ui.teams
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.thebluealliance.android.data.repository.AuthRepository
 import com.thebluealliance.android.data.repository.MyTBARepository
 import com.thebluealliance.android.data.repository.TeamRepository
 import com.thebluealliance.android.domain.model.ModelType
@@ -19,6 +20,7 @@ import javax.inject.Inject
 class TeamsViewModel @Inject constructor(
     private val teamRepository: TeamRepository,
     private val myTBARepository: MyTBARepository,
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     private val _isRefreshing = MutableStateFlow(false)
@@ -37,6 +39,14 @@ class TeamsViewModel @Inject constructor(
 
     init {
         refreshTeams()
+        refreshFavorites()
+    }
+
+    private fun refreshFavorites() {
+        viewModelScope.launch {
+            if (!authRepository.isSignedIn()) return@launch
+            try { myTBARepository.refreshFavorites() } catch (_: Exception) {}
+        }
     }
 
     fun refreshTeams() {


### PR DESCRIPTION
## Summary
- Favorites were only fetched from the server when the MyTBA tab was visited — Teams and Events tabs observed the local Room cache but never triggered a network refresh
- On a fresh app start with an already-signed-in user, no favorites would appear on Teams/Events until visiting the MyTBA tab
- Both `TeamsViewModel` and `EventsViewModel` now call `myTBARepository.refreshFavorites()` on init (if signed in), matching what `MyTBAViewModel` already does

## Test plan
- [ ] Sign in, force-stop the app, relaunch — verify favorites appear on Teams tab without visiting MyTBA first
- [ ] Same for Events tab
- [ ] Add a favorite on web, pull-to-refresh on Teams/Events — verify it appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)