### PR TITLE
[RFC] Allow filtering the main event list by district/regional

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -8,24 +8,32 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,17 +48,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.thebluealliance.android.domain.model.District
 import com.thebluealliance.android.ui.components.EventRow
 import com.thebluealliance.android.ui.components.FastScrollbar
 import com.thebluealliance.android.ui.components.SectionHeader
 import com.thebluealliance.android.ui.components.SectionHeaderInfo
 import com.thebluealliance.android.ui.components.TBATopAppBar
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.Search
-import kotlinx.coroutines.flow.Flow
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,10 +69,41 @@ fun EventsScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val selectedYear by viewModel.selectedYear.collectAsStateWithLifecycle()
     val maxYear by viewModel.maxYear.collectAsStateWithLifecycle()
+    val selectedFilter by viewModel.selectedFilter.collectAsStateWithLifecycle()
+    val availableDistricts by viewModel.availableDistricts.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
 
     var yearDropdownExpanded by remember { mutableStateOf(false) }
+    var showFilterDialog by remember { mutableStateOf(false) }
+
+    val selectedFilterSubtitle = remember(selectedFilter, availableDistricts) {
+        filterSubtitle(selectedFilter, availableDistricts)
+    }
+
+    if (showFilterDialog) {
+        EventFilterDialog(
+            selectedFilter = selectedFilter,
+            availableDistricts = availableDistricts,
+            onDismiss = { showFilterDialog = false },
+            onSelectAll = {
+                viewModel.selectAllFilter()
+                showFilterDialog = false
+            },
+            onSelectRegionals = {
+                viewModel.selectRegionalsFilter()
+                showFilterDialog = false
+            },
+            onSelectOffseasons = {
+                viewModel.selectOffseasonsFilter()
+                showFilterDialog = false
+            },
+            onSelectDistrict = { districtKey ->
+                viewModel.selectDistrictFilter(districtKey)
+                showFilterDialog = false
+            },
+        )
+    }
 
     LaunchedEffect(reselectFlow) {
         reselectFlow.collect {
@@ -80,32 +117,41 @@ fun EventsScreen(
             TBATopAppBar(
                 title = {
                     if (selectedYear > 0) {
-                        Row(
-                            modifier = Modifier.clickable { yearDropdownExpanded = true },
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text("$selectedYear Events")
-                            Icon(Icons.Default.ArrowDropDown, contentDescription = "Select year")
-                            DropdownMenu(
-                                expanded = yearDropdownExpanded,
-                                onDismissRequest = { yearDropdownExpanded = false },
+                        Column {
+                            Row(
+                                modifier = Modifier.clickable { yearDropdownExpanded = true },
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                (maxYear downTo 1992).forEach { year ->
-                                    DropdownMenuItem(
-                                        text = { Text(year.toString()) },
-                                        onClick = {
-                                            viewModel.selectYear(year)
-                                            yearDropdownExpanded = false
-                                        },
-                                    )
+                                Text("$selectedYear Events")
+                                Icon(Icons.Default.ArrowDropDown, contentDescription = "Select year")
+                                DropdownMenu(
+                                    expanded = yearDropdownExpanded,
+                                    onDismissRequest = { yearDropdownExpanded = false },
+                                ) {
+                                    (maxYear downTo 1992).forEach { year ->
+                                        DropdownMenuItem(
+                                            text = { Text(year.toString()) },
+                                            onClick = {
+                                                viewModel.selectYear(year)
+                                                yearDropdownExpanded = false
+                                            },
+                                        )
+                                    }
                                 }
                             }
+                            Text(
+                                text = selectedFilterSubtitle,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
                         }
                     } else {
                         Text("Events")
                     }
                 },
                 actions = {
+                    IconButton(onClick = { showFilterDialog = true }) {
+                        Icon(Icons.Default.FilterList, contentDescription = "Filter events")
+                    }
                     IconButton(onClick = onNavigateToSearch) {
                         Icon(Icons.Default.Search, contentDescription = "Search")
                     }
@@ -277,6 +323,110 @@ private fun EventsList(
                     EventRow(event = event, onClick = { onNavigateToEvent(event.key) })
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun EventFilterDialog(
+    selectedFilter: EventsFilter,
+    availableDistricts: List<District>,
+    onDismiss: () -> Unit,
+    onSelectAll: () -> Unit,
+    onSelectRegionals: () -> Unit,
+    onSelectOffseasons: () -> Unit,
+    onSelectDistrict: (String) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Filter Events") },
+        text = {
+            LazyColumn {
+                item {
+                    FilterDialogRow(
+                        label = "All",
+                        selected = selectedFilter == EventsFilter.All,
+                        onClick = onSelectAll,
+                    )
+                }
+                item {
+                    FilterDialogRow(
+                        label = "Regionals",
+                        selected = selectedFilter == EventsFilter.Regionals,
+                        onClick = onSelectRegionals,
+                    )
+                }
+                item {
+                    FilterDialogRow(
+                        label = "Offseasons",
+                        selected = selectedFilter == EventsFilter.Offseasons,
+                        onClick = onSelectOffseasons,
+                    )
+                }
+
+                if (availableDistricts.isNotEmpty()) {
+                    item {
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                        Text(
+                            text = "Districts",
+                            style = MaterialTheme.typography.titleSmall,
+                            modifier = Modifier.padding(vertical = 8.dp),
+                        )
+                    }
+                    items(availableDistricts, key = { it.key }) { district ->
+                        FilterDialogRow(
+                            label = district.displayName,
+                            selected = selectedFilter is EventsFilter.District &&
+                                selectedFilter.districtKey == district.key,
+                            onClick = { onSelectDistrict(district.key) },
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Close")
+            }
+        },
+    )
+}
+
+@Composable
+private fun FilterDialogRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = onClick,
+        )
+        Text(
+            text = label,
+            modifier = Modifier.padding(start = 8.dp),
+        )
+    }
+}
+
+private fun filterSubtitle(
+    selectedFilter: EventsFilter,
+    availableDistricts: List<District>,
+): String {
+    return when (selectedFilter) {
+        EventsFilter.All -> "All"
+        EventsFilter.Regionals -> "Regionals"
+        EventsFilter.Offseasons -> "Offseasons"
+        is EventsFilter.District -> {
+            availableDistricts.firstOrNull { it.key == selectedFilter.districtKey }?.displayName
+                ?: selectedFilter.districtKey
         }
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
@@ -1,5 +1,6 @@
 package com.thebluealliance.android.ui.events
 
+import com.thebluealliance.android.domain.model.District
 import com.thebluealliance.android.domain.model.Event
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -7,11 +8,20 @@ import java.time.temporal.ChronoUnit
 
 data class EventSection(val label: String, val events: List<Event>)
 
+sealed interface EventsFilter {
+    data object All : EventsFilter
+    data object Regionals : EventsFilter
+    data object Offseasons : EventsFilter
+    data class District(val districtKey: String) : EventsFilter
+}
+
 sealed interface EventsUiState {
     data object Loading : EventsUiState
     data class Success(
         val sections: List<EventSection>,
         val favoriteEventKeys: Set<String> = emptySet(),
+        val selectedFilter: EventsFilter = EventsFilter.All,
+        val availableDistricts: List<District> = emptyList(),
     ) : EventsUiState
     data class Error(val message: String) : EventsUiState
 }
@@ -161,4 +171,13 @@ private fun datesOverlap(event: Event, rangeStart: LocalDate, rangeEnd: LocalDat
     val eventStart = parseDate(event.startDate) ?: return false
     val eventEnd = parseDate(event.endDate) ?: return false
     return !eventEnd.isBefore(rangeStart) && !eventStart.isAfter(rangeEnd)
+}
+
+fun filterEvents(events: List<Event>, filter: EventsFilter): List<Event> {
+    return when (filter) {
+        EventsFilter.All -> events
+        EventsFilter.Regionals -> events.filter { it.type == 0 }
+        EventsFilter.Offseasons -> events.filter { it.type == 99 }
+        is EventsFilter.District -> events.filter { it.district == filter.districtKey }
+    }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsViewModel.kt
@@ -4,10 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.thebluealliance.android.data.remote.TbaApi
 import com.thebluealliance.android.data.repository.AuthRepository
+import com.thebluealliance.android.data.repository.DistrictRepository
 import com.thebluealliance.android.data.repository.EventRepository
 import com.thebluealliance.android.data.repository.MyTBARepository
-import com.thebluealliance.android.domain.model.ModelType
+import com.thebluealliance.android.domain.model.District
 import com.thebluealliance.android.domain.model.Event
+import com.thebluealliance.android.domain.model.ModelType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -17,8 +19,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import java.time.LocalDate
-import java.time.temporal.ChronoUnit
 import java.util.Calendar
 import javax.inject.Inject
 
@@ -26,6 +26,7 @@ import javax.inject.Inject
 @HiltViewModel
 class EventsViewModel @Inject constructor(
     private val eventRepository: EventRepository,
+    private val districtRepository: DistrictRepository,
     private val tbaApi: TbaApi,
     private val myTBARepository: MyTBARepository,
     private val authRepository: AuthRepository,
@@ -37,28 +38,63 @@ class EventsViewModel @Inject constructor(
     private val _selectedYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
     val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
 
+    private val _selectedFilter = MutableStateFlow<EventsFilter>(EventsFilter.All)
+    val selectedFilter: StateFlow<EventsFilter> = _selectedFilter.asStateFlow()
+
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
     private val _hasLoaded = MutableStateFlow(false)
+
+    val availableDistricts: StateFlow<List<District>> = _selectedYear
+        .flatMapLatest { year ->
+            combine(
+                districtRepository.observeDistrictsForYear(year),
+                eventRepository.observeEventsForYear(year),
+            ) { districts, events ->
+                mergeDistrictOptions(
+                    year = year,
+                    districts = districts,
+                    events = events,
+                )
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     val uiState: StateFlow<EventsUiState> = _selectedYear
         .flatMapLatest { year ->
             _hasLoaded.value = false
             combine(
                 eventRepository.observeEventsForYear(year),
+                districtRepository.observeDistrictsForYear(year),
+                _selectedFilter,
                 _hasLoaded,
                 myTBARepository.observeFavorites(),
-            ) { events, hasLoaded, favorites ->
+            ) { events, districts, selectedFilter, hasLoaded, favorites ->
+                val availableDistricts = mergeDistrictOptions(
+                    year = year,
+                    districts = districts,
+                    events = events,
+                )
                 if (events.isEmpty() && !hasLoaded) {
                     EventsUiState.Loading
                 } else {
-                    val sections = buildEventSections(events)
+                    val activeFilter = selectedFilter.takeIf { filter ->
+                        filter !is EventsFilter.District ||
+                            availableDistricts.any { it.key == filter.districtKey }
+                    } ?: EventsFilter.All
+                    val filteredEvents = filterEvents(events, activeFilter)
+                    val sections = buildEventSections(filteredEvents)
                     val favoriteEventKeys = favorites
                         .filter { it.modelType == ModelType.EVENT }
                         .map { it.modelKey }
                         .toSet()
-                    EventsUiState.Success(sections, favoriteEventKeys)
+                    EventsUiState.Success(
+                        sections = sections,
+                        favoriteEventKeys = favoriteEventKeys,
+                        selectedFilter = activeFilter,
+                        availableDistricts = availableDistricts,
+                    )
                 }
             }
         }
@@ -97,17 +133,70 @@ class EventsViewModel @Inject constructor(
         refreshEvents()
     }
 
+    fun selectAllFilter() {
+        _selectedFilter.value = EventsFilter.All
+    }
+
+    fun selectRegionalsFilter() {
+        _selectedFilter.value = EventsFilter.Regionals
+    }
+
+    fun selectDistrictFilter(districtKey: String) {
+        _selectedFilter.value = EventsFilter.District(districtKey)
+    }
+
+    fun selectOffseasonsFilter() {
+        _selectedFilter.value = EventsFilter.Offseasons
+    }
+
     fun refreshEvents() {
         viewModelScope.launch {
             _isRefreshing.value = true
             try {
                 eventRepository.refreshEventsForYear(_selectedYear.value)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Data will come from Room cache if available
+            }
+            try {
+                districtRepository.refreshDistrictsForYear(_selectedYear.value)
+            } catch (_: Exception) {
+                // District cache may still be available
             } finally {
                 _hasLoaded.value = true
                 _isRefreshing.value = false
             }
         }
+    }
+
+    private fun mergeDistrictOptions(
+        year: Int,
+        districts: List<District>,
+        events: List<Event>,
+    ): List<District> {
+        val fromRepo = districts.associateBy { it.key }
+        val fromEvents = events
+            .mapNotNull { it.district }
+            .distinct()
+            .associateWith { key ->
+                District(
+                    key = key,
+                    abbreviation = districtAbbreviationFromKey(key),
+                    displayName = districtDisplayNameFromKey(key),
+                    year = year,
+                )
+            }
+
+        return (fromEvents + fromRepo)
+            .values
+            .sortedBy { it.displayName }
+    }
+
+    private fun districtAbbreviationFromKey(key: String): String {
+        val trimmed = key.removePrefix(key.takeWhile { it.isDigit() })
+        return trimmed.ifBlank { key }
+    }
+
+    private fun districtDisplayNameFromKey(key: String): String {
+        return districtAbbreviationFromKey(key).uppercase()
     }
 }

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
@@ -15,6 +15,7 @@ class EventsUiStateTest {
         name: String = "Test Event",
         year: Int = 2026,
         type: Int? = 0,
+        district: String? = null,
         week: Int? = null,
         startDate: String? = null,
         endDate: String? = null,
@@ -24,7 +25,7 @@ class EventsUiStateTest {
         eventCode = key.removePrefix("${year}"),
         year = year,
         type = type,
-        district = null,
+        district = district,
         city = null,
         state = null,
         country = null,
@@ -294,5 +295,59 @@ class EventsUiStateTest {
         val week = findCurrentCompetitionWeek(events, today)
 
         assertNull(week)
+    }
+
+    // --- Events filtering ---
+
+    @Test
+    fun `regionals filter keeps only regional event types`() {
+        val events = listOf(
+            makeEvent(key = "2026reg", type = 0),
+            makeEvent(key = "2026district", type = 1, district = "2026ne"),
+            makeEvent(key = "2026cmp", type = 3),
+        )
+
+        val filtered = filterEvents(events, EventsFilter.Regionals)
+
+        assertEquals(listOf("2026reg"), filtered.map { it.key })
+    }
+
+    @Test
+    fun `district filter keeps only selected district events`() {
+        val events = listOf(
+            makeEvent(key = "2026ne1", district = "2026ne"),
+            makeEvent(key = "2026ne2", district = "2026ne"),
+            makeEvent(key = "2026fim1", district = "2026fim"),
+            makeEvent(key = "2026reg", district = null),
+        )
+
+        val filtered = filterEvents(events, EventsFilter.District("2026ne"))
+
+        assertEquals(listOf("2026ne1", "2026ne2"), filtered.map { it.key })
+    }
+
+    @Test
+    fun `all filter keeps all events`() {
+        val events = listOf(
+            makeEvent(key = "2026reg", type = 0),
+            makeEvent(key = "2026district", type = 1, district = "2026ne"),
+        )
+
+        val filtered = filterEvents(events, EventsFilter.All)
+
+        assertEquals(events.map { it.key }, filtered.map { it.key })
+    }
+
+    @Test
+    fun `offseasons filter keeps only offseason events`() {
+        val events = listOf(
+            makeEvent(key = "2026off", type = 99),
+            makeEvent(key = "2026pre", type = 100),
+            makeEvent(key = "2026reg", type = 0),
+        )
+
+        val filtered = filterEvents(events, EventsFilter.Offseasons)
+
+        assertEquals(listOf("2026off"), filtered.map { it.key })
     }
 }


### PR DESCRIPTION
This has some new ideas at the home navigation, in response to some of the confusion we've seen. This will add a "filter" so we can limit the events we show to regionals / offseason / a specific district.

Some future looking thoughts:
 - if a user has a single district favorited, can we default to that so they get the right view by default?
 - should we nux this to prompt your "home region" (state or district) so we can also better fill this?
 - should we delete the districts tab, and replace it with a single "Advancement" one that shows both district & regional rankings & (D)CMP advancement?

I'm not 100% sure we can merge this as-is (and @gregmarra, you're also welcome to fiddle with this). Maybe we can land it behind a feature gate (or an opt in "Beta Feature" framework in settings). Or idk.

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/48a9d404-d61b-4b4d-9aac-07bf5e0cb48a" />


<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/4f36f4eb-c6f2-4570-ad23-7fd89f724e4e" />

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/93c48dcc-1bf5-43b5-8d26-5ed1bd19f09e" />


<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/ee611d2a-31b7-4a29-8689-2ad401a230b1" />

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Events list — filter affordance** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1179_events_before-18cffc11.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1179_events_after-77e4b565.png" width="300"> |

**New filter dialog (district / regional / offseason)**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1179_filter_dialog-a9b70846.png" width="320">
<!-- screenshots:end -->