### PR TITLE
Make alliance team numbers tappable to navigate to Team@Event

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -305,6 +305,10 @@ fun EventDetailScreen(
                     )
                     4 -> EventAlliancesTab(
                         alliances = uiState.alliances,
+                        onTeamClick = { teamKey ->
+                            val eventKey = uiState.event?.key
+                            if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
+                        },
                         innerPadding = innerPadding,
                     )
                     5 -> EventInsightsTab(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
@@ -1,6 +1,10 @@
 package com.thebluealliance.android.ui.events.detail.tabs
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,9 +21,11 @@ import com.thebluealliance.android.domain.model.Alliance
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun EventAlliancesTab(
     alliances: List<Alliance>?,
+    onTeamClick: (teamKey: String) -> Unit = {},
     innerPadding: PaddingValues = PaddingValues.Zero,
 ) {
     if (alliances == null) {
@@ -50,11 +56,19 @@ fun EventAlliancesTab(
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                 )
-                Text(
-                    text = alliance.picks.joinToString(", ") { it.removePrefix("frc") },
-                    style = MaterialTheme.typography.bodyMedium,
+                FlowRow(
                     modifier = Modifier.padding(top = 2.dp),
-                )
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    alliance.picks.forEachIndexed { index, teamKey ->
+                        Text(
+                            text = teamKey.removePrefix("frc") + if (index < alliance.picks.lastIndex) "," else "",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.clickable { onTeamClick(teamKey) },
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Team numbers in the Alliances tab are now styled as tappable primary-color links
- Tapping navigates to the Team@Event detail page, consistent with the Teams and Rankings tabs
- Uses `FlowRow` so team numbers wrap naturally with commas

## Test plan

- [x] Open 2026 İstanbul Regional → Alliances tab → tap a team number → navigates to Team@Event
- [x] Build and unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)