### PR TITLE
Make team rows tappable in Awards and District Points tabs

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -317,10 +317,20 @@ fun EventDetailScreen(
                         uiState.districtPoints,
                         uiState.event,
                         uiState.teams,
+                        onTeamClick = { teamKey ->
+                            val eventKey = uiState.event?.key
+                            if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
+                            else onNavigateToTeam(teamKey)
+                        },
                         innerPadding = innerPadding,
                     )
                     7 -> EventAwardsTab(
                         awards = uiState.awards,
+                        onTeamClick = { teamKey ->
+                            val eventKey = uiState.event?.key
+                            if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
+                            else onNavigateToTeam(teamKey)
+                        },
                         innerPadding = innerPadding,
                     )
                 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAwardsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAwardsTab.kt
@@ -1,5 +1,6 @@
 package com.thebluealliance.android.ui.events.detail.tabs
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,6 +21,7 @@ import com.thebluealliance.android.ui.common.LoadingBox
 @Composable
 fun EventAwardsTab(
     awards: List<Award>?,
+    onTeamClick: (String) -> Unit = {},
     innerPadding: PaddingValues = PaddingValues.Zero,
 ) {
     if (awards == null) {
@@ -43,6 +45,10 @@ fun EventAwardsTab(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .then(
+                        if (award.teamKey.isNotEmpty()) Modifier.clickable { onTeamClick(award.teamKey) }
+                        else Modifier
+                    )
                     .padding(horizontal = 16.dp, vertical = 8.dp),
             ) {
                 Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventDistrictPointsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventDistrictPointsTab.kt
@@ -1,5 +1,6 @@
 package com.thebluealliance.android.ui.events.detail.tabs
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -29,6 +30,7 @@ fun EventDistrictPointsTab(
     districtPoints: List<EventDistrictPoints>?,
     event: Event?,
     teams: List<Team>?,
+    onTeamClick: (String) -> Unit = {},
     innerPadding: PaddingValues = PaddingValues.Zero,
 ) {
     if (districtPoints == null) {
@@ -65,6 +67,7 @@ fun EventDistrictPointsTab(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .clickable { onTeamClick(points.teamKey) }
                     .padding(horizontal = 16.dp, vertical = 6.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {


### PR DESCRIPTION
## Summary
- Adds `onTeamClick` callback to `EventAwardsTab` — tapping an award row with a team navigates to Team@Event
- Adds `onTeamClick` callback to `EventDistrictPointsTab` — tapping any team row navigates to Team@Event
- Awards rows without an associated team are not clickable
- Wires both callbacks through `EventDetailScreen`

## Test plan
- [x] Navigate to an event with awards (e.g. 2026 İstanbul Regional)
- [x] Tap an award row with a team number → navigates to Team@Event
- [x] Navigate to an event with district points
- [x] Tap a team row in District Points → navigates to Team@Event
- [x] Build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)