### PR TITLE
Increase text size for match rows, score breakdowns, and ranking stats

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -185,13 +185,13 @@ fun MatchItem(
         Column(modifier = Modifier.weight(0.35f)) {
             Text(
                 text = match.redTeamKeys.joinToString(", ") { it.removePrefix("frc") },
-                style = MaterialTheme.typography.bodySmall,
+                style = MaterialTheme.typography.bodyMedium,
                 fontWeight = if (match.winningAlliance == "red") FontWeight.Bold else FontWeight.Normal,
                 color = MaterialTheme.colorScheme.error,
             )
             Text(
                 text = match.blueTeamKeys.joinToString(", ") { it.removePrefix("frc") },
-                style = MaterialTheme.typography.bodySmall,
+                style = MaterialTheme.typography.bodyMedium,
                 fontWeight = if (match.winningAlliance == "blue") FontWeight.Bold else FontWeight.Normal,
                 color = MaterialTheme.colorScheme.primary,
             )
@@ -212,13 +212,13 @@ fun MatchItem(
             ) {
                 Text(
                     text = match.redScore.toString(),
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyMedium,
                     fontWeight = if (match.winningAlliance == "red") FontWeight.Bold else FontWeight.Normal,
                     color = MaterialTheme.colorScheme.error,
                 )
                 Text(
                     text = match.blueScore.toString(),
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyMedium,
                     fontWeight = if (match.winningAlliance == "blue") FontWeight.Bold else FontWeight.Normal,
                     color = MaterialTheme.colorScheme.primary,
                 )
@@ -233,7 +233,7 @@ fun MatchItem(
                     kotlin.math.abs(match.predictedTime - match.time) > 60
                 Text(
                     text = formatMatchTime(displayTime),
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 if (isEstimate) {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -344,13 +344,13 @@ private fun RankingItem(
                         ) {
                             Text(
                                 text = sortOrder.name,
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 modifier = Modifier.weight(1f),
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = formattedValue,
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 fontWeight = FontWeight.Medium,
                             )
                         }
@@ -378,13 +378,13 @@ private fun RankingItem(
                         ) {
                             Text(
                                 text = statName,
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 modifier = Modifier.weight(1f),
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = String.format(Locale.US, "%.${precision}f", value),
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 fontWeight = FontWeight.Medium,
                             )
                         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -310,20 +310,20 @@ private fun BreakdownRow(label: String, redValue: String, blueValue: String) {
     ) {
         Text(
             text = redValue,
-            style = MaterialTheme.typography.bodySmall,
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.error,
             modifier = Modifier.weight(0.2f),
             textAlign = TextAlign.Center,
         )
         Text(
             text = label,
-            style = MaterialTheme.typography.bodySmall,
+            style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.weight(0.6f),
             textAlign = TextAlign.Center,
         )
         Text(
             text = blueValue,
-            style = MaterialTheme.typography.bodySmall,
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.primary,
             modifier = Modifier.weight(0.2f),
             textAlign = TextAlign.Center,


### PR DESCRIPTION
## Summary

Primary data content was using `bodySmall` (12sp), making it harder to read at a glance. Bumped to `bodyMedium` (14sp) for:

- **Match list**: team numbers, scores, and match times
- **Match detail**: score breakdown rows (red value, label, blue value)
- **Rankings**: sort order names/values and extra stat names/values

## Screenshots
|Before|After|
|-|-|
|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/09d69428-ec12-44a8-ad2c-43d5a1050926" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/1d37db4a-e98b-4868-96cc-3d5d0ff815cd" />|

## Test plan

- [x] Build and unit tests pass
- [x] Visual comparison of match list before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)