### PR TITLE
Fix hardcoded /usr/bin/git path for Windows compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ val localProperties = Properties().apply {
 // versionCode formula: MAJOR * 1_000_000 + MINOR * 10_000 + PATCH * 100
 // This matches the legacy app's formula and leaves room for hotfix candidates.
 val gitDescribeResult = providers.exec {
-    commandLine("/usr/bin/git", "describe", "--tags", "--long", "--match", "v[0-9]*")
+    commandLine("git", "describe", "--tags", "--long", "--match", "v[0-9]*")
     isIgnoreExitValue = true
 }
 val gitDescribe = gitDescribeResult.result.get().exitValue.let { exitCode ->
@@ -63,7 +63,7 @@ android {
         buildConfigField("String", "TBA_BASE_URL", "\"https://www.thebluealliance.com/\"")
         buildConfigField("String", "TBA_API_KEY", "\"\"")
         buildConfigField("String", "BUILD_TIME", "\"${Instant.now()}\"")
-        buildConfigField("String", "GIT_HASH", "\"${providers.exec { commandLine("/usr/bin/git", "rev-parse", "--short", "HEAD") }.standardOutput.asText.get().trim()}\"")
+        buildConfigField("String", "GIT_HASH", "\"${providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }.standardOutput.asText.get().trim()}\"")
 
     }
 


### PR DESCRIPTION
## Summary
- Replaces `/usr/bin/git` with `git` in `build.gradle.kts` so Gradle resolves it from PATH
- Fixes Android Studio builds on Windows where `/usr/bin/git` doesn't exist
- Reported by @pherkel on #1174

## Test plan
- [x] `./gradlew :app:assembleDebug` succeeds on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)