### PR TITLE
Fix widget tap actions failing on release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,1 +1,16 @@
 # Add project specific ProGuard rules here.
+
+# Glance ActionCallback subclasses are instantiated by class name via reflection
+# (Class.getDeclaredConstructor() with zero args). R8 must preserve the class name
+# AND the no-arg constructor, otherwise widget actions silently fail with
+# NoSuchMethodException on <init>.
+-keep,allowobfuscation class androidx.glance.appwidget.action.ActionCallback
+-keep class * implements androidx.glance.appwidget.action.ActionCallback {
+    <init>();
+}
+-keep class * extends androidx.glance.appwidget.action.ActionCallback {
+    <init>();
+}
+-keep class com.thebluealliance.android.widget.TeamTrackingWidgetOpenAction { <init>(); }
+-keep class com.thebluealliance.android.widget.TeamTrackingWidgetSettingsAction { <init>(); }
+-keep class com.thebluealliance.android.widget.TeamTrackingWidgetRefreshAction { <init>(); }


### PR DESCRIPTION
## Summary
- Add ProGuard rules to keep no-arg constructors on Glance `ActionCallback` subclasses
- R8 was stripping `<init>()` from the action classes, causing `NoSuchMethodException` when Glance tried to instantiate them via reflection
- Symptom: widget elements highlight on tap but nothing happens

## Root cause
```
E GlanceAppWidget: Error in Glance App Widget
E GlanceAppWidget: java.lang.NoSuchMethodException: 
    com.thebluealliance.android.widget.TeamTrackingWidgetOpenAction.<init> []
```

Glance's `actionRunCallback` resolves callbacks via `Class.getDeclaredConstructor().newInstance()`. The library ships a `-keep` rule for the class names but not the constructors. R8 was optimizing away the unused constructors.

## Test plan
- [x] Confirmed on Pixel 9 Pro — all four tap targets (team name, event row, gear, refresh) now work after installing the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)