### PR TITLE
Sort events within sections by start date, district, then name

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
@@ -38,6 +38,11 @@ private fun eventSectionKey(event: Event, preseasonOver: Boolean): SectionKey {
     }
 }
 
+private val eventComparator: Comparator<Event> =
+    compareBy<Event> { it.startDate ?: "" }
+        .thenBy { it.district ?: "" }
+        .thenBy { it.name }
+
 fun buildEventSections(events: List<Event>, today: LocalDate = LocalDate.now()): List<EventSection> {
     val lastPreseasonEnd = events
         .filter { it.type == 100 }
@@ -49,7 +54,9 @@ fun buildEventSections(events: List<Event>, today: LocalDate = LocalDate.now()):
         .groupBy { eventSectionKey(it, preseasonOver) }
         .entries
         .sortedBy { it.key.sortOrder }
-        .map { (key, sectionEvents) -> EventSection(key.label, sectionEvents) }
+        .map { (key, sectionEvents) ->
+            EventSection(key.label, sectionEvents.sortedWith(eventComparator))
+        }
 }
 
 data class ThisWeekResult(val label: String, val events: List<Event>)

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
@@ -41,6 +41,23 @@ class EventsUiStateTest {
         playoffType = PlayoffType.BRACKET_8_TEAM,
     )
 
+    // --- buildEventSections: sort order within sections ---
+
+    @Test
+    fun `events within a section are sorted by start date then district then name`() {
+        val events = listOf(
+            makeEvent(key = "2026z", name = "Zebra Event", week = 0, startDate = "2026-03-04", endDate = "2026-03-07"),
+            makeEvent(key = "2026a", name = "Alpha Event", week = 0, startDate = "2026-03-06", endDate = "2026-03-08"),
+            makeEvent(key = "2026m", name = "Middle Event", week = 0, startDate = "2026-03-04", endDate = "2026-03-07"),
+        )
+
+        val sections = buildEventSections(events)
+        val week1 = sections.first { it.label == "Week 1" }
+
+        // Same start date → sorted by name (district is null for all)
+        assertEquals(listOf("Middle Event", "Zebra Event", "Alpha Event"), week1.events.map { it.name })
+    }
+
     // --- buildEventSections: preseason ordering ---
 
     @Test


### PR DESCRIPTION
## Summary

- Events within each section were unsorted, so ordering was nondeterministic between loads (depended on Room/API response order)
- Now sorts by: start date (earliest first) → district (alphabetical) → event name (alphabetical)
- Applies to both the main Events list and district event lists (both use `buildEventSections`)

## Test plan

- [x] Unit test added verifying sort order within a section
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)