### PR TITLE
Fix notification bell showing TBA lamp on team detail screen

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
@@ -178,17 +179,10 @@ fun TeamDetailScreen(
                             }
                         }) {
                             val hasSubscription = subscription?.notifications?.isNotEmpty() == true
-                            if (hasSubscription) {
-                                Icon(
-                                    painter = painterResource(R.drawable.ic_notification),
-                                    contentDescription = "Notification preferences",
-                                )
-                            } else {
-                                Icon(
-                                    imageVector = Icons.Outlined.NotificationsNone,
-                                    contentDescription = "Notification preferences",
-                                )
-                            }
+                            Icon(
+                                imageVector = if (hasSubscription) Icons.Filled.Notifications else Icons.Outlined.NotificationsNone,
+                                contentDescription = "Notification preferences",
+                            )
                         }
                         IconButton(onClick = viewModel::toggleFavorite) {
                             Icon(


### PR DESCRIPTION
## Summary
- TeamDetailScreen used `R.drawable.ic_notification` (the TBA lamp scaled to 24dp, intended for system notifications) instead of `Icons.Filled.Notifications` when a team had active subscriptions
- Now uses the Material filled bell icon, matching EventDetailScreen's behavior

## Test plan
- [x] Navigate to a team detail screen
- [x] Enable notification subscriptions (e.g. Upcoming match, Match score)
- [x] Verify the bell icon remains a bell (filled) — not the TBA lamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)