### PR TITLE
Animate navigation transitions and bottom bar show/hide

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -35,6 +35,12 @@ import com.thebluealliance.android.ui.teams.TeamDetailScreen
 import com.thebluealliance.android.ui.teams.TeamDetailViewModel
 import com.thebluealliance.android.ui.teams.TeamsScreen
 import com.thebluealliance.android.ui.regional.RegionalAdvancementScreen
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
@@ -65,6 +71,18 @@ fun TBANavigation(
                 .weight(1f)
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background),
+            transitionSpec = {
+                slideInHorizontally(initialOffsetX = { it }) togetherWith
+                    slideOutHorizontally(targetOffsetX = { -it })
+            },
+            popTransitionSpec = {
+                slideInHorizontally(initialOffsetX = { -it }) togetherWith
+                    slideOutHorizontally(targetOffsetX = { it })
+            },
+            predictivePopTransitionSpec = {
+                slideInHorizontally(initialOffsetX = { -it }) togetherWith
+                    slideOutHorizontally(targetOffsetX = { it })
+            },
             onBack = { navigator.goBack() },
             entries = navState.toEntries(
                 entryProvider = entryProvider {
@@ -274,7 +292,11 @@ fun TBANavigation(
             ),
         )
 
-        if (showBottomBar) {
+        AnimatedVisibility(
+            visible = showBottomBar,
+            enter = slideInVertically(initialOffsetY = { it }),
+            exit = slideOutVertically(targetOffsetY = { it }),
+        ) {
             TBABottomBar(
                 currentRoute = navState.currentRoute,
                 onNavigate = { navigator.navigate(it) },


### PR DESCRIPTION
## Summary
- Add horizontal slide transitions for forward/back screen navigation (right-to-left on push, left-to-right on pop)
- Animate bottom bar with vertical slide — slides down when entering detail screens, slides up when returning to tab screens
- Replaces the jarring instant show/hide of the bottom bar with smooth `AnimatedVisibility`

## Test plan
- [ ] Navigate to a detail screen (event, team, match) — bottom bar slides down smoothly
- [ ] Navigate back to a tab screen — bottom bar slides up smoothly
- [ ] Switch between tabs — bottom bar stays visible, no animation
- [ ] Forward navigation slides new screen in from the right
- [ ] Back navigation slides screen out to the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)