### PR TITLE
Remove extra whitespace around district upcoming events divider

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
@@ -252,7 +252,7 @@ private fun EventsTab(
                 EventRow(event = event, onClick = { onNavigateToEvent(event.key) })
             }
             item(key = "this_week_divider") {
-                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                HorizontalDivider()
             }
         }
         sections.forEach { section ->


### PR DESCRIPTION
## Summary
- The `HorizontalDivider` after the "Upcoming This Week" section in district detail had `padding(vertical = 4.dp)` causing a visible gap before the next section header
- Removed the padding so the divider sits flush between sections

## Test plan
- [x] Verified on emulator — no extra whitespace below the divider

🤖 Generated with [Claude Code](https://claude.com/claude-code)