### PR TITLE
Relocate red/blue teams list on match detail

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -1,12 +1,15 @@
 package com.thebluealliance.android.ui.matches
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -23,8 +26,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -34,6 +40,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.formatBreakdownValue
 import com.thebluealliance.android.domain.getFullLabel
 import com.thebluealliance.android.domain.model.Match
+import com.thebluealliance.android.domain.rpBonuses
 import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.common.shareTbaUrl
 import com.thebluealliance.android.ui.components.MediaGridItem
@@ -133,11 +140,12 @@ fun MatchDetailScreen(
                     }
 
                     // Teams
-                    item(key = "red_teams") {
-                        AllianceTeams("Red alliance", match.redTeamKeys, MaterialTheme.colorScheme.error, onNavigateToTeam)
-                    }
-                    item(key = "blue_teams") {
-                        AllianceTeams("Blue alliance", match.blueTeamKeys, MaterialTheme.colorScheme.primary, onNavigateToTeam)
+                    item(key = "alliance_teams") {
+                        AllianceTeams(
+                            redTeamKeys = match.redTeamKeys,
+                            blueTeamKeys = match.blueTeamKeys,
+                            onTeamClick = onNavigateToTeam,
+                        )
                     }
 
                     // Media
@@ -148,7 +156,7 @@ fun MatchDetailScreen(
                         item(key = "media_header") {
                             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
                             Text(
-                                text = "Video",
+                                text = "Match Video",
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold,
                                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
@@ -168,7 +176,7 @@ fun MatchDetailScreen(
                         item(key = "breakdown_header") {
                             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
                             Text(
-                                text = "Score breakdown",
+                                text = "Score Breakdown",
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold,
                                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
@@ -231,6 +239,8 @@ private fun EventInfo(
 
 @Composable
 private fun ScoreSummary(match: Match) {
+    val rpBonuses = remember(match.scoreBreakdown) { match.rpBonuses() }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -248,6 +258,9 @@ private fun ScoreSummary(match: Match) {
                 fontWeight = if (match.winningAlliance == "red") FontWeight.Bold else FontWeight.Normal,
                 color = MaterialTheme.colorScheme.error,
             )
+            if (rpBonuses != null) {
+                RpDots(rpBonuses.red, MaterialTheme.colorScheme.error)
+            }
         }
         Text(
             text = "-",
@@ -265,37 +278,62 @@ private fun ScoreSummary(match: Match) {
                 fontWeight = if (match.winningAlliance == "blue") FontWeight.Bold else FontWeight.Normal,
                 color = MaterialTheme.colorScheme.primary,
             )
+            if (rpBonuses != null) {
+                RpDots(rpBonuses.blue, MaterialTheme.colorScheme.primary)
+            }
         }
     }
 }
 
 @Composable
 private fun AllianceTeams(
-    title: String,
-    teamKeys: List<String>,
-    color: androidx.compose.ui.graphics.Color,
+    redTeamKeys: List<String>,
+    blueTeamKeys: List<String>,
     onTeamClick: (String) -> Unit,
 ) {
-    Column(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            redTeamKeys.forEach { key ->
+                Text(
+                    text = key.removePrefix("frc"),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier
+                        .clickable { onTeamClick(key) }
+                        .padding(top = 2.dp),
+                )
+            }
+        }
+
+        // Invisible separator to match ScoreSummary alignment
         Text(
-            text = title,
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
-            color = color,
+            text = "-",
+            style = MaterialTheme.typography.displaySmall,
+            color = Color.Transparent,
+            modifier = Modifier.padding(horizontal = 16.dp),
         )
-        teamKeys.forEach { key ->
-            Text(
-                text = key.removePrefix("frc"),
-                style = MaterialTheme.typography.bodyLarge,
-                color = color,
-                modifier = Modifier
-                    .clickable { onTeamClick(key) }
-                    .padding(start = 8.dp, top = 2.dp),
-            )
+
+        Column(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            blueTeamKeys.forEach { key ->
+                Text(
+                    text = key.removePrefix("frc"),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .clickable { onTeamClick(key) }
+                        .padding(top = 2.dp),
+                )
+            }
         }
     }
 }
@@ -328,6 +366,32 @@ private fun BreakdownRow(label: String, redValue: String, blueValue: String) {
             modifier = Modifier.weight(0.2f),
             textAlign = TextAlign.Center,
         )
+    }
+}
+
+@Composable
+private fun RpDots(bonuses: List<Boolean>, achievedColor: Color) {
+    Row(
+        modifier = Modifier.padding(top = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        bonuses.forEach { achieved ->
+            Canvas(modifier = Modifier.size(8.dp)) {
+                if (achieved) {
+                    drawCircle(
+                        color = achievedColor,
+                        radius = size.minDimension / 2,
+                    )
+                } else {
+                    drawCircle(
+                        color = Color(0xFF9CA3AF),
+                        radius = size.minDimension / 2 - 1.dp.toPx(),
+                        style = Stroke(width = 1.dp.toPx()),
+                    )
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
**Summary:** 

- Minor adjustment match participant display to make better use of space
- Added bonus RP indicators

**Previous:**
<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/9f5b5874-d308-4ea4-a063-4ce15b7b957f" />




**Updated:**
<img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/ce185e67-29f2-4ff9-93ef-fdf42ead8863" />
