### PR TITLE
chore: set up ktlint formatting and CI lint job

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,7 @@ indent_size = 2
 [*.sql]
 indent_size = 2
 
+[*.{kt,kts}]
+# Compose @Composable functions use PascalCase by convention
+ktlint_standard_function-naming = disabled
+

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Revisions to ignore in `git blame`.
+# Configure locally with: git config blame.ignoreRevsFile .git-blame-ignore-revs
+# GitHub respects this file automatically in its blame UI.
+
+# chore: apply ktlint formatting to entire codebase (#1069)
+47b2061d6a1a17b5da2822c799243200fa46064e

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -1,0 +1,21 @@
+name: CI — Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ktlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+      - name: Run ktlint
+        run: ./gradlew ktlintCheck --stacktrace

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,22 +15,31 @@ plugins {
     alias(libs.plugins.play.publisher)
 }
 
-val localProperties = Properties().apply {
-    val file = rootProject.file("local.properties")
-    if (file.exists()) load(FileInputStream(file))
-}
+val localProperties =
+    Properties().apply {
+        val file = rootProject.file("local.properties")
+        if (file.exists()) load(FileInputStream(file))
+    }
 
 // --- Git tag-based versioning ---
 // Tags must be in the format "vMAJOR.MINOR.PATCH" (e.g., v10.9.0)
 // versionCode formula: MAJOR * 1_000_000 + MINOR * 10_000 + PATCH * 100
 // This matches the legacy app's formula and leaves room for hotfix candidates.
-val gitDescribeResult = providers.exec {
-    commandLine("git", "describe", "--tags", "--long", "--match", "v[0-9]*")
-    isIgnoreExitValue = true
-}
-val gitDescribe = gitDescribeResult.result.get().exitValue.let { exitCode ->
-    if (exitCode == 0) gitDescribeResult.standardOutput.asText.get().trim() else ""
-}
+val gitDescribeResult =
+    providers.exec {
+        commandLine("git", "describe", "--tags", "--long", "--match", "v[0-9]*")
+        isIgnoreExitValue = true
+    }
+val gitDescribe =
+    gitDescribeResult.result.get().exitValue.let { exitCode ->
+        if (exitCode == 0) {
+            gitDescribeResult.standardOutput.asText
+                .get()
+                .trim()
+        } else {
+            ""
+        }
+    }
 
 val versionPattern = Regex("""^v(\d+)\.(\d+)\.(\d+)-(\d+)-g[0-9a-f]+$""")
 val versionMatch = versionPattern.matchEntire(gitDescribe)
@@ -41,11 +50,12 @@ val vPatch = versionMatch?.groupValues?.get(3)?.toInt() ?: 0
 val commitDistance = versionMatch?.groupValues?.get(4)?.toInt() ?: 0
 
 val computedVersionCode = vMajor * 1_000_000 + vMinor * 10_000 + vPatch * 100 + commitDistance
-val computedVersionName = if (commitDistance == 0) {
-    "$vMajor.$vMinor.$vPatch"
-} else {
-    "$vMajor.$vMinor.$vPatch-dev.$commitDistance"
-}
+val computedVersionName =
+    if (commitDistance == 0) {
+        "$vMajor.$vMinor.$vPatch"
+    } else {
+        "$vMajor.$vMinor.$vPatch-dev.$commitDistance"
+    }
 
 android {
     namespace = "com.thebluealliance.android"
@@ -63,13 +73,26 @@ android {
         buildConfigField("String", "TBA_BASE_URL", "\"https://www.thebluealliance.com/\"")
         buildConfigField("String", "TBA_API_KEY", "\"\"")
         buildConfigField("String", "BUILD_TIME", "\"${Instant.now()}\"")
-        buildConfigField("String", "GIT_HASH", "\"${providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }.standardOutput.asText.get().trim()}\"")
-
+        buildConfigField(
+            "String",
+            "GIT_HASH",
+            "\"${providers.exec {
+                commandLine(
+                    "git",
+                    "rev-parse",
+                    "--short",
+                    "HEAD",
+                )
+            }.standardOutput.asText.get().trim()}\"",
+        )
     }
 
     signingConfigs {
         create("release") {
-            storeFile = rootProject.file(localProperties.getProperty("release.store.file", "release.keystore"))
+            storeFile =
+                rootProject.file(
+                    localProperties.getProperty("release.store.file", "release.keystore"),
+                )
             storePassword = localProperties.getProperty("release.store.password", "")
             keyAlias = localProperties.getProperty("release.key.alias", "")
             keyPassword = localProperties.getProperty("release.key.password", "")
@@ -79,13 +102,21 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix = ".development"
-            buildConfigField("String", "TBA_BASE_URL", "\"${
-                localProperties.getProperty(
-                    "tba.url.debug",
-                    "http://10.0.2.2:8080/"
-                )
-            }\"")
-            buildConfigField("String", "TBA_API_KEY", "\"${localProperties.getProperty("tba.api.key.debug", "tba-dev-key")}\"")
+            buildConfigField(
+                "String",
+                "TBA_BASE_URL",
+                "\"${
+                    localProperties.getProperty(
+                        "tba.url.debug",
+                        "http://10.0.2.2:8080/",
+                    )
+                }\"",
+            )
+            buildConfigField(
+                "String",
+                "TBA_API_KEY",
+                "\"${localProperties.getProperty("tba.api.key.debug", "tba-dev-key")}\"",
+            )
         }
         release {
             signingConfig = signingConfigs.getByName("release")
@@ -93,7 +124,7 @@ android {
             isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -117,7 +148,11 @@ android {
 }
 
 play {
-    serviceAccountCredentials.set(rootProject.file(localProperties.getProperty("play.service.account.key", "play-service-account.json")))
+    serviceAccountCredentials.set(
+        rootProject.file(
+            localProperties.getProperty("play.service.account.key", "play-service-account.json"),
+        ),
+    )
     track.set("alpha")
     defaultToAppBundles.set(true)
 }

--- a/app/src/debug/kotlin/com/thebluealliance/android/widget/MockWidgetActivity.kt
+++ b/app/src/debug/kotlin/com/thebluealliance/android/widget/MockWidgetActivity.kt
@@ -35,7 +35,6 @@ import java.time.LocalDate
  *   "upcoming"  — Team 254 with 3 upcoming events, no current event
  */
 class MockWidgetActivity : ComponentActivity() {
-
     companion object {
         private const val TAG = "MockWidget"
     }
@@ -75,7 +74,10 @@ class MockWidgetActivity : ComponentActivity() {
                         "at-event" -> writeAtEventPreset(prefs)
                         "upcoming" -> writeUpcomingPreset(prefs)
                         else -> {
-                            Log.e(TAG, "Unknown preset: $preset (expected 'at-event' or 'upcoming')")
+                            Log.e(
+                                TAG,
+                                "Unknown preset: $preset (expected 'at-event' or 'upcoming')",
+                            )
                             return@updateAppWidgetState
                         }
                     }
@@ -93,23 +95,32 @@ class MockWidgetActivity : ComponentActivity() {
 
     /** Look up the team's avatar from the local Room DB (current year, falling back to last year). */
     private suspend fun fetchAvatarBase64(teamKey: String): String? {
-        val db = Room.databaseBuilder(applicationContext, TBADatabase::class.java, "tba.db")
-            .fallbackToDestructiveMigration(dropAllTables = true)
-            .build()
+        val db =
+            Room
+                .databaseBuilder(applicationContext, TBADatabase::class.java, "tba.db")
+                .fallbackToDestructiveMigration(dropAllTables = true)
+                .build()
         return try {
             val year = LocalDate.now().year
-            val media = db.mediaDao().observeByTeamYear(teamKey, year).firstOrNull()
-                ?: emptyList()
-            val avatar = media.firstOrNull { it.type == "avatar" && it.base64Image != null }
-                ?: db.mediaDao().observeByTeamYear(teamKey, year - 1).firstOrNull()
-                    ?.firstOrNull { it.type == "avatar" && it.base64Image != null }
+            val media =
+                db.mediaDao().observeByTeamYear(teamKey, year).firstOrNull()
+                    ?: emptyList()
+            val avatar =
+                media.firstOrNull { it.type == "avatar" && it.base64Image != null }
+                    ?: db
+                        .mediaDao()
+                        .observeByTeamYear(teamKey, year - 1)
+                        .firstOrNull()
+                        ?.firstOrNull { it.type == "avatar" && it.base64Image != null }
             avatar?.base64Image
         } finally {
             db.close()
         }
     }
 
-    private suspend fun writeAtEventPreset(prefs: androidx.datastore.preferences.core.MutablePreferences) {
+    private suspend fun writeAtEventPreset(
+        prefs: androidx.datastore.preferences.core.MutablePreferences,
+    ) {
         // Team 177 "Bobcat Robotics" at NE District Event — matches sampleData()
         prefs[TeamTrackingWidgetKeys.TEAM_NUMBER] = "177"
         prefs[TeamTrackingWidgetKeys.TEAM_KEY] = "frc177"
@@ -150,7 +161,9 @@ class MockWidgetActivity : ComponentActivity() {
         prefs.remove(TeamTrackingWidgetKeys.UPCOMING_EVENTS)
     }
 
-    private suspend fun writeUpcomingPreset(prefs: androidx.datastore.preferences.core.MutablePreferences) {
+    private suspend fun writeUpcomingPreset(
+        prefs: androidx.datastore.preferences.core.MutablePreferences,
+    ) {
         // Team 254 "The Cheesy Poofs" — not at an event, 3 upcoming events
         prefs[TeamTrackingWidgetKeys.TEAM_NUMBER] = "254"
         prefs[TeamTrackingWidgetKeys.TEAM_KEY] = "frc254"
@@ -177,10 +190,11 @@ class MockWidgetActivity : ComponentActivity() {
         for (k in TeamTrackingWidgetKeys.ALL_NEXT_MATCH_KEYS) prefs.remove(k)
 
         // Upcoming events (tab-separated: name\tcity\tdate)
-        prefs[TeamTrackingWidgetKeys.UPCOMING_EVENTS] = listOf(
-            "Silicon Valley Regional\tSan Jose, CA\tMar 27–29",
-            "Sacramento Regional\tSacramento, CA\tApr 3–5",
-            "Championship\tHouston, TX\tApr 17–19",
-        ).joinToString("\n")
+        prefs[TeamTrackingWidgetKeys.UPCOMING_EVENTS] =
+            listOf(
+                "Silicon Valley Regional\tSan Jose, CA\tMar 27–29",
+                "Sacramento Regional\tSacramento, CA\tApr 3–5",
+                "Championship\tHouston, TX\tApr 17–19",
+            ).joinToString("\n")
     }
 }

--- a/app/src/debug/kotlin/com/thebluealliance/android/widget/PinWidgetActivity.kt
+++ b/app/src/debug/kotlin/com/thebluealliance/android/widget/PinWidgetActivity.kt
@@ -7,12 +7,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
-import androidx.glance.appwidget.GlanceAppWidgetManager
-import androidx.glance.appwidget.state.updateAppWidgetState
-import androidx.lifecycle.lifecycleScope
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.WorkManager
-import kotlinx.coroutines.launch
 
 /**
  * Debug-only activity that programmatically requests pinning the Team Tracking widget,
@@ -30,7 +24,6 @@ import kotlinx.coroutines.launch
  *   adb shell am start -n ...PinWidgetActivity --es team 604 --es size 2x1
  */
 class PinWidgetActivity : ComponentActivity() {
-
     companion object {
         private const val TAG = "PinWidgetActivity"
         private const val EXTRA_TEAM = "team"
@@ -55,11 +48,12 @@ class PinWidgetActivity : ComponentActivity() {
         }
 
         // Pass team number through extras so the config activity can auto-fill
-        val extras = if (teamNumber != null) {
-            Bundle().apply { putString(EXTRA_TEAM, teamNumber) }
-        } else {
-            null
-        }
+        val extras =
+            if (teamNumber != null) {
+                Bundle().apply { putString(EXTRA_TEAM, teamNumber) }
+            } else {
+                null
+            }
 
         if (teamNumber != null) {
             // Create a callback PendingIntent so we get the appWidgetId after pinning
@@ -69,10 +63,13 @@ class PinWidgetActivity : ComponentActivity() {
                 callbackIntent.putExtra(EXTRA_SIZE, forcedSize)
             }
             val requestCode = System.currentTimeMillis().toInt()
-            val callbackPending = PendingIntent.getBroadcast(
-                this, requestCode, callbackIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
-            )
+            val callbackPending =
+                PendingIntent.getBroadcast(
+                    this,
+                    requestCode,
+                    callbackIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+                )
             awm.requestPinAppWidget(provider, extras, callbackPending)
         } else {
             awm.requestPinAppWidget(provider, extras, null)

--- a/app/src/debug/kotlin/com/thebluealliance/android/widget/PinWidgetReceiver.kt
+++ b/app/src/debug/kotlin/com/thebluealliance/android/widget/PinWidgetReceiver.kt
@@ -18,18 +18,21 @@ import kotlinx.coroutines.launch
  * Triggered by the PendingIntent callback from [PinWidgetActivity].
  */
 class PinWidgetReceiver : BroadcastReceiver() {
-
     companion object {
         private const val TAG = "PinWidgetReceiver"
     }
 
-    override fun onReceive(context: Context, intent: Intent) {
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
         val teamNumber = intent.getStringExtra("team") ?: return
         val forcedSize = intent.getStringExtra("size")
-        val appWidgetId = intent.getIntExtra(
-            AppWidgetManager.EXTRA_APPWIDGET_ID,
-            AppWidgetManager.INVALID_APPWIDGET_ID,
-        )
+        val appWidgetId =
+            intent.getIntExtra(
+                AppWidgetManager.EXTRA_APPWIDGET_ID,
+                AppWidgetManager.INVALID_APPWIDGET_ID,
+            )
 
         if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
             Log.e(TAG, "No valid appWidgetId in pin callback")
@@ -55,7 +58,8 @@ class PinWidgetReceiver : BroadcastReceiver() {
                 TeamTrackingWidget().update(context, glanceId)
 
                 TeamTrackingWorker.enqueuePeriodicRefresh(context)
-                WorkManager.getInstance(context)
+                WorkManager
+                    .getInstance(context)
                     .enqueue(OneTimeWorkRequestBuilder<TeamTrackingWorker>().build())
 
                 Log.d(TAG, "Widget $appWidgetId configured for team $teamNumber")

--- a/app/src/debug/kotlin/com/thebluealliance/android/widget/ReconfigureWidgetsActivity.kt
+++ b/app/src/debug/kotlin/com/thebluealliance/android/widget/ReconfigureWidgetsActivity.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.launch
  *   adb shell am start -n com.thebluealliance.androidclient.development/com.thebluealliance.android.widget.ReconfigureWidgetsActivity --es team 125
  */
 class ReconfigureWidgetsActivity : ComponentActivity() {
-
     companion object {
         private const val TAG = "ReconfigureWidgets"
     }
@@ -73,7 +72,8 @@ class ReconfigureWidgetsActivity : ComponentActivity() {
             }
 
             // Trigger a data refresh
-            WorkManager.getInstance(this@ReconfigureWidgetsActivity)
+            WorkManager
+                .getInstance(this@ReconfigureWidgetsActivity)
                 .enqueue(OneTimeWorkRequestBuilder<TeamTrackingWorker>().build())
 
             Log.d(TAG, "Done. Triggered data refresh.")

--- a/app/src/debug/kotlin/com/thebluealliance/android/widget/RemoveWidgetsActivity.kt
+++ b/app/src/debug/kotlin/com/thebluealliance/android/widget/RemoveWidgetsActivity.kt
@@ -15,9 +15,9 @@ import androidx.activity.ComponentActivity
  *   adb shell am start -n com.thebluealliance.androidclient.development/com.thebluealliance.android.widget.RemoveWidgetsActivity
  */
 class RemoveWidgetsActivity : ComponentActivity() {
-
     companion object {
         private const val TAG = "RemoveWidgetsActivity"
+
         // Pixel Launcher's host ID
         private const val LAUNCHER_HOST_ID = 1024
     }

--- a/app/src/debug/kotlin/com/thebluealliance/android/widget/ResizeWidgetsActivity.kt
+++ b/app/src/debug/kotlin/com/thebluealliance/android/widget/ResizeWidgetsActivity.kt
@@ -24,18 +24,18 @@ import kotlinx.coroutines.launch
  * Supported sizes: 1x1, 2x1, 2x2, 4x1, 4x2
  */
 class ResizeWidgetsActivity : ComponentActivity() {
-
     companion object {
         private const val TAG = "ResizeWidgetsActivity"
 
         // Size tiers in dp matching TeamTrackingWidget.Companion
-        private val SIZE_TIERS = listOf(
-            "4x2" to Pair(250, 110),
-            "4x1" to Pair(250, 60),
-            "2x2" to Pair(110, 110),
-            "2x1" to Pair(110, 60),
-            "1x1" to Pair(60, 60),
-        )
+        private val SIZE_TIERS =
+            listOf(
+                "4x2" to Pair(250, 110),
+                "4x1" to Pair(250, 60),
+                "2x2" to Pair(110, 110),
+                "2x1" to Pair(110, 60),
+                "1x1" to Pair(60, 60),
+            )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -93,17 +93,18 @@ class ResizeWidgetsActivity : ComponentActivity() {
         label: String,
     ) {
         try {
-            val options = Bundle().apply {
-                putInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, widthDp)
-                putInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH, widthDp)
-                putInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, heightDp)
-                putInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, heightDp)
-                // Android 12+ uses OPTION_APPWIDGET_SIZES for Glance SizeMode.Responsive
-                putParcelableArrayList(
-                    AppWidgetManager.OPTION_APPWIDGET_SIZES,
-                    arrayListOf(SizeF(widthDp.toFloat(), heightDp.toFloat())),
-                )
-            }
+            val options =
+                Bundle().apply {
+                    putInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, widthDp)
+                    putInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH, widthDp)
+                    putInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, heightDp)
+                    putInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, heightDp)
+                    // Android 12+ uses OPTION_APPWIDGET_SIZES for Glance SizeMode.Responsive
+                    putParcelableArrayList(
+                        AppWidgetManager.OPTION_APPWIDGET_SIZES,
+                        arrayListOf(SizeF(widthDp.toFloat(), heightDp.toFloat())),
+                    )
+                }
             awm.updateAppWidgetOptions(appWidgetId, options)
 
             val glanceId = manager.getGlanceIdBy(appWidgetId)

--- a/app/src/main/kotlin/com/thebluealliance/android/MainActivity.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/MainActivity.kt
@@ -8,8 +8,8 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.activity.SystemBarStyle
+import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.credentials.CredentialManager
@@ -35,19 +35,22 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
     @Inject lateinit var firebaseAuth: FirebaseAuth
+
     @Inject lateinit var dataSyncManager: DataSyncManager
+
     @Inject lateinit var deviceRegistrationManager: DeviceRegistrationManager
+
     @Inject lateinit var themePreferences: ThemePreferences
 
     private val deepLinkHandler = DeeplinkMatcher()
 
-    private val notificationPermissionLauncher = registerForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { granted ->
-        Log.d("MainActivity", "Notification permission granted: $granted")
-    }
+    private val notificationPermissionLauncher =
+        registerForActivityResult(
+            ActivityResultContracts.RequestPermission(),
+        ) { granted ->
+            Log.d("MainActivity", "Notification permission granted: $granted")
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -56,12 +59,14 @@ class MainActivity : ComponentActivity() {
         )
 
         val flags = intent.flags
-        val isNewTask = flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0 &&
+        val isNewTask =
+            flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0 &&
                 flags and Intent.FLAG_ACTIVITY_CLEAR_TASK != 0
 
-        val startRoute = getNotificationDestination()
-            ?: getDeeplinkDestination()
-            ?: Screen.Events
+        val startRoute =
+            getNotificationDestination()
+                ?: getDeeplinkDestination()
+                ?: Screen.Events
 
         setContent {
             TBAApp(
@@ -83,16 +88,21 @@ class MainActivity : ComponentActivity() {
         val eventKey = intent.getStringExtra(NotificationBuilder.EXTRA_EVENT_KEY)
         val teamKey = intent.getStringExtra(NotificationBuilder.EXTRA_TEAM_KEY)
 
-        val destination = when {
-            matchKey != null -> Screen.MatchDetail(matchKey)
-            teamKey != null && eventKey != null -> Screen.TeamEventDetail(teamKey, eventKey)
-            eventKey != null -> Screen.EventDetail(eventKey)
-            teamKey != null -> {
-                val initialTab = intent.getIntExtra(TeamTrackingWidgetOpenAction.EXTRA_INITIAL_TAB, 0)
-                Screen.TeamDetail(teamKey, initialTab)
+        val destination =
+            when {
+                matchKey != null -> Screen.MatchDetail(matchKey)
+                teamKey != null && eventKey != null -> Screen.TeamEventDetail(teamKey, eventKey)
+                eventKey != null -> Screen.EventDetail(eventKey)
+                teamKey != null -> {
+                    val initialTab =
+                        intent.getIntExtra(
+                            TeamTrackingWidgetOpenAction.EXTRA_INITIAL_TAB,
+                            0,
+                        )
+                    Screen.TeamDetail(teamKey, initialTab)
+                }
+                else -> null
             }
-            else -> null
-        }
 
         return destination
     }
@@ -102,14 +112,19 @@ class MainActivity : ComponentActivity() {
         return deepLinkHandler.match(data)
     }
 
-    override fun onNewIntent(intent: Intent, caller: ComponentCaller) {
+    override fun onNewIntent(
+        intent: Intent,
+        caller: ComponentCaller,
+    ) {
         super.onNewIntent(intent, caller)
         Log.d("MainActivity", "Received new intent: $intent")
     }
 
     fun requestNotificationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) !=
+                PackageManager.PERMISSION_GRANTED
+            ) {
                 notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         }
@@ -121,21 +136,29 @@ class MainActivity : ComponentActivity() {
             return
         }
 
-        val googleIdOption = GetGoogleIdOption.Builder()
-            .setFilterByAuthorizedAccounts(false)
-            .setServerClientId(getString(R.string.default_web_client_id))
-            .build()
+        val googleIdOption =
+            GetGoogleIdOption
+                .Builder()
+                .setFilterByAuthorizedAccounts(false)
+                .setServerClientId(getString(R.string.default_web_client_id))
+                .build()
 
-        val request = GetCredentialRequest.Builder()
-            .addCredentialOption(googleIdOption)
-            .build()
+        val request =
+            GetCredentialRequest
+                .Builder()
+                .addCredentialOption(googleIdOption)
+                .build()
 
         lifecycleScope.launch {
             try {
                 val credentialManager = CredentialManager.create(this@MainActivity)
                 val result = credentialManager.getCredential(this@MainActivity, request)
                 val googleIdToken = GoogleIdTokenCredential.createFrom(result.credential.data)
-                val firebaseCredential = GoogleAuthProvider.getCredential(googleIdToken.idToken, null)
+                val firebaseCredential =
+                    GoogleAuthProvider.getCredential(
+                        googleIdToken.idToken,
+                        null,
+                    )
                 firebaseAuth.signInWithCredential(firebaseCredential).await()
                 requestNotificationPermission()
             } catch (e: Exception) {
@@ -148,7 +171,8 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             try {
                 // The Firebase Auth emulator accepts a JSON object as a fake Google ID token
-                val fakeIdToken = """{"sub":"2","email":"user@thebluealliance.com","email_verified":true}"""
+                val fakeIdToken =
+                    """{"sub":"2","email":"user@thebluealliance.com","email_verified":true}"""
                 val credential = GoogleAuthProvider.getCredential(fakeIdToken, null)
                 firebaseAuth.signInWithCredential(credential).await()
                 Log.d("MainActivity", "Emulator sign-in succeeded")
@@ -158,5 +182,4 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
-
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/TBAApplication.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/TBAApplication.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
-import androidx.work.WorkManager
 import com.thebluealliance.android.config.ApiKeyProvider
 import com.thebluealliance.android.messaging.NotificationChannelManager
 import com.thebluealliance.android.shortcuts.TBAShortcutManager
@@ -17,17 +16,23 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltAndroidApp
-class TBAApplication : Application(), Configuration.Provider {
-
+class TBAApplication :
+    Application(),
+    Configuration.Provider {
     @Inject lateinit var apiKeyProvider: ApiKeyProvider
+
     @Inject lateinit var notificationChannelManager: NotificationChannelManager
+
     @Inject lateinit var workerFactory: HiltWorkerFactory
+
     @Inject lateinit var shortcutManager: TBAShortcutManager
 
     override val workManagerConfiguration: Configuration
-        get() = Configuration.Builder()
-            .setWorkerFactory(workerFactory)
-            .build()
+        get() =
+            Configuration
+                .Builder()
+                .setWorkerFactory(workerFactory)
+                .build()
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/kotlin/com/thebluealliance/android/config/ApiKeyProvider.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/config/ApiKeyProvider.kt
@@ -10,60 +10,62 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ApiKeyProvider @Inject constructor(
-    private val sharedPreferences: SharedPreferences,
-    private val remoteConfig: FirebaseRemoteConfig,
-) {
-    private val fetchComplete = CountDownLatch(1)
+class ApiKeyProvider
+    @Inject
+    constructor(
+        private val sharedPreferences: SharedPreferences,
+        private val remoteConfig: FirebaseRemoteConfig,
+    ) {
+        private val fetchComplete = CountDownLatch(1)
 
-    val apiKey: String
-        get() {
-            if (BuildConfig.DEBUG) {
+        val apiKey: String
+            get() {
+                if (BuildConfig.DEBUG) {
+                    return BuildConfig.TBA_API_KEY
+                }
+
+                // Use cached key immediately if available
+                val cachedKey = sharedPreferences.getString(PREFS_KEY, null)
+                if (!cachedKey.isNullOrEmpty()) {
+                    return cachedKey
+                }
+
+                // No cached key — wait for the in-flight Remote Config fetch
+                fetchComplete.await(5, TimeUnit.SECONDS)
+
+                // Check Remote Config (now activated)
+                val remoteConfigKey = remoteConfig.getString(REMOTE_CONFIG_KEY)
+                if (remoteConfigKey.isNotEmpty()) {
+                    return remoteConfigKey
+                }
+
+                // Last resort (will be empty string if not in local.properties)
                 return BuildConfig.TBA_API_KEY
             }
 
-            // Use cached key immediately if available
-            val cachedKey = sharedPreferences.getString(PREFS_KEY, null)
-            if (!cachedKey.isNullOrEmpty()) {
-                return cachedKey
+        fun init() {
+            if (BuildConfig.DEBUG) {
+                fetchComplete.countDown()
+                return
             }
 
-            // No cached key — wait for the in-flight Remote Config fetch
-            fetchComplete.await(5, TimeUnit.SECONDS)
-
-            // Check Remote Config (now activated)
-            val remoteConfigKey = remoteConfig.getString(REMOTE_CONFIG_KEY)
-            if (remoteConfigKey.isNotEmpty()) {
-                return remoteConfigKey
-            }
-
-            // Last resort (will be empty string if not in local.properties)
-            return BuildConfig.TBA_API_KEY
-        }
-
-    fun init() {
-        if (BuildConfig.DEBUG) {
-            fetchComplete.countDown()
-            return
-        }
-
-        remoteConfig.fetchAndActivate().addOnCompleteListener { task ->
-            if (task.isSuccessful) {
-                val key = remoteConfig.getString(REMOTE_CONFIG_KEY)
-                if (key.isNotEmpty()) {
-                    sharedPreferences.edit().putString(PREFS_KEY, key).apply()
-                    Log.d(TAG, "Updated API key from Remote Config")
+            remoteConfig.fetchAndActivate().addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    val key = remoteConfig.getString(REMOTE_CONFIG_KEY)
+                    if (key.isNotEmpty()) {
+                        sharedPreferences.edit().putString(PREFS_KEY, key).apply()
+                        Log.d(TAG, "Updated API key from Remote Config")
+                    }
+                } else {
+                    Log.w(TAG, "Failed to fetch Remote Config", task.exception)
                 }
-            } else {
-                Log.w(TAG, "Failed to fetch Remote Config", task.exception)
+                fetchComplete.countDown()
             }
-            fetchComplete.countDown()
+        }
+
+        companion object {
+            private const val TAG = "ApiKeyProvider"
+            private const val REMOTE_CONFIG_KEY = "apiv3_auth_key"
+            private const val PREFS_KEY = "tba_api_key"
         }
     }
-
-    companion object {
-        private const val TAG = "ApiKeyProvider"
-        private const val REMOTE_CONFIG_KEY = "apiv3_auth_key"
-        private const val PREFS_KEY = "tba_api_key"
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/config/ThemePreferences.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/config/ThemePreferences.kt
@@ -11,19 +11,22 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ThemePreferences @Inject constructor(
-    private val dataStore: DataStore<Preferences>,
-) {
-    private val themeModeKey = stringPreferencesKey("theme_mode")
+class ThemePreferences
+    @Inject
+    constructor(
+        private val dataStore: DataStore<Preferences>,
+    ) {
+        private val themeModeKey = stringPreferencesKey("theme_mode")
 
-    val themeModeFlow: Flow<ThemeMode> = dataStore.data.map { prefs ->
-        val name = prefs[themeModeKey]
-        ThemeMode.entries.firstOrNull { it.name == name } ?: ThemeMode.AUTO
-    }
+        val themeModeFlow: Flow<ThemeMode> =
+            dataStore.data.map { prefs ->
+                val name = prefs[themeModeKey]
+                ThemeMode.entries.firstOrNull { it.name == name } ?: ThemeMode.AUTO
+            }
 
-    suspend fun setThemeMode(mode: ThemeMode) {
-        dataStore.edit { prefs ->
-            prefs[themeModeKey] = mode.name
+        suspend fun setThemeMode(mode: ThemeMode) {
+            dataStore.edit { prefs ->
+                prefs[themeModeKey] = mode.name
+            }
         }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/TBADatabase.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/TBADatabase.kt
@@ -2,8 +2,42 @@ package com.thebluealliance.android.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import com.thebluealliance.android.data.local.dao.*
-import com.thebluealliance.android.data.local.entity.*
+import com.thebluealliance.android.data.local.dao.AllianceDao
+import com.thebluealliance.android.data.local.dao.AwardDao
+import com.thebluealliance.android.data.local.dao.DistrictDao
+import com.thebluealliance.android.data.local.dao.DistrictRankingDao
+import com.thebluealliance.android.data.local.dao.EventCOPRsDao
+import com.thebluealliance.android.data.local.dao.EventDao
+import com.thebluealliance.android.data.local.dao.EventDistrictPointsDao
+import com.thebluealliance.android.data.local.dao.EventInsightsDao
+import com.thebluealliance.android.data.local.dao.EventOPRsDao
+import com.thebluealliance.android.data.local.dao.EventRankingSortOrderDao
+import com.thebluealliance.android.data.local.dao.EventTeamDao
+import com.thebluealliance.android.data.local.dao.FavoriteDao
+import com.thebluealliance.android.data.local.dao.MatchDao
+import com.thebluealliance.android.data.local.dao.MediaDao
+import com.thebluealliance.android.data.local.dao.RankingDao
+import com.thebluealliance.android.data.local.dao.SubscriptionDao
+import com.thebluealliance.android.data.local.dao.TeamDao
+import com.thebluealliance.android.data.local.dao.TeamEventStatusDao
+import com.thebluealliance.android.data.local.entity.AllianceEntity
+import com.thebluealliance.android.data.local.entity.AwardEntity
+import com.thebluealliance.android.data.local.entity.DistrictEntity
+import com.thebluealliance.android.data.local.entity.DistrictRankingEntity
+import com.thebluealliance.android.data.local.entity.EventCOPRsEntity
+import com.thebluealliance.android.data.local.entity.EventDistrictPointsEntity
+import com.thebluealliance.android.data.local.entity.EventEntity
+import com.thebluealliance.android.data.local.entity.EventInsightsEntity
+import com.thebluealliance.android.data.local.entity.EventOPRsEntity
+import com.thebluealliance.android.data.local.entity.EventRankingSortOrderEntity
+import com.thebluealliance.android.data.local.entity.EventTeamEntity
+import com.thebluealliance.android.data.local.entity.FavoriteEntity
+import com.thebluealliance.android.data.local.entity.MatchEntity
+import com.thebluealliance.android.data.local.entity.MediaEntity
+import com.thebluealliance.android.data.local.entity.RankingEntity
+import com.thebluealliance.android.data.local.entity.SubscriptionEntity
+import com.thebluealliance.android.data.local.entity.TeamEntity
+import com.thebluealliance.android.data.local.entity.TeamEventStatusEntity
 
 @Database(
     entities = [
@@ -31,21 +65,38 @@ import com.thebluealliance.android.data.local.entity.*
 )
 abstract class TBADatabase : RoomDatabase() {
     abstract fun teamDao(): TeamDao
+
     abstract fun eventDao(): EventDao
+
     abstract fun matchDao(): MatchDao
+
     abstract fun awardDao(): AwardDao
+
     abstract fun rankingDao(): RankingDao
+
     abstract fun allianceDao(): AllianceDao
+
     abstract fun districtDao(): DistrictDao
+
     abstract fun districtRankingDao(): DistrictRankingDao
+
     abstract fun mediaDao(): MediaDao
+
     abstract fun eventTeamDao(): EventTeamDao
+
     abstract fun favoriteDao(): FavoriteDao
+
     abstract fun subscriptionDao(): SubscriptionDao
+
     abstract fun eventDistrictPointsDao(): EventDistrictPointsDao
+
     abstract fun eventOPRsDao(): EventOPRsDao
+
     abstract fun eventCOPRsDao(): EventCOPRsDao
+
     abstract fun eventInsightsDao(): EventInsightsDao
+
     abstract fun eventRankingSortOrderDao(): EventRankingSortOrderDao
+
     abstract fun teamEventStatusDao(): TeamEventStatusDao
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/EventCOPRsDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/EventCOPRsDao.kt
@@ -18,4 +18,3 @@ interface EventCOPRsDao {
     @Query("DELETE FROM event_coprs WHERE eventKey = :eventKey")
     suspend fun delete(eventKey: String)
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/EventDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/EventDao.kt
@@ -24,7 +24,9 @@ interface EventDao {
     @Query("SELECT * FROM events WHERE district = :districtKey ORDER BY startDate ASC")
     fun observeByDistrict(districtKey: String): Flow<List<EventEntity>>
 
-    @Query("SELECT * FROM events WHERE name LIKE '%' || :query || '%' OR key LIKE '%' || :query || '%' OR shortName LIKE '%' || :query || '%' OR city LIKE '%' || :query || '%' ORDER BY year DESC, startDate ASC LIMIT 50")
+    @Query(
+        "SELECT * FROM events WHERE name LIKE '%' || :query || '%' OR key LIKE '%' || :query || '%' OR shortName LIKE '%' || :query || '%' OR city LIKE '%' || :query || '%' ORDER BY year DESC, startDate ASC LIMIT 50",
+    )
     fun search(query: String): Flow<List<EventEntity>>
 
     @Query("DELETE FROM events WHERE year = :year")

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/EventInsightsDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/EventInsightsDao.kt
@@ -18,4 +18,3 @@ interface EventInsightsDao {
     @Query("DELETE FROM event_insights WHERE eventKey = :eventKey")
     suspend fun delete(eventKey: String)
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/EventRankingSortOrderDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/EventRankingSortOrderDao.kt
@@ -18,4 +18,3 @@ interface EventRankingSortOrderDao {
     @Query("DELETE FROM event_ranking_sort_orders WHERE eventKey = :eventKey")
     suspend fun delete(eventKey: String)
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/EventTeamDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/EventTeamDao.kt
@@ -25,5 +25,8 @@ interface EventTeamDao {
     suspend fun deleteByTeam(teamKey: String)
 
     @Query("DELETE FROM event_teams WHERE teamKey = :teamKey AND eventKey LIKE :yearPrefix || '%'")
-    suspend fun deleteByTeamAndYear(teamKey: String, yearPrefix: String)
+    suspend fun deleteByTeamAndYear(
+        teamKey: String,
+        yearPrefix: String,
+    )
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/FavoriteDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/FavoriteDao.kt
@@ -12,14 +12,22 @@ interface FavoriteDao {
     @Query("SELECT * FROM favorites ORDER BY modelType, modelKey ASC")
     fun observeAll(): Flow<List<FavoriteEntity>>
 
-    @Query("SELECT EXISTS(SELECT 1 FROM favorites WHERE modelKey = :modelKey AND modelType = :modelType)")
-    fun isFavorite(modelKey: String, modelType: Int): Flow<Boolean>
+    @Query(
+        "SELECT EXISTS(SELECT 1 FROM favorites WHERE modelKey = :modelKey AND modelType = :modelType)",
+    )
+    fun isFavorite(
+        modelKey: String,
+        modelType: Int,
+    ): Flow<Boolean>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(favorites: List<FavoriteEntity>)
 
     @Query("DELETE FROM favorites WHERE modelKey = :modelKey AND modelType = :modelType")
-    suspend fun delete(modelKey: String, modelType: Int)
+    suspend fun delete(
+        modelKey: String,
+        modelType: Int,
+    )
 
     @Query("DELETE FROM favorites")
     suspend fun deleteAll()

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/MatchDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/MatchDao.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface MatchDao {
-    @Query("SELECT * FROM matches WHERE eventKey = :eventKey ORDER BY compLevel, setNumber, matchNumber ASC")
+    @Query(
+        "SELECT * FROM matches WHERE eventKey = :eventKey ORDER BY compLevel, setNumber, matchNumber ASC",
+    )
     fun observeByEvent(eventKey: String): Flow<List<MatchEntity>>
 
     @Query("SELECT * FROM matches WHERE key = :key")

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/MediaDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/MediaDao.kt
@@ -10,10 +10,16 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface MediaDao {
     @Query("SELECT * FROM media WHERE teamKey = :teamKey AND year = :year")
-    fun observeByTeamYear(teamKey: String, year: Int): Flow<List<MediaEntity>>
+    fun observeByTeamYear(
+        teamKey: String,
+        year: Int,
+    ): Flow<List<MediaEntity>>
 
     @Query("DELETE FROM media WHERE teamKey = :teamKey AND year = :year")
-    suspend fun deleteByTeamYear(teamKey: String, year: Int)
+    suspend fun deleteByTeamYear(
+        teamKey: String,
+        year: Int,
+    )
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(media: List<MediaEntity>)

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/SubscriptionDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/SubscriptionDao.kt
@@ -13,7 +13,10 @@ interface SubscriptionDao {
     fun observeAll(): Flow<List<SubscriptionEntity>>
 
     @Query("SELECT * FROM subscriptions WHERE modelKey = :modelKey AND modelType = :modelType")
-    fun observe(modelKey: String, modelType: Int): Flow<SubscriptionEntity?>
+    fun observe(
+        modelKey: String,
+        modelType: Int,
+    ): Flow<SubscriptionEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(subscriptions: List<SubscriptionEntity>)

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/TeamDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/TeamDao.kt
@@ -18,7 +18,9 @@ interface TeamDao {
     @Query("SELECT * FROM teams WHERE key IN (:keys) ORDER BY number ASC")
     fun observeByKeys(keys: List<String>): Flow<List<TeamEntity>>
 
-    @Query("SELECT * FROM teams WHERE nickname LIKE '%' || :query || '%' OR name LIKE '%' || :query || '%' OR key LIKE '%' || :query || '%' OR CAST(number AS TEXT) = :query ORDER BY number ASC LIMIT 50")
+    @Query(
+        "SELECT * FROM teams WHERE nickname LIKE '%' || :query || '%' OR name LIKE '%' || :query || '%' OR key LIKE '%' || :query || '%' OR CAST(number AS TEXT) = :query ORDER BY number ASC LIMIT 50",
+    )
     fun search(query: String): Flow<List<TeamEntity>>
 
     @Query("SELECT COUNT(*) FROM teams")

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/TeamEventStatusDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/TeamEventStatusDao.kt
@@ -10,7 +10,10 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface TeamEventStatusDao {
     @Query("SELECT * FROM team_event_status WHERE teamKey = :teamKey AND eventKey = :eventKey")
-    fun observe(teamKey: String, eventKey: String): Flow<TeamEventStatusEntity?>
+    fun observe(
+        teamKey: String,
+        eventKey: String,
+    ): Flow<TeamEventStatusEntity?>
 
     @Query("SELECT * FROM team_event_status WHERE eventKey = :eventKey")
     fun observeByEvent(eventKey: String): Flow<List<TeamEventStatusEntity>>

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/entity/EventCOPRsEntity.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/entity/EventCOPRsEntity.kt
@@ -8,4 +8,3 @@ data class EventCOPRsEntity(
     @PrimaryKey val eventKey: String,
     val coprs: String, // JSON map of stat name -> team stats
 )
-

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/entity/EventInsightsEntity.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/entity/EventInsightsEntity.kt
@@ -9,4 +9,3 @@ data class EventInsightsEntity(
     val qualInsights: String?, // JSON object of qual insights
     val playoffInsights: String?, // JSON object of playoff insights
 )
-

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/entity/EventRankingSortOrderEntity.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/entity/EventRankingSortOrderEntity.kt
@@ -10,4 +10,3 @@ data class EventRankingSortOrderEntity(
     val sortOrderInfo: String, // JSON array of RankingSortOrderDto
     val extraStatsInfo: String? = null, // JSON array of RankingSortOrderDto
 )
-

--- a/app/src/main/kotlin/com/thebluealliance/android/data/mappers/Mappers.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/mappers/Mappers.kt
@@ -1,206 +1,285 @@
 package com.thebluealliance.android.data.mappers
 
-import com.thebluealliance.android.data.local.entity.*
-import com.thebluealliance.android.data.remote.dto.*
-import com.thebluealliance.android.domain.model.*
+import com.thebluealliance.android.data.local.entity.AllianceEntity
+import com.thebluealliance.android.data.local.entity.AwardEntity
+import com.thebluealliance.android.data.local.entity.DistrictEntity
+import com.thebluealliance.android.data.local.entity.DistrictRankingEntity
+import com.thebluealliance.android.data.local.entity.EventCOPRsEntity
+import com.thebluealliance.android.data.local.entity.EventDistrictPointsEntity
+import com.thebluealliance.android.data.local.entity.EventEntity
+import com.thebluealliance.android.data.local.entity.EventInsightsEntity
+import com.thebluealliance.android.data.local.entity.EventOPRsEntity
+import com.thebluealliance.android.data.local.entity.EventRankingSortOrderEntity
+import com.thebluealliance.android.data.local.entity.MatchEntity
+import com.thebluealliance.android.data.local.entity.MediaEntity
+import com.thebluealliance.android.data.local.entity.RankingEntity
+import com.thebluealliance.android.data.local.entity.TeamEntity
+import com.thebluealliance.android.data.remote.dto.AwardDto
+import com.thebluealliance.android.data.remote.dto.DistrictDto
+import com.thebluealliance.android.data.remote.dto.DistrictEventPointsDto
+import com.thebluealliance.android.data.remote.dto.DistrictRankingDto
+import com.thebluealliance.android.data.remote.dto.EventAllianceDto
+import com.thebluealliance.android.data.remote.dto.EventCOPRsDto
+import com.thebluealliance.android.data.remote.dto.EventDistrictPointsEntryDto
+import com.thebluealliance.android.data.remote.dto.EventDto
+import com.thebluealliance.android.data.remote.dto.EventInsightsDto
+import com.thebluealliance.android.data.remote.dto.EventOPRsDto
+import com.thebluealliance.android.data.remote.dto.MatchDto
+import com.thebluealliance.android.data.remote.dto.MediaDto
+import com.thebluealliance.android.data.remote.dto.RankingItemDto
+import com.thebluealliance.android.data.remote.dto.RankingResponseDto
+import com.thebluealliance.android.data.remote.dto.RankingSortOrderDto
+import com.thebluealliance.android.data.remote.dto.RegionalRankingDto
+import com.thebluealliance.android.data.remote.dto.TeamDto
+import com.thebluealliance.android.data.remote.dto.WebcastDto
+import com.thebluealliance.android.domain.model.Alliance
+import com.thebluealliance.android.domain.model.Award
+import com.thebluealliance.android.domain.model.CompLevel
+import com.thebluealliance.android.domain.model.District
+import com.thebluealliance.android.domain.model.DistrictEventPoints
+import com.thebluealliance.android.domain.model.DistrictRanking
+import com.thebluealliance.android.domain.model.Event
+import com.thebluealliance.android.domain.model.EventAdvancementPoints
+import com.thebluealliance.android.domain.model.EventCOPRs
+import com.thebluealliance.android.domain.model.EventInsights
+import com.thebluealliance.android.domain.model.EventOPRs
+import com.thebluealliance.android.domain.model.Match
+import com.thebluealliance.android.domain.model.Media
+import com.thebluealliance.android.domain.model.PlayoffType
+import com.thebluealliance.android.domain.model.Ranking
+import com.thebluealliance.android.domain.model.RankingSortOrder
+import com.thebluealliance.android.domain.model.RegionalEventPoints
+import com.thebluealliance.android.domain.model.RegionalRanking
+import com.thebluealliance.android.domain.model.Team
+import com.thebluealliance.android.domain.model.Webcast
 import kotlinx.serialization.json.Json
 
 private val json = Json { ignoreUnknownKeys = true }
 
 // ── Team ──
 
-fun TeamDto.toEntity() = TeamEntity(
-    key = key,
-    number = teamNumber,
-    name = name,
-    nickname = nickname,
-    city = city,
-    state = stateProv,
-    country = country,
-    rookieYear = rookieYear,
-)
+fun TeamDto.toEntity() =
+    TeamEntity(
+        key = key,
+        number = teamNumber,
+        name = name,
+        nickname = nickname,
+        city = city,
+        state = stateProv,
+        country = country,
+        rookieYear = rookieYear,
+    )
 
-fun TeamEntity.toDomain() = Team(
-    key = key,
-    number = number,
-    name = name,
-    nickname = nickname,
-    city = city,
-    state = state,
-    country = country,
-    rookieYear = rookieYear,
-)
+fun TeamEntity.toDomain() =
+    Team(
+        key = key,
+        number = number,
+        name = name,
+        nickname = nickname,
+        city = city,
+        state = state,
+        country = country,
+        rookieYear = rookieYear,
+    )
 
 // ── Event ──
 
-fun EventDto.toEntity() = EventEntity(
-    key = key,
-    name = name,
-    eventCode = eventCode,
-    year = year,
-    type = eventType,
-    district = district?.key,
-    city = city,
-    state = stateProv,
-    country = country,
-    startDate = startDate,
-    endDate = endDate,
-    week = week,
-    shortName = shortName,
-    website = website,
-    timezone = timezone,
-    webcasts = webcasts?.let { json.encodeToString(it) },
-    locationName = locationName,
-    address = address,
-    gmapsUrl = gmapsUrl,
-    playoffType = playoffType ?: PlayoffType.OTHER.typeInt,
-)
+fun EventDto.toEntity() =
+    EventEntity(
+        key = key,
+        name = name,
+        eventCode = eventCode,
+        year = year,
+        type = eventType,
+        district = district?.key,
+        city = city,
+        state = stateProv,
+        country = country,
+        startDate = startDate,
+        endDate = endDate,
+        week = week,
+        shortName = shortName,
+        website = website,
+        timezone = timezone,
+        webcasts = webcasts?.let { json.encodeToString(it) },
+        locationName = locationName,
+        address = address,
+        gmapsUrl = gmapsUrl,
+        playoffType = playoffType ?: PlayoffType.OTHER.typeInt,
+    )
 
-fun EventEntity.toDomain() = Event(
-    key = key,
-    name = name,
-    eventCode = eventCode,
-    year = year,
-    type = type,
-    district = district,
-    city = city,
-    state = state,
-    country = country,
-    startDate = startDate,
-    endDate = endDate,
-    week = week,
-    shortName = shortName,
-    website = website,
-    timezone = timezone,
-    locationName = locationName,
-    address = address,
-    gmapsUrl = gmapsUrl,
-    playoffType = PlayoffType.fromInt(playoffType),
-    webcasts = webcasts?.let { raw ->
-        try {
-            json.decodeFromString<List<WebcastDto>>(raw).map {
-                Webcast(type = it.type, channel = it.channel, file = it.file, date = it.date)
-            }
-        } catch (_: Exception) { emptyList() }
-    } ?: emptyList(),
-)
+fun EventEntity.toDomain() =
+    Event(
+        key = key,
+        name = name,
+        eventCode = eventCode,
+        year = year,
+        type = type,
+        district = district,
+        city = city,
+        state = state,
+        country = country,
+        startDate = startDate,
+        endDate = endDate,
+        week = week,
+        shortName = shortName,
+        website = website,
+        timezone = timezone,
+        locationName = locationName,
+        address = address,
+        gmapsUrl = gmapsUrl,
+        playoffType = PlayoffType.fromInt(playoffType),
+        webcasts =
+            webcasts?.let { raw ->
+                try {
+                    json.decodeFromString<List<WebcastDto>>(raw).map {
+                        Webcast(
+                            type = it.type,
+                            channel = it.channel,
+                            file = it.file,
+                            date = it.date,
+                        )
+                    }
+                } catch (_: Exception) {
+                    emptyList()
+                }
+            } ?: emptyList(),
+    )
 
 // ── Match ──
 
-fun MatchDto.toEntity() = MatchEntity(
-    key = key,
-    eventKey = eventKey,
-    compLevel = compLevel,
-    matchNumber = matchNumber,
-    setNumber = setNumber,
-    time = time,
-    predictedTime = predictedTime,
-    actualTime = actualTime,
-    redTeamKeys = alliances?.red?.teamKeys?.joinToString(",") ?: "",
-    redScore = alliances?.red?.score ?: -1,
-    blueTeamKeys = alliances?.blue?.teamKeys?.joinToString(",") ?: "",
-    blueScore = alliances?.blue?.score ?: -1,
-    winningAlliance = winningAlliance,
-    scoreBreakdown = scoreBreakdown?.toString(),
-    videos = videos?.let { json.encodeToString(it) },
-)
+fun MatchDto.toEntity() =
+    MatchEntity(
+        key = key,
+        eventKey = eventKey,
+        compLevel = compLevel,
+        matchNumber = matchNumber,
+        setNumber = setNumber,
+        time = time,
+        predictedTime = predictedTime,
+        actualTime = actualTime,
+        redTeamKeys = alliances?.red?.teamKeys?.joinToString(",") ?: "",
+        redScore = alliances?.red?.score ?: -1,
+        blueTeamKeys = alliances?.blue?.teamKeys?.joinToString(",") ?: "",
+        blueScore = alliances?.blue?.score ?: -1,
+        winningAlliance = winningAlliance,
+        scoreBreakdown = scoreBreakdown?.toString(),
+        videos = videos?.let { json.encodeToString(it) },
+    )
 
-fun MatchEntity.toDomain() = Match(
-    key = key,
-    eventKey = eventKey,
-    compLevel = CompLevel.fromCode(compLevel),
-    matchNumber = matchNumber,
-    setNumber = setNumber,
-    time = time,
-    predictedTime = predictedTime,
-    actualTime = actualTime,
-    redTeamKeys = redTeamKeys.split(",").filter { it.isNotEmpty() },
-    redScore = redScore,
-    blueTeamKeys = blueTeamKeys.split(",").filter { it.isNotEmpty() },
-    blueScore = blueScore,
-    winningAlliance = winningAlliance,
-    scoreBreakdown = scoreBreakdown,
-    videos = videos,
-)
+fun MatchEntity.toDomain() =
+    Match(
+        key = key,
+        eventKey = eventKey,
+        compLevel = CompLevel.fromCode(compLevel),
+        matchNumber = matchNumber,
+        setNumber = setNumber,
+        time = time,
+        predictedTime = predictedTime,
+        actualTime = actualTime,
+        redTeamKeys = redTeamKeys.split(",").filter { it.isNotEmpty() },
+        redScore = redScore,
+        blueTeamKeys = blueTeamKeys.split(",").filter { it.isNotEmpty() },
+        blueScore = blueScore,
+        winningAlliance = winningAlliance,
+        scoreBreakdown = scoreBreakdown,
+        videos = videos,
+    )
 
 // ── Award ──
 
 fun AwardDto.toEntities(): List<AwardEntity> {
     val recipientJson = json.encodeToString(recipientList)
-    return recipientList.map { recipient ->
-        AwardEntity(
-            eventKey = eventKey,
-            awardType = awardType,
-            teamKey = recipient.teamKey ?: "",
-            awardee = recipient.awardee ?: "",
-            name = name,
-            year = year,
-            recipientList = recipientJson,
-        )
-    }.ifEmpty {
-        listOf(
+    return recipientList
+        .map { recipient ->
             AwardEntity(
                 eventKey = eventKey,
                 awardType = awardType,
-                teamKey = "",
-                awardee = "",
+                teamKey = recipient.teamKey ?: "",
+                awardee = recipient.awardee ?: "",
                 name = name,
                 year = year,
                 recipientList = recipientJson,
             )
-        )
-    }
+        }.ifEmpty {
+            listOf(
+                AwardEntity(
+                    eventKey = eventKey,
+                    awardType = awardType,
+                    teamKey = "",
+                    awardee = "",
+                    name = name,
+                    year = year,
+                    recipientList = recipientJson,
+                ),
+            )
+        }
 }
 
-fun AwardEntity.toDomain() = Award(
-    eventKey = eventKey,
-    awardType = awardType,
-    teamKey = teamKey,
-    awardee = awardee.ifEmpty { null },
-    name = name,
-    year = year,
-)
+fun AwardEntity.toDomain() =
+    Award(
+        eventKey = eventKey,
+        awardType = awardType,
+        teamKey = teamKey,
+        awardee = awardee.ifEmpty { null },
+        name = name,
+        year = year,
+    )
 
 // ── Ranking ──
 
-fun RankingItemDto.toEntity(eventKey: String) = RankingEntity(
-    eventKey = eventKey,
-    teamKey = teamKey,
-    rank = rank,
-    dq = dq,
-    matchesPlayed = matchesPlayed,
-    wins = record?.wins ?: 0,
-    losses = record?.losses ?: 0,
-    ties = record?.ties ?: 0,
-    sortOrders = json.encodeToString(sortOrders),
-    extraStats = json.encodeToString(extraStats),
-    qualAverage = qualAverage,
-)
+fun RankingItemDto.toEntity(eventKey: String) =
+    RankingEntity(
+        eventKey = eventKey,
+        teamKey = teamKey,
+        rank = rank,
+        dq = dq,
+        matchesPlayed = matchesPlayed,
+        wins = record?.wins ?: 0,
+        losses = record?.losses ?: 0,
+        ties = record?.ties ?: 0,
+        sortOrders = json.encodeToString(sortOrders),
+        extraStats = json.encodeToString(extraStats),
+        qualAverage = qualAverage,
+    )
 
-fun RankingEntity.toDomain() = Ranking(
-    eventKey = eventKey,
-    teamKey = teamKey,
-    rank = rank,
-    dq = dq,
-    matchesPlayed = matchesPlayed,
-    wins = wins,
-    losses = losses,
-    ties = ties,
-    qualAverage = qualAverage,
-    sortOrders = try { json.decodeFromString(sortOrders) } catch (_: Exception) { emptyList() },
-    extraStats = try { json.decodeFromString(extraStats) } catch (_: Exception) { emptyList() },
-)
+fun RankingEntity.toDomain() =
+    Ranking(
+        eventKey = eventKey,
+        teamKey = teamKey,
+        rank = rank,
+        dq = dq,
+        matchesPlayed = matchesPlayed,
+        wins = wins,
+        losses = losses,
+        ties = ties,
+        qualAverage = qualAverage,
+        sortOrders =
+            try {
+                json.decodeFromString(sortOrders)
+            } catch (_: Exception) {
+                emptyList()
+            },
+        extraStats =
+            try {
+                json.decodeFromString(extraStats)
+            } catch (_: Exception) {
+                emptyList()
+            },
+    )
 
-fun RankingSortOrderDto.toDomain() = RankingSortOrder(
-    name = name,
-    precision = precision,
-)
+fun RankingSortOrderDto.toDomain() =
+    RankingSortOrder(
+        name = name,
+        precision = precision,
+    )
 
-fun RankingResponseDto.toSortOrderEntity(eventKey: String) = EventRankingSortOrderEntity(
-    eventKey = eventKey,
-    sortOrderInfo = json.encodeToString(sortOrderInfo ?: emptyList()),
-    extraStatsInfo = json.encodeToString(extraStatsInfo ?: emptyList()),
-)
+fun RankingResponseDto.toSortOrderEntity(eventKey: String) =
+    EventRankingSortOrderEntity(
+        eventKey = eventKey,
+        sortOrderInfo = json.encodeToString(sortOrderInfo ?: emptyList()),
+        extraStatsInfo = json.encodeToString(extraStatsInfo ?: emptyList()),
+    )
 
 fun EventRankingSortOrderEntity.getSortOrderInfo(): List<RankingSortOrder> =
     try {
@@ -213,14 +292,19 @@ fun EventRankingSortOrderEntity.getExtraStatsInfo(): List<RankingSortOrder> =
     try {
         if (extraStatsInfo != null) {
             json.decodeFromString<List<RankingSortOrderDto>>(extraStatsInfo).map { it.toDomain() }
-        } else emptyList()
+        } else {
+            emptyList()
+        }
     } catch (_: Exception) {
         emptyList()
     }
 
 // ── Alliance ──
 
-fun EventAllianceDto.toEntity(eventKey: String, number: Int) = AllianceEntity(
+fun EventAllianceDto.toEntity(
+    eventKey: String,
+    number: Int,
+) = AllianceEntity(
     eventKey = eventKey,
     number = number,
     name = name,
@@ -233,86 +317,99 @@ fun EventAllianceDto.toEntity(eventKey: String, number: Int) = AllianceEntity(
     playoffDoubleElimRound = status?.doubleElimRound,
 )
 
-fun AllianceEntity.toDomain() = Alliance(
-    eventKey = eventKey,
-    number = number,
-    name = name,
-    picks = json.decodeFromString(picks),
-    declines = json.decodeFromString(declines),
-    backupIn = backupIn,
-    backupOut = backupOut,
-    playoffStatus = playoffStatus,
-    playoffLevel = playoffLevel,
-    playoffDoubleElimRound = playoffDoubleElimRound,
-)
+fun AllianceEntity.toDomain() =
+    Alliance(
+        eventKey = eventKey,
+        number = number,
+        name = name,
+        picks = json.decodeFromString(picks),
+        declines = json.decodeFromString(declines),
+        backupIn = backupIn,
+        backupOut = backupOut,
+        playoffStatus = playoffStatus,
+        playoffLevel = playoffLevel,
+        playoffDoubleElimRound = playoffDoubleElimRound,
+    )
 
 // ── District ──
 
-fun DistrictDto.toEntity() = DistrictEntity(
-    key = key,
-    abbreviation = abbreviation,
-    displayName = displayName,
-    year = year,
-)
+fun DistrictDto.toEntity() =
+    DistrictEntity(
+        key = key,
+        abbreviation = abbreviation,
+        displayName = displayName,
+        year = year,
+    )
 
-fun DistrictEntity.toDomain() = District(
-    key = key,
-    abbreviation = abbreviation,
-    displayName = displayName,
-    year = year,
-)
+fun DistrictEntity.toDomain() =
+    District(
+        key = key,
+        abbreviation = abbreviation,
+        displayName = displayName,
+        year = year,
+    )
 
 // ── DistrictRanking ──
 
-fun DistrictRankingDto.toEntity(districtKey: String) = DistrictRankingEntity(
-    districtKey = districtKey,
-    teamKey = teamKey,
-    rank = rank,
-    pointTotal = pointTotal,
-    rookieBonus = rookieBonus,
-    eventPoints = json.encodeToString(eventPoints),
-)
+fun DistrictRankingDto.toEntity(districtKey: String) =
+    DistrictRankingEntity(
+        districtKey = districtKey,
+        teamKey = teamKey,
+        rank = rank,
+        pointTotal = pointTotal,
+        rookieBonus = rookieBonus,
+        eventPoints = json.encodeToString(eventPoints),
+    )
 
-fun DistrictRankingEntity.toDomain() = DistrictRanking(
-    districtKey = districtKey,
-    teamKey = teamKey,
-    rank = rank,
-    pointTotal = pointTotal,
-    rookieBonus = rookieBonus,
-    eventPoints = try {
-        json.decodeFromString<List<DistrictEventPointsDto>>(eventPoints).map {
-            DistrictEventPoints(
-                eventKey = it.eventKey,
-                total = it.total,
-                districtCmp = it.districtCmp
-            )
-        }
-    } catch (_: Exception) {
-        emptyList()
-    }
-)
+fun DistrictRankingEntity.toDomain() =
+    DistrictRanking(
+        districtKey = districtKey,
+        teamKey = teamKey,
+        rank = rank,
+        pointTotal = pointTotal,
+        rookieBonus = rookieBonus,
+        eventPoints =
+            try {
+                json.decodeFromString<List<DistrictEventPointsDto>>(eventPoints).map {
+                    DistrictEventPoints(
+                        eventKey = it.eventKey,
+                        total = it.total,
+                        districtCmp = it.districtCmp,
+                    )
+                }
+            } catch (_: Exception) {
+                emptyList()
+            },
+    )
 
 // ── RegionalRanking ──
 
-fun RegionalRankingDto.toDomain(year: Int, advancementMethod: String? = null) = RegionalRanking(
+fun RegionalRankingDto.toDomain(
+    year: Int,
+    advancementMethod: String? = null,
+) = RegionalRanking(
     year = year,
     teamKey = teamKey,
     rank = rank,
     pointTotal = pointTotal,
     rookieBonus = rookieBonus,
     singleEventBonus = singleEventBonus,
-    eventPoints = eventPoints.map { point ->
-        RegionalEventPoints(
-            eventKey = point.eventKey,
-            total = point.total,
-        )
-    },
+    eventPoints =
+        eventPoints.map { point ->
+            RegionalEventPoints(
+                eventKey = point.eventKey,
+                total = point.total,
+            )
+        },
     advancementMethod = advancementMethod,
 )
 
 // ── EventDistrictPoints ──
 
-fun EventDistrictPointsEntryDto.toEntity(eventKey: String, teamKey: String) = EventDistrictPointsEntity(
+fun EventDistrictPointsEntryDto.toEntity(
+    eventKey: String,
+    teamKey: String,
+) = EventDistrictPointsEntity(
     eventKey = eventKey,
     teamKey = teamKey,
     qualPoints = qualPoints,
@@ -323,76 +420,88 @@ fun EventDistrictPointsEntryDto.toEntity(eventKey: String, teamKey: String) = Ev
     total = total,
 )
 
-fun EventDistrictPointsEntity.toDomain() = EventAdvancementPoints(
-    teamKey = teamKey,
-    qualPoints = qualPoints,
-    elimPoints = elimPoints,
-    alliancePoints = alliancePoints,
-    awardPoints = awardPoints,
-    rookieBonus = rookieBonus,
-    total = total,
-)
+fun EventDistrictPointsEntity.toDomain() =
+    EventAdvancementPoints(
+        teamKey = teamKey,
+        qualPoints = qualPoints,
+        elimPoints = elimPoints,
+        alliancePoints = alliancePoints,
+        awardPoints = awardPoints,
+        rookieBonus = rookieBonus,
+        total = total,
+    )
 
 // ── Media ──
 
-fun MediaDto.toEntity(teamKey: String, year: Int) = MediaEntity(
+fun MediaDto.toEntity(
+    teamKey: String,
+    year: Int,
+) = MediaEntity(
     teamKey = teamKey,
     type = type,
     foreignKey = foreignKey,
     year = year,
     preferred = preferred,
     details = details?.toString(),
-    base64Image = base64Image
-        ?: details?.get("base64Image")?.let {
-            (it as? kotlinx.serialization.json.JsonPrimitive)?.content
-        },
+    base64Image =
+        base64Image
+            ?: details?.get("base64Image")?.let {
+                (it as? kotlinx.serialization.json.JsonPrimitive)?.content
+            },
 )
 
-fun MediaEntity.toDomain() = Media(
-    teamKey = teamKey,
-    type = type,
-    foreignKey = foreignKey,
-    year = year,
-    preferred = preferred,
-    details = details,
-    base64Image = base64Image,
-)
+fun MediaEntity.toDomain() =
+    Media(
+        teamKey = teamKey,
+        type = type,
+        foreignKey = foreignKey,
+        year = year,
+        preferred = preferred,
+        details = details,
+        base64Image = base64Image,
+    )
 
 // ── OPRs ──
 
-fun EventOPRsDto.toEntity(eventKey: String) = EventOPRsEntity(
-    eventKey = eventKey,
-    oprs = json.encodeToString(oprs),
-    dprs = json.encodeToString(dprs),
-    ccwms = json.encodeToString(ccwms),
-)
+fun EventOPRsDto.toEntity(eventKey: String) =
+    EventOPRsEntity(
+        eventKey = eventKey,
+        oprs = json.encodeToString(oprs),
+        dprs = json.encodeToString(dprs),
+        ccwms = json.encodeToString(ccwms),
+    )
 
-fun EventOPRsEntity.toDomain() = EventOPRs(
-    oprs = json.decodeFromString(oprs),
-    dprs = json.decodeFromString(dprs),
-    ccwms = json.decodeFromString(ccwms),
-)
+fun EventOPRsEntity.toDomain() =
+    EventOPRs(
+        oprs = json.decodeFromString(oprs),
+        dprs = json.decodeFromString(dprs),
+        ccwms = json.decodeFromString(ccwms),
+    )
 
 // ── COPRs ──
 
-fun EventCOPRsDto.toEntity(eventKey: String) = EventCOPRsEntity(
-    eventKey = eventKey,
-    coprs = json.encodeToString(coprs),
-)
+fun EventCOPRsDto.toEntity(eventKey: String) =
+    EventCOPRsEntity(
+        eventKey = eventKey,
+        coprs = json.encodeToString(coprs),
+    )
 
-fun EventCOPRsEntity.toDomain() = EventCOPRs(
-    coprs = json.decodeFromString(coprs),
-)
+fun EventCOPRsEntity.toDomain() =
+    EventCOPRs(
+        coprs = json.decodeFromString(coprs),
+    )
 
 // ── Insights ──
 
-fun EventInsightsDto.toEntity(eventKey: String) = EventInsightsEntity(
-    eventKey = eventKey,
-    qualInsights = qual,
-    playoffInsights = playoff,
-)
+fun EventInsightsDto.toEntity(eventKey: String) =
+    EventInsightsEntity(
+        eventKey = eventKey,
+        qualInsights = qual,
+        playoffInsights = playoff,
+    )
 
-fun EventInsightsEntity.toDomain() = EventInsights(
-    qual = qualInsights,
-    playoff = playoffInsights,
-)
+fun EventInsightsEntity.toDomain() =
+    EventInsights(
+        qual = qualInsights,
+        playoff = playoffInsights,
+    )

--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/AuthTokenInterceptor.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/AuthTokenInterceptor.kt
@@ -6,22 +6,28 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
-class AuthTokenInterceptor @Inject constructor(
-    private val authRepository: dagger.Lazy<AuthRepository>,
-) : Interceptor {
-    override fun intercept(chain: Interceptor.Chain): Response {
-        val token = try {
-            runBlocking { authRepository.get().getIdToken() }
-        } catch (_: Exception) {
-            null
+class AuthTokenInterceptor
+    @Inject
+    constructor(
+        private val authRepository: dagger.Lazy<AuthRepository>,
+    ) : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val token =
+                try {
+                    runBlocking { authRepository.get().getIdToken() }
+                } catch (_: Exception) {
+                    null
+                }
+            val request =
+                if (token != null) {
+                    chain
+                        .request()
+                        .newBuilder()
+                        .addHeader("Authorization", "Bearer $token")
+                        .build()
+                } else {
+                    chain.request()
+                }
+            return chain.proceed(request)
         }
-        val request = if (token != null) {
-            chain.request().newBuilder()
-                .addHeader("Authorization", "Bearer $token")
-                .build()
-        } else {
-            chain.request()
-        }
-        return chain.proceed(request)
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/ClientApi.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/ClientApi.kt
@@ -10,19 +10,28 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface ClientApi {
-
     @POST("clientapi/tbaClient/v9/favorites/list")
-    suspend fun listFavorites(@Body body: VoidRequestDto = VoidRequestDto()): FavoriteCollectionDto
+    suspend fun listFavorites(
+        @Body body: VoidRequestDto = VoidRequestDto(),
+    ): FavoriteCollectionDto
 
     @POST("clientapi/tbaClient/v9/subscriptions/list")
-    suspend fun listSubscriptions(@Body body: VoidRequestDto = VoidRequestDto()): SubscriptionCollectionDto
+    suspend fun listSubscriptions(
+        @Body body: VoidRequestDto = VoidRequestDto(),
+    ): SubscriptionCollectionDto
 
     @POST("clientapi/tbaClient/v9/model/setPreferences")
-    suspend fun updateModelPreferences(@Body request: ModelPreferenceRequestDto): BaseResponseDto
+    suspend fun updateModelPreferences(
+        @Body request: ModelPreferenceRequestDto,
+    ): BaseResponseDto
 
     @POST("clientapi/tbaClient/v9/register")
-    suspend fun registerDevice(@Body request: RegisterDeviceRequestDto): BaseResponseDto
+    suspend fun registerDevice(
+        @Body request: RegisterDeviceRequestDto,
+    ): BaseResponseDto
 
     @POST("clientapi/tbaClient/v9/unregister")
-    suspend fun unregisterDevice(@Body request: RegisterDeviceRequestDto): BaseResponseDto
+    suspend fun unregisterDevice(
+        @Body request: RegisterDeviceRequestDto,
+    ): BaseResponseDto
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/TbaApi.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/TbaApi.kt
@@ -1,38 +1,66 @@
 package com.thebluealliance.android.data.remote
 
-import com.thebluealliance.android.data.remote.dto.*
+import com.thebluealliance.android.data.remote.dto.ApiStatusDto
+import com.thebluealliance.android.data.remote.dto.AwardDto
+import com.thebluealliance.android.data.remote.dto.DistrictDto
+import com.thebluealliance.android.data.remote.dto.DistrictRankingDto
+import com.thebluealliance.android.data.remote.dto.EventAllianceDto
+import com.thebluealliance.android.data.remote.dto.EventCOPRsDto
+import com.thebluealliance.android.data.remote.dto.EventDistrictPointsResponseDto
+import com.thebluealliance.android.data.remote.dto.EventDto
+import com.thebluealliance.android.data.remote.dto.EventOPRsDto
+import com.thebluealliance.android.data.remote.dto.MatchDto
+import com.thebluealliance.android.data.remote.dto.MediaDto
+import com.thebluealliance.android.data.remote.dto.RankingResponseDto
+import com.thebluealliance.android.data.remote.dto.RegionalAdvancementDto
+import com.thebluealliance.android.data.remote.dto.RegionalRankingDto
+import com.thebluealliance.android.data.remote.dto.TeamDto
+import com.thebluealliance.android.data.remote.dto.TeamEventStatusDto
+import kotlinx.serialization.json.JsonObject
 import retrofit2.http.GET
 import retrofit2.http.Path
-import kotlinx.serialization.json.JsonObject
 
 interface TbaApi {
-
     // Status
     @GET("api/v3/status")
     suspend fun getStatus(): ApiStatusDto
 
     // Teams
     @GET("api/v3/teams/{page_num}")
-    suspend fun getTeams(@Path("page_num") page: Int): List<TeamDto>
+    suspend fun getTeams(
+        @Path("page_num") page: Int,
+    ): List<TeamDto>
 
     @GET("api/v3/team/{team_key}")
-    suspend fun getTeam(@Path("team_key") teamKey: String): TeamDto
+    suspend fun getTeam(
+        @Path("team_key") teamKey: String,
+    ): TeamDto
 
     @GET("api/v3/team/{team_key}/years_participated")
-    suspend fun getTeamYearsParticipated(@Path("team_key") teamKey: String): List<Int>
+    suspend fun getTeamYearsParticipated(
+        @Path("team_key") teamKey: String,
+    ): List<Int>
 
     @GET("api/v3/event/{event_key}/teams")
-    suspend fun getEventTeams(@Path("event_key") eventKey: String): List<TeamDto>
+    suspend fun getEventTeams(
+        @Path("event_key") eventKey: String,
+    ): List<TeamDto>
 
     @GET("api/v3/district/{district_key}/teams")
-    suspend fun getDistrictTeams(@Path("district_key") districtKey: String): List<TeamDto>
+    suspend fun getDistrictTeams(
+        @Path("district_key") districtKey: String,
+    ): List<TeamDto>
 
     // Events
     @GET("api/v3/events/{year}")
-    suspend fun getEventsForYear(@Path("year") year: Int): List<EventDto>
+    suspend fun getEventsForYear(
+        @Path("year") year: Int,
+    ): List<EventDto>
 
     @GET("api/v3/event/{event_key}")
-    suspend fun getEvent(@Path("event_key") eventKey: String): EventDto
+    suspend fun getEvent(
+        @Path("event_key") eventKey: String,
+    ): EventDto
 
     @GET("api/v3/team/{team_key}/events/{year}")
     suspend fun getTeamEvents(
@@ -41,11 +69,15 @@ interface TbaApi {
     ): List<EventDto>
 
     @GET("api/v3/district/{district_key}/events")
-    suspend fun getDistrictEvents(@Path("district_key") districtKey: String): List<EventDto>
+    suspend fun getDistrictEvents(
+        @Path("district_key") districtKey: String,
+    ): List<EventDto>
 
     // Matches
     @GET("api/v3/event/{event_key}/matches")
-    suspend fun getEventMatches(@Path("event_key") eventKey: String): List<MatchDto>
+    suspend fun getEventMatches(
+        @Path("event_key") eventKey: String,
+    ): List<MatchDto>
 
     @GET("api/v3/team/{team_key}/event/{event_key}/matches")
     suspend fun getTeamEventMatches(
@@ -54,11 +86,15 @@ interface TbaApi {
     ): List<MatchDto>
 
     @GET("api/v3/match/{match_key}")
-    suspend fun getMatch(@Path("match_key") matchKey: String): MatchDto
+    suspend fun getMatch(
+        @Path("match_key") matchKey: String,
+    ): MatchDto
 
     // Awards
     @GET("api/v3/event/{event_key}/awards")
-    suspend fun getEventAwards(@Path("event_key") eventKey: String): List<AwardDto>
+    suspend fun getEventAwards(
+        @Path("event_key") eventKey: String,
+    ): List<AwardDto>
 
     @GET("api/v3/team/{team_key}/event/{event_key}/awards")
     suspend fun getTeamEventAwards(
@@ -68,49 +104,73 @@ interface TbaApi {
 
     // Rankings
     @GET("api/v3/event/{event_key}/rankings")
-    suspend fun getEventRankings(@Path("event_key") eventKey: String): RankingResponseDto
+    suspend fun getEventRankings(
+        @Path("event_key") eventKey: String,
+    ): RankingResponseDto
 
     // Alliances
     @GET("api/v3/event/{event_key}/alliances")
-    suspend fun getEventAlliances(@Path("event_key") eventKey: String): List<EventAllianceDto>
+    suspend fun getEventAlliances(
+        @Path("event_key") eventKey: String,
+    ): List<EventAllianceDto>
 
     // OPRs
     @GET("api/v3/event/{event_key}/oprs")
-    suspend fun getEventOPRs(@Path("event_key") eventKey: String): EventOPRsDto
+    suspend fun getEventOPRs(
+        @Path("event_key") eventKey: String,
+    ): EventOPRsDto
 
     // COPRs
     @GET("api/v3/event/{event_key}/coprs")
-    suspend fun getEventCOPRs(@Path("event_key") eventKey: String): EventCOPRsDto
+    suspend fun getEventCOPRs(
+        @Path("event_key") eventKey: String,
+    ): EventCOPRsDto
 
     // Insights
     @GET("api/v3/event/{event_key}/insights")
-    suspend fun getEventInsights(@Path("event_key") eventKey: String): JsonObject
+    suspend fun getEventInsights(
+        @Path("event_key") eventKey: String,
+    ): JsonObject
 
     // Districts
     @GET("api/v3/districts/{year}")
-    suspend fun getDistrictsForYear(@Path("year") year: Int): List<DistrictDto>
+    suspend fun getDistrictsForYear(
+        @Path("year") year: Int,
+    ): List<DistrictDto>
 
     @GET("api/v3/district/{district_abbreviation}/history")
-    suspend fun getDistrictHistory(@Path("district_abbreviation") districtAbbreviation: String): List<DistrictDto>
+    suspend fun getDistrictHistory(
+        @Path("district_abbreviation") districtAbbreviation: String,
+    ): List<DistrictDto>
 
     // District Rankings
     @GET("api/v3/district/{district_key}/rankings")
-    suspend fun getDistrictRankings(@Path("district_key") districtKey: String): List<DistrictRankingDto>?
+    suspend fun getDistrictRankings(
+        @Path("district_key") districtKey: String,
+    ): List<DistrictRankingDto>?
 
     // Event District Points
     @GET("api/v3/event/{event_key}/district_points")
-    suspend fun getEventDistrictPoints(@Path("event_key") eventKey: String): EventDistrictPointsResponseDto
+    suspend fun getEventDistrictPoints(
+        @Path("event_key") eventKey: String,
+    ): EventDistrictPointsResponseDto
 
     // Event Regional Points (returns the same structure as district points)
     @GET("api/v3/event/{event_key}/regional_champs_pool_points")
-    suspend fun getEventRegionalPoints(@Path("event_key") eventKey: String): EventDistrictPointsResponseDto
+    suspend fun getEventRegionalPoints(
+        @Path("event_key") eventKey: String,
+    ): EventDistrictPointsResponseDto
 
     // Regional Advancement
     @GET("api/v3/regional_advancement/{year}/rankings")
-    suspend fun getRegionalAdvancementRankings(@Path("year") year: Int): List<RegionalRankingDto>?
+    suspend fun getRegionalAdvancementRankings(
+        @Path("year") year: Int,
+    ): List<RegionalRankingDto>?
 
     @GET("api/v3/regional_advancement/{year}")
-    suspend fun getRegionalAdvancement(@Path("year") year: Int): Map<String, RegionalAdvancementDto>?
+    suspend fun getRegionalAdvancement(
+        @Path("year") year: Int,
+    ): Map<String, RegionalAdvancementDto>?
 
     // Media
     @GET("api/v3/team/{team_key}/media/{year}")

--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/TbaApiKeyInterceptor.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/TbaApiKeyInterceptor.kt
@@ -5,13 +5,18 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
-class TbaApiKeyInterceptor @Inject constructor(
-    private val apiKeyProvider: ApiKeyProvider,
-) : Interceptor {
-    override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request().newBuilder()
-            .addHeader("X-TBA-Auth-Key", apiKeyProvider.apiKey)
-            .build()
-        return chain.proceed(request)
+class TbaApiKeyInterceptor
+    @Inject
+    constructor(
+        private val apiKeyProvider: ApiKeyProvider,
+    ) : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val request =
+                chain
+                    .request()
+                    .newBuilder()
+                    .addHeader("X-TBA-Auth-Key", apiKeyProvider.apiKey)
+                    .build()
+            return chain.proceed(request)
+        }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/EventCOPRsDto.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/EventCOPRsDto.kt
@@ -21,11 +21,15 @@ data class EventCOPRsDto(
 )
 
 object EventCOPRsDtoSerializer : KSerializer<EventCOPRsDto> {
-    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("EventCOPRsDto") {
-        element<Map<String, Map<String, Double>>>("coprs")
-    }
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("EventCOPRsDto") {
+            element<Map<String, Map<String, Double>>>("coprs")
+        }
 
-    override fun serialize(encoder: Encoder, value: EventCOPRsDto) {
+    override fun serialize(
+        encoder: Encoder,
+        value: EventCOPRsDto,
+    ) {
         error("Serialization not supported")
     }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/EventInsightsDto.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/EventInsightsDto.kt
@@ -6,7 +6,3 @@ data class EventInsightsDto(
     val qual: String? = null,
     val playoff: String? = null,
 )
-
-
-
-

--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/EventOPRsDto.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/EventOPRsDto.kt
@@ -15,6 +15,5 @@ data class EventOPRsDto(
 // Alternative: Use JsonElement for the whole response
 @Serializable
 data class EventOPRsResponseDto(
-    val response: JsonObject
+    val response: JsonObject,
 )
-

--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/RegionalRankingDto.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/RegionalRankingDto.kt
@@ -30,4 +30,3 @@ data class RegionalAdvancementDto(
     @SerialName("qualifying_event") val qualifyingEvent: String? = null,
     @SerialName("qualifying_pool_week") val qualifyingPoolWeek: Int? = null,
 )
-

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/AuthRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/AuthRepository.kt
@@ -11,29 +11,34 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class AuthRepository @Inject constructor(
-    private val firebaseAuth: FirebaseAuth,
-) {
-    val currentUser: Flow<FirebaseUser?> = callbackFlow {
-        val listener = FirebaseAuth.AuthStateListener { auth ->
-            val user = auth.currentUser
-            try {
-                FirebaseCrashlytics.getInstance().setUserId(user?.uid.orEmpty())
-            } catch (_: Exception) { }
-            trySend(user)
+class AuthRepository
+    @Inject
+    constructor(
+        private val firebaseAuth: FirebaseAuth,
+    ) {
+        val currentUser: Flow<FirebaseUser?> =
+            callbackFlow {
+                val listener =
+                    FirebaseAuth.AuthStateListener { auth ->
+                        val user = auth.currentUser
+                        try {
+                            FirebaseCrashlytics.getInstance().setUserId(user?.uid.orEmpty())
+                        } catch (_: Exception) {
+                        }
+                        trySend(user)
+                    }
+                firebaseAuth.addAuthStateListener(listener)
+                awaitClose { firebaseAuth.removeAuthStateListener(listener) }
+            }
+
+        fun isSignedIn(): Boolean = firebaseAuth.currentUser != null
+
+        suspend fun getIdToken(): String? {
+            val user = firebaseAuth.currentUser ?: return null
+            return user.getIdToken(false).await().token
         }
-        firebaseAuth.addAuthStateListener(listener)
-        awaitClose { firebaseAuth.removeAuthStateListener(listener) }
-    }
 
-    fun isSignedIn(): Boolean = firebaseAuth.currentUser != null
-
-    suspend fun getIdToken(): String? {
-        val user = firebaseAuth.currentUser ?: return null
-        return user.getIdToken(false).await().token
+        fun signOut() {
+            firebaseAuth.signOut()
+        }
     }
-
-    fun signOut() {
-        firebaseAuth.signOut()
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/DistrictRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/DistrictRepository.kt
@@ -15,37 +15,41 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class DistrictRepository @Inject constructor(
-    private val api: TbaApi,
-    private val db: TBADatabase,
-    private val districtDao: DistrictDao,
-    private val districtRankingDao: DistrictRankingDao,
-) {
-    fun observeDistrict(key: String): Flow<District?> =
-        districtDao.observe(key).map { it?.toDomain() }
+class DistrictRepository
+    @Inject
+    constructor(
+        private val api: TbaApi,
+        private val db: TBADatabase,
+        private val districtDao: DistrictDao,
+        private val districtRankingDao: DistrictRankingDao,
+    ) {
+        fun observeDistrict(key: String): Flow<District?> =
+            districtDao.observe(key).map { it?.toDomain() }
 
-    fun observeDistrictsForYear(year: Int): Flow<List<District>> =
-        districtDao.observeByYear(year).map { list -> list.map { it.toDomain() } }
+        fun observeDistrictsForYear(year: Int): Flow<List<District>> =
+            districtDao.observeByYear(year).map { list -> list.map { it.toDomain() } }
 
-    fun observeDistrictRankings(districtKey: String): Flow<List<DistrictRanking>> =
-        districtRankingDao.observeByDistrict(districtKey).map { list -> list.map { it.toDomain() } }
+        fun observeDistrictRankings(districtKey: String): Flow<List<DistrictRanking>> =
+            districtRankingDao.observeByDistrict(districtKey).map { list ->
+                list.map { it.toDomain() }
+            }
 
-    suspend fun refreshDistrictsForYear(year: Int) {
-        val dtos = api.getDistrictsForYear(year)
-        db.withTransaction {
-            districtDao.deleteByYear(year)
-            districtDao.insertAll(dtos.map { it.toEntity() })
+        suspend fun refreshDistrictsForYear(year: Int) {
+            val dtos = api.getDistrictsForYear(year)
+            db.withTransaction {
+                districtDao.deleteByYear(year)
+                districtDao.insertAll(dtos.map { it.toEntity() })
+            }
         }
-    }
 
-    suspend fun refreshDistrictRankings(districtKey: String) {
-        val dtos = api.getDistrictRankings(districtKey) ?: return
-        db.withTransaction {
-            districtRankingDao.deleteByDistrict(districtKey)
-            districtRankingDao.insertAll(dtos.map { it.toEntity(districtKey) })
+        suspend fun refreshDistrictRankings(districtKey: String) {
+            val dtos = api.getDistrictRankings(districtKey) ?: return
+            db.withTransaction {
+                districtRankingDao.deleteByDistrict(districtKey)
+                districtRankingDao.insertAll(dtos.map { it.toEntity(districtKey) })
+            }
         }
-    }
 
-    suspend fun getDistrictHistory(districtAbbreviation: String): List<Int> =
-        api.getDistrictHistory(districtAbbreviation).map { it.year }.sortedDescending()
-}
+        suspend fun getDistrictHistory(districtAbbreviation: String): List<Int> =
+            api.getDistrictHistory(districtAbbreviation).map { it.year }.sortedDescending()
+    }

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
@@ -15,15 +15,20 @@ import com.thebluealliance.android.data.local.dao.RankingDao
 import com.thebluealliance.android.data.local.dao.TeamEventStatusDao
 import com.thebluealliance.android.data.local.entity.EventTeamEntity
 import com.thebluealliance.android.data.local.entity.TeamEventStatusEntity
-import com.thebluealliance.android.data.mappers.*
+import com.thebluealliance.android.data.mappers.getExtraStatsInfo
+import com.thebluealliance.android.data.mappers.getSortOrderInfo
+import com.thebluealliance.android.data.mappers.toDomain
+import com.thebluealliance.android.data.mappers.toEntities
+import com.thebluealliance.android.data.mappers.toEntity
+import com.thebluealliance.android.data.mappers.toSortOrderEntity
 import com.thebluealliance.android.data.remote.TbaApi
 import com.thebluealliance.android.data.remote.dto.EventInsightsDto
 import com.thebluealliance.android.domain.model.Alliance
 import com.thebluealliance.android.domain.model.Award
 import com.thebluealliance.android.domain.model.CmpAdvancement
 import com.thebluealliance.android.domain.model.Event
-import com.thebluealliance.android.domain.model.EventCOPRs
 import com.thebluealliance.android.domain.model.EventAdvancementPoints
+import com.thebluealliance.android.domain.model.EventCOPRs
 import com.thebluealliance.android.domain.model.EventInsights
 import com.thebluealliance.android.domain.model.EventOPRs
 import com.thebluealliance.android.domain.model.EventRankings
@@ -38,265 +43,320 @@ import javax.inject.Singleton
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @Singleton
-class EventRepository @Inject constructor(
-    private val api: TbaApi,
-    private val db: TBADatabase,
-    private val eventDao: EventDao,
-    private val awardDao: AwardDao,
-    private val rankingDao: RankingDao,
-    private val allianceDao: AllianceDao,
-    private val eventTeamDao: EventTeamDao,
-    private val eventDistrictPointsDao: EventDistrictPointsDao,
-    private val eventOPRsDao: EventOPRsDao,
-    private val eventCOPRsDao: EventCOPRsDao,
-    private val eventInsightsDao: EventInsightsDao,
-    private val eventRankingSortOrderDao: EventRankingSortOrderDao,
-    private val teamEventStatusDao: TeamEventStatusDao,
-) {
-    fun searchEvents(query: String): Flow<List<Event>> =
-        eventDao.search(query).map { list -> list.map { it.toDomain() } }
+class EventRepository
+    @Inject
+    constructor(
+        private val api: TbaApi,
+        private val db: TBADatabase,
+        private val eventDao: EventDao,
+        private val awardDao: AwardDao,
+        private val rankingDao: RankingDao,
+        private val allianceDao: AllianceDao,
+        private val eventTeamDao: EventTeamDao,
+        private val eventDistrictPointsDao: EventDistrictPointsDao,
+        private val eventOPRsDao: EventOPRsDao,
+        private val eventCOPRsDao: EventCOPRsDao,
+        private val eventInsightsDao: EventInsightsDao,
+        private val eventRankingSortOrderDao: EventRankingSortOrderDao,
+        private val teamEventStatusDao: TeamEventStatusDao,
+    ) {
+        fun searchEvents(query: String): Flow<List<Event>> =
+            eventDao.search(query).map { list -> list.map { it.toDomain() } }
 
-    fun observeEventsForYear(year: Int): Flow<List<Event>> =
-        eventDao.observeByYear(year).map { list -> list.map { it.toDomain() } }
+        fun observeEventsForYear(year: Int): Flow<List<Event>> =
+            eventDao.observeByYear(year).map { list -> list.map { it.toDomain() } }
 
-    fun observeEvent(key: String): Flow<Event?> =
-        eventDao.observe(key).map { it?.toDomain() }
+        fun observeEvent(key: String): Flow<Event?> = eventDao.observe(key).map { it?.toDomain() }
 
-    fun observeEventAwards(eventKey: String): Flow<List<Award>> =
-        awardDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
+        fun observeEventAwards(eventKey: String): Flow<List<Award>> =
+            awardDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
 
-    fun observeEventRankings(eventKey: String): Flow<List<Ranking>> =
-        rankingDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
+        fun observeEventRankings(eventKey: String): Flow<List<Ranking>> =
+            rankingDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
 
-    fun observeEventRankingSortOrders(eventKey: String): Flow<List<RankingSortOrder>> =
-        eventRankingSortOrderDao.observe(eventKey).map { entity ->
-            entity?.getSortOrderInfo() ?: emptyList()
-        }
+        fun observeEventRankingSortOrders(eventKey: String): Flow<List<RankingSortOrder>> =
+            eventRankingSortOrderDao.observe(eventKey).map { entity ->
+                entity?.getSortOrderInfo() ?: emptyList()
+            }
 
-    fun observeEventRankingExtraStatsInfo(eventKey: String): Flow<List<RankingSortOrder>> =
-        eventRankingSortOrderDao.observe(eventKey).map { entity ->
-            entity?.getExtraStatsInfo() ?: emptyList()
-        }
+        fun observeEventRankingExtraStatsInfo(eventKey: String): Flow<List<RankingSortOrder>> =
+            eventRankingSortOrderDao.observe(eventKey).map { entity ->
+                entity?.getExtraStatsInfo() ?: emptyList()
+            }
 
-    fun observeEventRankingsWithSortOrders(eventKey: String): Flow<EventRankings?> =
-        rankingDao.observeByEvent(eventKey).flatMapLatest { rankingEntities ->
-            eventRankingSortOrderDao.observe(eventKey).map { sortOrderEntity ->
-                if (rankingEntities.isEmpty() || sortOrderEntity == null) {
-                    null
-                } else {
-                    EventRankings(
-                        rankings = rankingEntities.map { it.toDomain() },
-                        sortOrderInfo = sortOrderEntity.getSortOrderInfo(),
-                        extraStatsInfo = sortOrderEntity.getExtraStatsInfo(),
+        fun observeEventRankingsWithSortOrders(eventKey: String): Flow<EventRankings?> =
+            rankingDao.observeByEvent(eventKey).flatMapLatest { rankingEntities ->
+                eventRankingSortOrderDao.observe(eventKey).map { sortOrderEntity ->
+                    if (rankingEntities.isEmpty() || sortOrderEntity == null) {
+                        null
+                    } else {
+                        EventRankings(
+                            rankings = rankingEntities.map { it.toDomain() },
+                            sortOrderInfo = sortOrderEntity.getSortOrderInfo(),
+                            extraStatsInfo = sortOrderEntity.getExtraStatsInfo(),
+                        )
+                    }
+                }
+            }
+
+        fun observeEventAlliances(eventKey: String): Flow<List<Alliance>> =
+            allianceDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
+
+        fun observeTeamEventKeys(teamKey: String): Flow<List<String>> =
+            eventTeamDao.observeByTeam(teamKey).map { list -> list.map { it.eventKey } }
+
+        fun observeTeamEvents(
+            teamKey: String,
+            year: Int,
+        ): Flow<List<Event>> =
+            eventTeamDao
+                .observeByTeam(teamKey)
+                .map { list ->
+                    list.map { it.eventKey }.filter { it.startsWith(year.toString()) }
+                }.flatMapLatest { keys ->
+                    if (keys.isEmpty()) {
+                        flowOf(emptyList())
+                    } else {
+                        eventDao.observeByKeys(keys).map { entities ->
+                            entities.map { it.toDomain() }
+                        }
+                    }
+                }
+
+        suspend fun refreshTeamEvents(
+            teamKey: String,
+            year: Int,
+        ) {
+            try {
+                val dtos = api.getTeamEvents(teamKey, year)
+                db.withTransaction {
+                    eventDao.insertAll(dtos.map { it.toEntity() })
+                    eventTeamDao.deleteByTeamAndYear(teamKey, year.toString())
+                    eventTeamDao.insertAll(
+                        dtos.map { EventTeamEntity(eventKey = it.key, teamKey = teamKey) },
                     )
                 }
+            } catch (_: Exception) {
             }
         }
 
-    fun observeEventAlliances(eventKey: String): Flow<List<Alliance>> =
-        allianceDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
+        fun observeDistrictEvents(districtKey: String): Flow<List<Event>> =
+            eventDao.observeByDistrict(districtKey).map { list -> list.map { it.toDomain() } }
 
-    fun observeTeamEventKeys(teamKey: String): Flow<List<String>> =
-        eventTeamDao.observeByTeam(teamKey).map { list -> list.map { it.eventKey } }
-
-    fun observeTeamEvents(teamKey: String, year: Int): Flow<List<Event>> =
-        eventTeamDao.observeByTeam(teamKey).map { list ->
-            list.map { it.eventKey }.filter { it.startsWith(year.toString()) }
-        }.flatMapLatest { keys ->
-            if (keys.isEmpty()) flowOf(emptyList())
-            else eventDao.observeByKeys(keys).map { entities -> entities.map { it.toDomain() } }
-        }
-
-    suspend fun refreshTeamEvents(teamKey: String, year: Int) {
-        try {
-            val dtos = api.getTeamEvents(teamKey, year)
-            db.withTransaction {
-                eventDao.insertAll(dtos.map { it.toEntity() })
-                eventTeamDao.deleteByTeamAndYear(teamKey, year.toString())
-                eventTeamDao.insertAll(dtos.map { EventTeamEntity(eventKey = it.key, teamKey = teamKey) })
-            }
-        } catch (_: Exception) { }
-    }
-
-    fun observeDistrictEvents(districtKey: String): Flow<List<Event>> =
-        eventDao.observeByDistrict(districtKey).map { list -> list.map { it.toDomain() } }
-
-    suspend fun refreshDistrictEvents(districtKey: String) {
-        try {
-            val dtos = api.getDistrictEvents(districtKey)
-            db.withTransaction {
-                eventDao.deleteByDistrict(districtKey)
-                eventDao.insertAll(dtos.map { it.toEntity() })
-            }
-        } catch (_: Exception) { }
-    }
-
-    suspend fun refreshEvent(eventKey: String) {
-        val dto = api.getEvent(eventKey)
-        eventDao.insertAll(listOf(dto.toEntity()))
-    }
-
-    suspend fun refreshEventsForYear(year: Int) {
-        val dtos = api.getEventsForYear(year)
-        db.withTransaction {
-            eventDao.deleteByYear(year)
-            eventDao.insertAll(dtos.map { it.toEntity() })
-        }
-    }
-
-    suspend fun refreshEventAwards(eventKey: String) {
-        try {
-            val dtos = api.getEventAwards(eventKey)
-            db.withTransaction {
-                awardDao.deleteByEvent(eventKey)
-                awardDao.insertAll(dtos.flatMap { it.toEntities() })
-            }
-        } catch (_: Exception) { }
-    }
-
-    suspend fun refreshEventRankings(eventKey: String) {
-        try {
-            val response = api.getEventRankings(eventKey)
-            db.withTransaction {
-                rankingDao.deleteByEvent(eventKey)
-                rankingDao.insertAll(response.rankings.map { it.toEntity(eventKey) })
-                eventRankingSortOrderDao.delete(eventKey)
-                eventRankingSortOrderDao.insert(response.toSortOrderEntity(eventKey))
-            }
-        } catch (_: Exception) { }
-    }
-
-    fun observeEventDistrictPoints(eventKey: String): Flow<List<EventAdvancementPoints>> =
-        eventDistrictPointsDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
-
-    suspend fun refreshEventDistrictPoints(eventKey: String) {
-        try {
-            val response = api.getEventDistrictPoints(eventKey)
-            val entities = response.points.map { (teamKey, entry) ->
-                entry.toEntity(eventKey, teamKey)
-            }
-            db.withTransaction {
-                eventDistrictPointsDao.deleteByEvent(eventKey)
-                eventDistrictPointsDao.insertAll(entities)
-            }
-        } catch (_: Exception) { }
-    }
-
-    fun observeEventRegionalPoints(eventKey: String): Flow<List<EventAdvancementPoints>> =
-        eventDistrictPointsDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
-
-    suspend fun refreshEventRegionalPoints(eventKey: String) {
-        try {
-            val response = api.getEventRegionalPoints(eventKey)
-            val entities = response.points.map { (teamKey, entry) ->
-                entry.toEntity(eventKey, teamKey)
-            }
-            db.withTransaction {
-                eventDistrictPointsDao.deleteByEvent(eventKey)
-                eventDistrictPointsDao.insertAll(entities)
-            }
-        } catch (_: Exception) { }
-    }
-
-    suspend fun fetchRegionalCmpAdvancementByTeam(year: Int): Map<String, CmpAdvancement> {
-        val advancements = api.getRegionalAdvancement(year).orEmpty()
-
-        // Pre-load event names for any EventQualified entries
-        val eventKeys = advancements.values
-            .filter { it.cmpStatus == "EventQualified" }
-            .mapNotNull { it.qualifyingEvent }
-            .distinct()
-        val eventsByKey = if (eventKeys.isNotEmpty()) {
-            eventDao.getByKeys(eventKeys).associateBy { it.key }
-        } else {
-            emptyMap()
-        }
-
-        return advancements.mapNotNull { (teamKey, advancement) ->
-            if (!advancement.cmp) return@mapNotNull null
-            val cmpAdv: CmpAdvancement = when (advancement.cmpStatus) {
-                "EventQualified" -> {
-                    val eventKey = advancement.qualifyingEvent ?: ""
-                    val entity = eventsByKey[eventKey]
-                    val shortName = entity?.shortName?.takeIf { it.isNotBlank() }
-                        ?: entity?.name
-                        ?: eventKey.ifBlank { null }
-                    CmpAdvancement.EventQualified(eventKey = eventKey, eventShortName = shortName)
+        suspend fun refreshDistrictEvents(districtKey: String) {
+            try {
+                val dtos = api.getDistrictEvents(districtKey)
+                db.withTransaction {
+                    eventDao.deleteByDistrict(districtKey)
+                    eventDao.insertAll(dtos.map { it.toEntity() })
                 }
-                "PoolQualified" -> CmpAdvancement.PoolQualified(week = advancement.qualifyingPoolWeek ?: 0)
-                else -> CmpAdvancement.Qualified
+            } catch (_: Exception) {
             }
-            teamKey to cmpAdv
-        }.toMap()
-    }
-
-    suspend fun refreshEventAlliances(eventKey: String) {
-        try {
-            val dtos = api.getEventAlliances(eventKey)
-            db.withTransaction {
-                allianceDao.deleteByEvent(eventKey)
-                allianceDao.insertAll(dtos.mapIndexed { index, dto -> dto.toEntity(eventKey, index + 1) })
-            }
-        } catch (_: Exception) { }
-    }
-
-    fun observeEventOPRs(eventKey: String): Flow<EventOPRs?> =
-        eventOPRsDao.observe(eventKey).map { it?.toDomain() }
-
-    suspend fun refreshEventOPRs(eventKey: String) {
-        try {
-            val dto = api.getEventOPRs(eventKey)
-            db.withTransaction {
-                eventOPRsDao.delete(eventKey)
-                eventOPRsDao.insert(dto.toEntity(eventKey))
-            }
-        } catch (_: Exception) { }
-    }
-
-    fun observeEventCOPRs(eventKey: String): Flow<EventCOPRs?> =
-        eventCOPRsDao.observe(eventKey).map { it?.toDomain() }
-
-    suspend fun refreshEventCOPRs(eventKey: String) {
-        try {
-            val dto = api.getEventCOPRs(eventKey)
-            db.withTransaction {
-                eventCOPRsDao.delete(eventKey)
-                eventCOPRsDao.insert(dto.toEntity(eventKey))
-            }
-        } catch (_: Exception) { }
-    }
-
-    fun observeEventInsights(eventKey: String): Flow<EventInsights?> =
-        eventInsightsDao.observe(eventKey).map { it?.toDomain() }
-
-    suspend fun refreshEventInsights(eventKey: String) {
-        try {
-            val insights = api.getEventInsights(eventKey)
-            val dto = EventInsightsDto(
-                qual = insights["qual"]?.toString(),
-                playoff = insights["playoff"]?.toString(),
-            )
-            db.withTransaction {
-                eventInsightsDao.delete(eventKey)
-                eventInsightsDao.insert(dto.toEntity(eventKey))
-            }
-        } catch (_: Exception) { }
-    }
-
-    fun observeEventPitLocations(eventKey: String): Flow<Map<String, String>> =
-        teamEventStatusDao.observeByEvent(eventKey).map { list ->
-            list.mapNotNull { entity ->
-                entity.pitLocation?.let { entity.teamKey to it }
-            }.toMap()
         }
 
-    suspend fun refreshEventPitLocations(eventKey: String) {
-        try {
-            val statuses = api.getEventTeamsStatuses(eventKey)
-            val entities = statuses.map { (teamKey, status) ->
-                TeamEventStatusEntity(teamKey, eventKey, status?.pitLocation)
+        suspend fun refreshEvent(eventKey: String) {
+            val dto = api.getEvent(eventKey)
+            eventDao.insertAll(listOf(dto.toEntity()))
+        }
+
+        suspend fun refreshEventsForYear(year: Int) {
+            val dtos = api.getEventsForYear(year)
+            db.withTransaction {
+                eventDao.deleteByYear(year)
+                eventDao.insertAll(dtos.map { it.toEntity() })
             }
-            teamEventStatusDao.insertAll(entities)
-        } catch (_: Exception) { }
+        }
+
+        suspend fun refreshEventAwards(eventKey: String) {
+            try {
+                val dtos = api.getEventAwards(eventKey)
+                db.withTransaction {
+                    awardDao.deleteByEvent(eventKey)
+                    awardDao.insertAll(dtos.flatMap { it.toEntities() })
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        suspend fun refreshEventRankings(eventKey: String) {
+            try {
+                val response = api.getEventRankings(eventKey)
+                db.withTransaction {
+                    rankingDao.deleteByEvent(eventKey)
+                    rankingDao.insertAll(response.rankings.map { it.toEntity(eventKey) })
+                    eventRankingSortOrderDao.delete(eventKey)
+                    eventRankingSortOrderDao.insert(response.toSortOrderEntity(eventKey))
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        fun observeEventDistrictPoints(eventKey: String): Flow<List<EventAdvancementPoints>> =
+            eventDistrictPointsDao.observeByEvent(eventKey).map { list ->
+                list.map { it.toDomain() }
+            }
+
+        suspend fun refreshEventDistrictPoints(eventKey: String) {
+            try {
+                val response = api.getEventDistrictPoints(eventKey)
+                val entities =
+                    response.points.map { (teamKey, entry) ->
+                        entry.toEntity(eventKey, teamKey)
+                    }
+                db.withTransaction {
+                    eventDistrictPointsDao.deleteByEvent(eventKey)
+                    eventDistrictPointsDao.insertAll(entities)
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        fun observeEventRegionalPoints(eventKey: String): Flow<List<EventAdvancementPoints>> =
+            eventDistrictPointsDao.observeByEvent(eventKey).map { list ->
+                list.map { it.toDomain() }
+            }
+
+        suspend fun refreshEventRegionalPoints(eventKey: String) {
+            try {
+                val response = api.getEventRegionalPoints(eventKey)
+                val entities =
+                    response.points.map { (teamKey, entry) ->
+                        entry.toEntity(eventKey, teamKey)
+                    }
+                db.withTransaction {
+                    eventDistrictPointsDao.deleteByEvent(eventKey)
+                    eventDistrictPointsDao.insertAll(entities)
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        suspend fun fetchRegionalCmpAdvancementByTeam(year: Int): Map<String, CmpAdvancement> {
+            val advancements = api.getRegionalAdvancement(year).orEmpty()
+
+            // Pre-load event names for any EventQualified entries
+            val eventKeys =
+                advancements.values
+                    .filter { it.cmpStatus == "EventQualified" }
+                    .mapNotNull { it.qualifyingEvent }
+                    .distinct()
+            val eventsByKey =
+                if (eventKeys.isNotEmpty()) {
+                    eventDao.getByKeys(eventKeys).associateBy { it.key }
+                } else {
+                    emptyMap()
+                }
+
+            return advancements
+                .mapNotNull { (teamKey, advancement) ->
+                    if (!advancement.cmp) return@mapNotNull null
+                    val cmpAdv: CmpAdvancement =
+                        when (advancement.cmpStatus) {
+                            "EventQualified" -> {
+                                val eventKey = advancement.qualifyingEvent ?: ""
+                                val entity = eventsByKey[eventKey]
+                                val shortName =
+                                    entity?.shortName?.takeIf { it.isNotBlank() }
+                                        ?: entity?.name
+                                        ?: eventKey.ifBlank { null }
+                                CmpAdvancement.EventQualified(
+                                    eventKey = eventKey,
+                                    eventShortName = shortName,
+                                )
+                            }
+                            "PoolQualified" ->
+                                CmpAdvancement.PoolQualified(
+                                    week =
+                                        advancement.qualifyingPoolWeek ?: 0,
+                                )
+                            else -> CmpAdvancement.Qualified
+                        }
+                    teamKey to cmpAdv
+                }.toMap()
+        }
+
+        suspend fun refreshEventAlliances(eventKey: String) {
+            try {
+                val dtos = api.getEventAlliances(eventKey)
+                db.withTransaction {
+                    allianceDao.deleteByEvent(eventKey)
+                    allianceDao.insertAll(
+                        dtos.mapIndexed { index, dto ->
+                            dto.toEntity(
+                                eventKey,
+                                index + 1,
+                            )
+                        },
+                    )
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        fun observeEventOPRs(eventKey: String): Flow<EventOPRs?> =
+            eventOPRsDao.observe(eventKey).map { it?.toDomain() }
+
+        suspend fun refreshEventOPRs(eventKey: String) {
+            try {
+                val dto = api.getEventOPRs(eventKey)
+                db.withTransaction {
+                    eventOPRsDao.delete(eventKey)
+                    eventOPRsDao.insert(dto.toEntity(eventKey))
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        fun observeEventCOPRs(eventKey: String): Flow<EventCOPRs?> =
+            eventCOPRsDao.observe(eventKey).map { it?.toDomain() }
+
+        suspend fun refreshEventCOPRs(eventKey: String) {
+            try {
+                val dto = api.getEventCOPRs(eventKey)
+                db.withTransaction {
+                    eventCOPRsDao.delete(eventKey)
+                    eventCOPRsDao.insert(dto.toEntity(eventKey))
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        fun observeEventInsights(eventKey: String): Flow<EventInsights?> =
+            eventInsightsDao.observe(eventKey).map { it?.toDomain() }
+
+        suspend fun refreshEventInsights(eventKey: String) {
+            try {
+                val insights = api.getEventInsights(eventKey)
+                val dto =
+                    EventInsightsDto(
+                        qual = insights["qual"]?.toString(),
+                        playoff = insights["playoff"]?.toString(),
+                    )
+                db.withTransaction {
+                    eventInsightsDao.delete(eventKey)
+                    eventInsightsDao.insert(dto.toEntity(eventKey))
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        fun observeEventPitLocations(eventKey: String): Flow<Map<String, String>> =
+            teamEventStatusDao.observeByEvent(eventKey).map { list ->
+                list
+                    .mapNotNull { entity ->
+                        entity.pitLocation?.let { entity.teamKey to it }
+                    }.toMap()
+            }
+
+        suspend fun refreshEventPitLocations(eventKey: String) {
+            try {
+                val statuses = api.getEventTeamsStatuses(eventKey)
+                val entities =
+                    statuses.map { (teamKey, status) ->
+                        TeamEventStatusEntity(teamKey, eventKey, status?.pitLocation)
+                    }
+                teamEventStatusDao.insertAll(entities)
+            } catch (_: Exception) {
+            }
+        }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/MatchRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/MatchRepository.kt
@@ -13,31 +13,34 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class MatchRepository @Inject constructor(
-    private val api: TbaApi,
-    private val db: TBADatabase,
-    private val matchDao: MatchDao,
-) {
-    fun observeEventMatches(eventKey: String): Flow<List<Match>> =
-        matchDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
+class MatchRepository
+    @Inject
+    constructor(
+        private val api: TbaApi,
+        private val db: TBADatabase,
+        private val matchDao: MatchDao,
+    ) {
+        fun observeEventMatches(eventKey: String): Flow<List<Match>> =
+            matchDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
 
-    fun observeMatch(key: String): Flow<Match?> =
-        matchDao.observe(key).map { it?.toDomain() }
+        fun observeMatch(key: String): Flow<Match?> = matchDao.observe(key).map { it?.toDomain() }
 
-    suspend fun refreshMatch(matchKey: String) {
-        try {
-            val dto = api.getMatch(matchKey)
-            matchDao.insertAll(listOf(dto.toEntity()))
-        } catch (_: Exception) { }
-    }
-
-    suspend fun refreshEventMatches(eventKey: String) {
-        try {
-            val dtos = api.getEventMatches(eventKey)
-            db.withTransaction {
-                matchDao.deleteByEvent(eventKey)
-                matchDao.insertAll(dtos.map { it.toEntity() })
+        suspend fun refreshMatch(matchKey: String) {
+            try {
+                val dto = api.getMatch(matchKey)
+                matchDao.insertAll(listOf(dto.toEntity()))
+            } catch (_: Exception) {
             }
-        } catch (_: Exception) { }
+        }
+
+        suspend fun refreshEventMatches(eventKey: String) {
+            try {
+                val dtos = api.getEventMatches(eventKey)
+                db.withTransaction {
+                    matchDao.deleteByEvent(eventKey)
+                    matchDao.insertAll(dtos.map { it.toEntity() })
+                }
+            } catch (_: Exception) {
+            }
+        }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/MyTBARepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/MyTBARepository.kt
@@ -17,136 +17,182 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class MyTBARepository @Inject constructor(
-    private val db: TBADatabase,
-    private val clientApi: ClientApi,
-    private val favoriteDao: FavoriteDao,
-    private val subscriptionDao: SubscriptionDao,
-    private val deviceRegistrationManager: com.thebluealliance.android.messaging.DeviceRegistrationManager,
-) {
-    fun observeFavorites(): Flow<List<Favorite>> =
-        favoriteDao.observeAll().map { list ->
-            list.map { Favorite(modelKey = it.modelKey, modelType = it.modelType) }
-        }
-
-    fun isFavorite(modelKey: String, modelType: Int): Flow<Boolean> =
-        favoriteDao.isFavorite(modelKey, modelType)
-
-    fun observeSubscriptions(): Flow<List<Subscription>> =
-        subscriptionDao.observeAll().map { list ->
-            list.map {
-                Subscription(
-                    modelKey = it.modelKey,
-                    modelType = it.modelType,
-                    notifications = it.notifications.split(",").filter { n -> n.isNotEmpty() },
-                )
-            }
-        }
-
-    fun observeSubscription(modelKey: String, modelType: Int): Flow<Subscription?> =
-        subscriptionDao.observe(modelKey, modelType).map { entity ->
-            entity?.let {
-                Subscription(
-                    modelKey = it.modelKey,
-                    modelType = it.modelType,
-                    notifications = it.notifications.split(",").filter { n -> n.isNotEmpty() },
-                )
-            }
-        }
-
-    suspend fun refreshFavorites() {
-        val response = clientApi.listFavorites()
-        Log.d("MyTBARepository", "refreshFavorites: code=${response.code} message=${response.message} favorites=${response.favorites.size}")
-        if (response.code == 401) {
-            throw MyTBAServerException(response.code, response.message)
-        }
-        db.withTransaction {
-            favoriteDao.deleteAll()
-            favoriteDao.insertAll(response.favorites.map {
-                FavoriteEntity(modelKey = it.modelKey, modelType = it.modelType)
-            })
-        }
-    }
-
-    suspend fun refreshSubscriptions() {
-        val response = clientApi.listSubscriptions()
-        if (response.code == 401) {
-            throw MyTBAServerException(response.code, response.message)
-        }
-        db.withTransaction {
-            subscriptionDao.deleteAll()
-            subscriptionDao.insertAll(response.subscriptions.map {
-                SubscriptionEntity(
-                    modelKey = it.modelKey,
-                    modelType = it.modelType,
-                    notifications = it.notifications.joinToString(","),
-                )
-            })
-        }
-    }
-
-    suspend fun addFavorite(modelKey: String, modelType: Int) {
-        val response = clientApi.updateModelPreferences(
-            ModelPreferenceRequestDto(
-                modelKey = modelKey,
-                modelType = modelType,
-                deviceKey = deviceRegistrationManager.deviceUuid,
-                favorite = true,
-            )
-        )
-        Log.d("MyTBARepository", "addFavorite: code=${response.code} message=${response.message}")
-        if (response.code == 401) {
-            try { refreshFavorites() } catch (_: Exception) { }
-            throw MyTBAServerException(response.code, response.message)
-        }
-        favoriteDao.insertAll(listOf(FavoriteEntity(modelKey = modelKey, modelType = modelType)))
-    }
-
-    suspend fun removeFavorite(modelKey: String, modelType: Int) {
-        val response = clientApi.updateModelPreferences(
-            ModelPreferenceRequestDto(
-                modelKey = modelKey,
-                modelType = modelType,
-                deviceKey = deviceRegistrationManager.deviceUuid,
-                favorite = false,
-            )
-        )
-        if (response.code == 401) {
-            try { refreshFavorites() } catch (_: Exception) { }
-            throw MyTBAServerException(response.code, response.message)
-        }
-        favoriteDao.delete(modelKey, modelType)
-    }
-
-    suspend fun updatePreferences(
-        modelKey: String,
-        modelType: Int,
-        favorite: Boolean,
-        notifications: List<String>,
+class MyTBARepository
+    @Inject
+    constructor(
+        private val db: TBADatabase,
+        private val clientApi: ClientApi,
+        private val favoriteDao: FavoriteDao,
+        private val subscriptionDao: SubscriptionDao,
+        private val deviceRegistrationManager:
+            com.thebluealliance.android.messaging.DeviceRegistrationManager,
     ) {
-        val response = clientApi.updateModelPreferences(
-            ModelPreferenceRequestDto(
-                modelKey = modelKey,
-                modelType = modelType,
-                deviceKey = deviceRegistrationManager.deviceUuid,
-                favorite = favorite,
-                notifications = notifications,
+        fun observeFavorites(): Flow<List<Favorite>> =
+            favoriteDao.observeAll().map { list ->
+                list.map { Favorite(modelKey = it.modelKey, modelType = it.modelType) }
+            }
+
+        fun isFavorite(
+            modelKey: String,
+            modelType: Int,
+        ): Flow<Boolean> = favoriteDao.isFavorite(modelKey, modelType)
+
+        fun observeSubscriptions(): Flow<List<Subscription>> =
+            subscriptionDao.observeAll().map { list ->
+                list.map {
+                    Subscription(
+                        modelKey = it.modelKey,
+                        modelType = it.modelType,
+                        notifications = it.notifications.split(",").filter { n -> n.isNotEmpty() },
+                    )
+                }
+            }
+
+        fun observeSubscription(
+            modelKey: String,
+            modelType: Int,
+        ): Flow<Subscription?> =
+            subscriptionDao.observe(modelKey, modelType).map { entity ->
+                entity?.let {
+                    Subscription(
+                        modelKey = it.modelKey,
+                        modelType = it.modelType,
+                        notifications = it.notifications.split(",").filter { n -> n.isNotEmpty() },
+                    )
+                }
+            }
+
+        suspend fun refreshFavorites() {
+            val response = clientApi.listFavorites()
+            Log.d(
+                "MyTBARepository",
+                "refreshFavorites: code=${response.code} message=${response.message} favorites=${response.favorites.size}",
             )
-        )
-        Log.d("MyTBARepository", "updatePreferences: code=${response.code} message=${response.message}")
-        if (response.code == 401) {
-            throw MyTBAServerException(response.code, response.message)
+            if (response.code == 401) {
+                throw MyTBAServerException(response.code, response.message)
+            }
+            db.withTransaction {
+                favoriteDao.deleteAll()
+                favoriteDao.insertAll(
+                    response.favorites.map {
+                        FavoriteEntity(modelKey = it.modelKey, modelType = it.modelType)
+                    },
+                )
+            }
         }
-        // Refresh both to sync local state with server
-        try { refreshFavorites() } catch (_: Exception) {}
-        try { refreshSubscriptions() } catch (_: Exception) {}
+
+        suspend fun refreshSubscriptions() {
+            val response = clientApi.listSubscriptions()
+            if (response.code == 401) {
+                throw MyTBAServerException(response.code, response.message)
+            }
+            db.withTransaction {
+                subscriptionDao.deleteAll()
+                subscriptionDao.insertAll(
+                    response.subscriptions.map {
+                        SubscriptionEntity(
+                            modelKey = it.modelKey,
+                            modelType = it.modelType,
+                            notifications = it.notifications.joinToString(","),
+                        )
+                    },
+                )
+            }
+        }
+
+        suspend fun addFavorite(
+            modelKey: String,
+            modelType: Int,
+        ) {
+            val response =
+                clientApi.updateModelPreferences(
+                    ModelPreferenceRequestDto(
+                        modelKey = modelKey,
+                        modelType = modelType,
+                        deviceKey = deviceRegistrationManager.deviceUuid,
+                        favorite = true,
+                    ),
+                )
+            Log.d(
+                "MyTBARepository",
+                "addFavorite: code=${response.code} message=${response.message}",
+            )
+            if (response.code == 401) {
+                try {
+                    refreshFavorites()
+                } catch (_: Exception) {
+                }
+                throw MyTBAServerException(response.code, response.message)
+            }
+            favoriteDao.insertAll(
+                listOf(FavoriteEntity(modelKey = modelKey, modelType = modelType)),
+            )
+        }
+
+        suspend fun removeFavorite(
+            modelKey: String,
+            modelType: Int,
+        ) {
+            val response =
+                clientApi.updateModelPreferences(
+                    ModelPreferenceRequestDto(
+                        modelKey = modelKey,
+                        modelType = modelType,
+                        deviceKey = deviceRegistrationManager.deviceUuid,
+                        favorite = false,
+                    ),
+                )
+            if (response.code == 401) {
+                try {
+                    refreshFavorites()
+                } catch (_: Exception) {
+                }
+                throw MyTBAServerException(response.code, response.message)
+            }
+            favoriteDao.delete(modelKey, modelType)
+        }
+
+        suspend fun updatePreferences(
+            modelKey: String,
+            modelType: Int,
+            favorite: Boolean,
+            notifications: List<String>,
+        ) {
+            val response =
+                clientApi.updateModelPreferences(
+                    ModelPreferenceRequestDto(
+                        modelKey = modelKey,
+                        modelType = modelType,
+                        deviceKey = deviceRegistrationManager.deviceUuid,
+                        favorite = favorite,
+                        notifications = notifications,
+                    ),
+                )
+            Log.d(
+                "MyTBARepository",
+                "updatePreferences: code=${response.code} message=${response.message}",
+            )
+            if (response.code == 401) {
+                throw MyTBAServerException(response.code, response.message)
+            }
+            // Refresh both to sync local state with server
+            try {
+                refreshFavorites()
+            } catch (_: Exception) {
+            }
+            try {
+                refreshSubscriptions()
+            } catch (_: Exception) {
+            }
+        }
+
+        suspend fun clearLocal() {
+            favoriteDao.deleteAll()
+            subscriptionDao.deleteAll()
+        }
     }
 
-    suspend fun clearLocal() {
-        favoriteDao.deleteAll()
-        subscriptionDao.deleteAll()
-    }
-}
-
-class MyTBAServerException(val code: Int, override val message: String) :
-    Exception("MyTBA server error $code: $message")
+class MyTBAServerException(
+    val code: Int,
+    override val message: String,
+) : Exception("MyTBA server error $code: $message")

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/RegionalAdvancementRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/RegionalAdvancementRepository.kt
@@ -7,17 +7,19 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class RegionalAdvancementRepository @Inject constructor(
-    private val api: TbaApi,
-) {
-    suspend fun getRegionalRankings(year: Int): List<RegionalRanking> {
-        val rankings = api.getRegionalAdvancementRankings(year).orEmpty()
-        val advancements = api.getRegionalAdvancement(year).orEmpty()
+class RegionalAdvancementRepository
+    @Inject
+    constructor(
+        private val api: TbaApi,
+    ) {
+        suspend fun getRegionalRankings(year: Int): List<RegionalRanking> {
+            val rankings = api.getRegionalAdvancementRankings(year).orEmpty()
+            val advancements = api.getRegionalAdvancement(year).orEmpty()
 
-        return rankings.map { ranking ->
-            val advancement = advancements[ranking.teamKey]
-            ranking.toDomain(year, advancement?.cmpStatus)
-        }.sortedBy { it.rank }
+            return rankings
+                .map { ranking ->
+                    val advancement = advancements[ranking.teamKey]
+                    ranking.toDomain(year, advancement?.cmpStatus)
+                }.sortedBy { it.rank }
+        }
     }
-}
-

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/TeamRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/TeamRepository.kt
@@ -19,70 +19,86 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class TeamRepository @Inject constructor(
-    private val api: TbaApi,
-    private val db: TBADatabase,
-    private val teamDao: TeamDao,
-    private val mediaDao: MediaDao,
-    private val eventTeamDao: EventTeamDao,
-    private val teamEventStatusDao: TeamEventStatusDao,
-) {
-    fun searchTeams(query: String): Flow<List<Team>> =
-        teamDao.search(query).map { list -> list.map { it.toDomain() } }
+class TeamRepository
+    @Inject
+    constructor(
+        private val api: TbaApi,
+        private val db: TBADatabase,
+        private val teamDao: TeamDao,
+        private val mediaDao: MediaDao,
+        private val eventTeamDao: EventTeamDao,
+        private val teamEventStatusDao: TeamEventStatusDao,
+    ) {
+        fun searchTeams(query: String): Flow<List<Team>> =
+            teamDao.search(query).map { list -> list.map { it.toDomain() } }
 
-    fun observeAllTeams(): Flow<List<Team>> =
-        teamDao.observeAll().map { list -> list.map { it.toDomain() } }
+        fun observeAllTeams(): Flow<List<Team>> =
+            teamDao.observeAll().map { list -> list.map { it.toDomain() } }
 
-    fun observeTeam(key: String): Flow<Team?> =
-        teamDao.observe(key).map { it?.toDomain() }
+        fun observeTeam(key: String): Flow<Team?> = teamDao.observe(key).map { it?.toDomain() }
 
-    fun observeTeams(keys: List<String>): Flow<List<Team>> =
-        teamDao.observeByKeys(keys).map { list -> list.map { it.toDomain() } }
+        fun observeTeams(keys: List<String>): Flow<List<Team>> =
+            teamDao.observeByKeys(keys).map { list -> list.map { it.toDomain() } }
 
-    fun observeTeamMedia(teamKey: String, year: Int): Flow<List<Media>> =
-        mediaDao.observeByTeamYear(teamKey, year).map { list -> list.map { it.toDomain() } }
+        fun observeTeamMedia(
+            teamKey: String,
+            year: Int,
+        ): Flow<List<Media>> =
+            mediaDao.observeByTeamYear(teamKey, year).map { list -> list.map { it.toDomain() } }
 
-    /** @return number of teams fetched */
-    suspend fun refreshTeamsPage(page: Int): Int {
-        val dtos = api.getTeams(page)
-        teamDao.insertAll(dtos.map { it.toEntity() })
-        return dtos.size
-    }
+        /** @return number of teams fetched */
+        suspend fun refreshTeamsPage(page: Int): Int {
+            val dtos = api.getTeams(page)
+            teamDao.insertAll(dtos.map { it.toEntity() })
+            return dtos.size
+        }
 
-    fun observeEventTeamKeys(eventKey: String): Flow<List<String>> =
-        eventTeamDao.observeByEvent(eventKey).map { list -> list.map { it.teamKey } }
+        fun observeEventTeamKeys(eventKey: String): Flow<List<String>> =
+            eventTeamDao.observeByEvent(eventKey).map { list -> list.map { it.teamKey } }
 
-    suspend fun refreshEventTeams(eventKey: String) {
-        try {
-            val dtos = api.getEventTeams(eventKey)
-            db.withTransaction {
-                teamDao.insertAll(dtos.map { it.toEntity() })
-                eventTeamDao.deleteByEvent(eventKey)
-                eventTeamDao.insertAll(dtos.map { EventTeamEntity(eventKey = eventKey, teamKey = it.key) })
+        suspend fun refreshEventTeams(eventKey: String) {
+            try {
+                val dtos = api.getEventTeams(eventKey)
+                db.withTransaction {
+                    teamDao.insertAll(dtos.map { it.toEntity() })
+                    eventTeamDao.deleteByEvent(eventKey)
+                    eventTeamDao.insertAll(
+                        dtos.map { EventTeamEntity(eventKey = eventKey, teamKey = it.key) },
+                    )
+                }
+            } catch (_: Exception) {
             }
-        } catch (_: Exception) { }
-    }
+        }
 
-    suspend fun refreshTeam(teamKey: String) {
-        val dto = api.getTeam(teamKey)
-        teamDao.insertAll(listOf(dto.toEntity()))
-    }
+        suspend fun refreshTeam(teamKey: String) {
+            val dto = api.getTeam(teamKey)
+            teamDao.insertAll(listOf(dto.toEntity()))
+        }
 
-    suspend fun refreshTeamMedia(teamKey: String, year: Int) {
-        val dtos = api.getTeamMedia(teamKey, year)
-        db.withTransaction {
-            mediaDao.deleteByTeamYear(teamKey, year)
-            mediaDao.insertAll(dtos.map { it.toEntity(teamKey, year) })
+        suspend fun refreshTeamMedia(
+            teamKey: String,
+            year: Int,
+        ) {
+            val dtos = api.getTeamMedia(teamKey, year)
+            db.withTransaction {
+                mediaDao.deleteByTeamYear(teamKey, year)
+                mediaDao.insertAll(dtos.map { it.toEntity(teamKey, year) })
+            }
+        }
+
+        fun observeTeamEventPitLocation(
+            teamKey: String,
+            eventKey: String,
+        ): Flow<String?> = teamEventStatusDao.observe(teamKey, eventKey).map { it?.pitLocation }
+
+        suspend fun refreshTeamEventPitLocation(
+            teamKey: String,
+            eventKey: String,
+        ) {
+            try {
+                val pitLocation = api.getTeamEventStatus(teamKey, eventKey)?.pitLocation
+                teamEventStatusDao.insert(TeamEventStatusEntity(teamKey, eventKey, pitLocation))
+            } catch (_: Exception) {
+            }
         }
     }
-
-    fun observeTeamEventPitLocation(teamKey: String, eventKey: String): Flow<String?> =
-        teamEventStatusDao.observe(teamKey, eventKey).map { it?.pitLocation }
-
-    suspend fun refreshTeamEventPitLocation(teamKey: String, eventKey: String) {
-        try {
-            val pitLocation = api.getTeamEventStatus(teamKey, eventKey)?.pitLocation
-            teamEventStatusDao.insert(TeamEventStatusEntity(teamKey, eventKey, pitLocation))
-        } catch (_: Exception) { }
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/data/sync/DataSyncManager.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/sync/DataSyncManager.kt
@@ -10,69 +10,71 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class DataSyncManager @Inject constructor(
-    private val api: TbaApi,
-    private val eventDao: EventDao,
-    private val teamDao: TeamDao,
-    private val eventRepository: EventRepository,
-    private val teamRepository: TeamRepository,
-) {
-    companion object {
-        private const val TAG = "DataSyncManager"
-        private const val FIRST_EVENT_YEAR = 1992
-        private const val TEAM_COUNT_THRESHOLD = 500
-    }
-
-    suspend fun syncIfNeeded() {
-        try {
-            val status = api.getStatus()
-            syncEvents(status.maxSeason)
-            syncTeams()
-        } catch (e: Exception) {
-            Log.e(TAG, "Sync failed to get API status", e)
-        }
-    }
-
-    private suspend fun syncEvents(maxSeason: Int) {
-        val loadedYears = eventDao.getLoadedYears().toSet()
-        val allYears = FIRST_EVENT_YEAR..maxSeason
-        val missingYears = allYears.filter { it !in loadedYears }
-
-        if (missingYears.isEmpty()) {
-            Log.d(TAG, "All event years already loaded")
-            return
+class DataSyncManager
+    @Inject
+    constructor(
+        private val api: TbaApi,
+        private val eventDao: EventDao,
+        private val teamDao: TeamDao,
+        private val eventRepository: EventRepository,
+        private val teamRepository: TeamRepository,
+    ) {
+        companion object {
+            private const val TAG = "DataSyncManager"
+            private const val FIRST_EVENT_YEAR = 1992
+            private const val TEAM_COUNT_THRESHOLD = 500
         }
 
-        Log.d(TAG, "Syncing ${missingYears.size} missing event years")
-        for (year in missingYears) {
+        suspend fun syncIfNeeded() {
             try {
-                eventRepository.refreshEventsForYear(year)
-                Log.d(TAG, "Synced events for $year")
+                val status = api.getStatus()
+                syncEvents(status.maxSeason)
+                syncTeams()
             } catch (e: Exception) {
-                Log.w(TAG, "Failed to sync events for $year", e)
+                Log.e(TAG, "Sync failed to get API status", e)
+            }
+        }
+
+        private suspend fun syncEvents(maxSeason: Int) {
+            val loadedYears = eventDao.getLoadedYears().toSet()
+            val allYears = FIRST_EVENT_YEAR..maxSeason
+            val missingYears = allYears.filter { it !in loadedYears }
+
+            if (missingYears.isEmpty()) {
+                Log.d(TAG, "All event years already loaded")
+                return
+            }
+
+            Log.d(TAG, "Syncing ${missingYears.size} missing event years")
+            for (year in missingYears) {
+                try {
+                    eventRepository.refreshEventsForYear(year)
+                    Log.d(TAG, "Synced events for $year")
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to sync events for $year", e)
+                }
+            }
+        }
+
+        private suspend fun syncTeams() {
+            val teamCount = teamDao.getCount()
+            if (teamCount >= TEAM_COUNT_THRESHOLD) {
+                Log.d(TAG, "Teams already loaded ($teamCount)")
+                return
+            }
+
+            Log.d(TAG, "Syncing teams ($teamCount below threshold)")
+            var page = 0
+            while (true) {
+                try {
+                    val count = teamRepository.refreshTeamsPage(page)
+                    Log.d(TAG, "Synced teams page $page ($count teams)")
+                    if (count == 0) break
+                    page++
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to sync teams page $page", e)
+                    break
+                }
             }
         }
     }
-
-    private suspend fun syncTeams() {
-        val teamCount = teamDao.getCount()
-        if (teamCount >= TEAM_COUNT_THRESHOLD) {
-            Log.d(TAG, "Teams already loaded ($teamCount)")
-            return
-        }
-
-        Log.d(TAG, "Syncing teams ($teamCount below threshold)")
-        var page = 0
-        while (true) {
-            try {
-                val count = teamRepository.refreshTeamsPage(page)
-                Log.d(TAG, "Synced teams page $page ($count teams)")
-                if (count == 0) break
-                page++
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to sync teams page $page", e)
-                break
-            }
-        }
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/di/AuthModule.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/di/AuthModule.kt
@@ -11,7 +11,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object AuthModule {
-
     @Provides
     @Singleton
     fun provideFirebaseAuth(): FirebaseAuth {

--- a/app/src/main/kotlin/com/thebluealliance/android/di/ConfigModule.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/di/ConfigModule.kt
@@ -18,19 +18,19 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 @Module
 @InstallIn(SingletonComponent::class)
 object ConfigModule {
+    @Provides
+    @Singleton
+    fun provideSharedPreferences(
+        @ApplicationContext context: Context,
+    ): SharedPreferences = context.getSharedPreferences("tba_config", Context.MODE_PRIVATE)
 
     @Provides
     @Singleton
-    fun provideSharedPreferences(@ApplicationContext context: Context): SharedPreferences =
-        context.getSharedPreferences("tba_config", Context.MODE_PRIVATE)
+    fun provideFirebaseRemoteConfig(): FirebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
 
     @Provides
     @Singleton
-    fun provideFirebaseRemoteConfig(): FirebaseRemoteConfig =
-        FirebaseRemoteConfig.getInstance()
-
-    @Provides
-    @Singleton
-    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
-        context.dataStore
+    fun provideDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> = context.dataStore
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/di/DatabaseModule.kt
@@ -3,7 +3,24 @@ package com.thebluealliance.android.di
 import android.content.Context
 import androidx.room.Room
 import com.thebluealliance.android.data.local.TBADatabase
-import com.thebluealliance.android.data.local.dao.*
+import com.thebluealliance.android.data.local.dao.AllianceDao
+import com.thebluealliance.android.data.local.dao.AwardDao
+import com.thebluealliance.android.data.local.dao.DistrictDao
+import com.thebluealliance.android.data.local.dao.DistrictRankingDao
+import com.thebluealliance.android.data.local.dao.EventCOPRsDao
+import com.thebluealliance.android.data.local.dao.EventDao
+import com.thebluealliance.android.data.local.dao.EventDistrictPointsDao
+import com.thebluealliance.android.data.local.dao.EventInsightsDao
+import com.thebluealliance.android.data.local.dao.EventOPRsDao
+import com.thebluealliance.android.data.local.dao.EventRankingSortOrderDao
+import com.thebluealliance.android.data.local.dao.EventTeamDao
+import com.thebluealliance.android.data.local.dao.FavoriteDao
+import com.thebluealliance.android.data.local.dao.MatchDao
+import com.thebluealliance.android.data.local.dao.MediaDao
+import com.thebluealliance.android.data.local.dao.RankingDao
+import com.thebluealliance.android.data.local.dao.SubscriptionDao
+import com.thebluealliance.android.data.local.dao.TeamDao
+import com.thebluealliance.android.data.local.dao.TeamEventStatusDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -14,30 +31,55 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object DatabaseModule {
-
     @Provides
     @Singleton
-    fun provideDatabase(@ApplicationContext context: Context): TBADatabase =
-        Room.databaseBuilder(context, TBADatabase::class.java, "tba.db")
+    fun provideDatabase(
+        @ApplicationContext context: Context,
+    ): TBADatabase =
+        Room
+            .databaseBuilder(context, TBADatabase::class.java, "tba.db")
             .fallbackToDestructiveMigration(dropAllTables = true)
             .build()
 
     @Provides fun provideTeamDao(db: TBADatabase): TeamDao = db.teamDao()
+
     @Provides fun provideEventDao(db: TBADatabase): EventDao = db.eventDao()
+
     @Provides fun provideMatchDao(db: TBADatabase): MatchDao = db.matchDao()
+
     @Provides fun provideAwardDao(db: TBADatabase): AwardDao = db.awardDao()
+
     @Provides fun provideRankingDao(db: TBADatabase): RankingDao = db.rankingDao()
-    @Provides fun provideEventRankingSortOrderDao(db: TBADatabase): EventRankingSortOrderDao = db.eventRankingSortOrderDao()
+
+    @Provides fun provideEventRankingSortOrderDao(db: TBADatabase): EventRankingSortOrderDao =
+        db.eventRankingSortOrderDao()
+
     @Provides fun provideAllianceDao(db: TBADatabase): AllianceDao = db.allianceDao()
+
     @Provides fun provideDistrictDao(db: TBADatabase): DistrictDao = db.districtDao()
-    @Provides fun provideDistrictRankingDao(db: TBADatabase): DistrictRankingDao = db.districtRankingDao()
+
+    @Provides fun provideDistrictRankingDao(db: TBADatabase): DistrictRankingDao =
+        db
+            .districtRankingDao()
+
     @Provides fun provideMediaDao(db: TBADatabase): MediaDao = db.mediaDao()
+
     @Provides fun provideEventTeamDao(db: TBADatabase): EventTeamDao = db.eventTeamDao()
+
     @Provides fun provideFavoriteDao(db: TBADatabase): FavoriteDao = db.favoriteDao()
+
     @Provides fun provideSubscriptionDao(db: TBADatabase): SubscriptionDao = db.subscriptionDao()
-    @Provides fun provideEventDistrictPointsDao(db: TBADatabase): EventDistrictPointsDao = db.eventDistrictPointsDao()
+
+    @Provides fun provideEventDistrictPointsDao(db: TBADatabase): EventDistrictPointsDao =
+        db.eventDistrictPointsDao()
+
     @Provides fun provideEventOPRsDao(db: TBADatabase): EventOPRsDao = db.eventOPRsDao()
+
     @Provides fun provideEventCOPRsDao(db: TBADatabase): EventCOPRsDao = db.eventCOPRsDao()
+
     @Provides fun provideEventInsightsDao(db: TBADatabase): EventInsightsDao = db.eventInsightsDao()
-    @Provides fun provideTeamEventStatusDao(db: TBADatabase): TeamEventStatusDao = db.teamEventStatusDao()
+
+    @Provides fun provideTeamEventStatusDao(db: TBADatabase): TeamEventStatusDao =
+        db
+            .teamEventStatusDao()
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/di/MessagingModule.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/di/MessagingModule.kt
@@ -12,9 +12,9 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object MessagingModule {
-
     @Provides
     @Singleton
-    fun provideWorkManager(@ApplicationContext context: Context): WorkManager =
-        WorkManager.getInstance(context)
+    fun provideWorkManager(
+        @ApplicationContext context: Context,
+    ): WorkManager = WorkManager.getInstance(context)
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/di/NetworkModule.kt
@@ -7,7 +7,6 @@ import com.thebluealliance.android.data.remote.ClientApi
 import com.thebluealliance.android.data.remote.GitHubApi
 import com.thebluealliance.android.data.remote.TbaApi
 import com.thebluealliance.android.data.remote.TbaApiKeyInterceptor
-import javax.inject.Named
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -18,40 +17,51 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import java.util.concurrent.TimeUnit
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
+    @Provides
+    @Singleton
+    fun provideJson(): Json =
+        Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+        }
 
     @Provides
     @Singleton
-    fun provideJson(): Json = Json {
-        ignoreUnknownKeys = true
-        encodeDefaults = true
-    }
+    fun provideOkHttpClient(apiKeyInterceptor: TbaApiKeyInterceptor): OkHttpClient =
+        OkHttpClient
+            .Builder()
+            .addInterceptor(apiKeyInterceptor)
+            .addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level =
+                        if (BuildConfig.DEBUG) {
+                            HttpLoggingInterceptor.Level.BASIC
+                        } else {
+                            HttpLoggingInterceptor.Level.NONE
+                        }
+                },
+            ).connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(apiKeyInterceptor: TbaApiKeyInterceptor): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(apiKeyInterceptor)
-        .addInterceptor(
-            HttpLoggingInterceptor().apply {
-                level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BASIC
-                else HttpLoggingInterceptor.Level.NONE
-            }
-        )
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(30, TimeUnit.SECONDS)
-        .build()
-
-    @Provides
-    @Singleton
-    fun provideRetrofit(client: OkHttpClient, json: Json): Retrofit = Retrofit.Builder()
-        .baseUrl(BuildConfig.TBA_BASE_URL)
-        .client(client)
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-        .build()
+    fun provideRetrofit(
+        client: OkHttpClient,
+        json: Json,
+    ): Retrofit =
+        Retrofit
+            .Builder()
+            .baseUrl(BuildConfig.TBA_BASE_URL)
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
 
     @Provides
     @Singleton
@@ -61,43 +71,54 @@ object NetworkModule {
     @Singleton
     @Named("authenticated")
     fun provideAuthOkHttpClient(authTokenInterceptor: AuthTokenInterceptor): OkHttpClient =
-        OkHttpClient.Builder()
+        OkHttpClient
+            .Builder()
             .addInterceptor(authTokenInterceptor)
             .addInterceptor(
                 HttpLoggingInterceptor().apply {
-                    level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BASIC
-                    else HttpLoggingInterceptor.Level.NONE
-                }
-            )
-            .build()
+                    level =
+                        if (BuildConfig.DEBUG) {
+                            HttpLoggingInterceptor.Level.BASIC
+                        } else {
+                            HttpLoggingInterceptor.Level.NONE
+                        }
+                },
+            ).build()
 
     @Provides
     @Singleton
-    fun provideGitHubApi(json: Json): GitHubApi = Retrofit.Builder()
-        .baseUrl("https://api.github.com/")
-        .client(
-            OkHttpClient.Builder()
-                .addInterceptor(
-                    HttpLoggingInterceptor().apply {
-                        level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BASIC
-                        else HttpLoggingInterceptor.Level.NONE
-                    }
-                )
-                .build()
-        )
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-        .build()
-        .create(GitHubApi::class.java)
+    fun provideGitHubApi(json: Json): GitHubApi =
+        Retrofit
+            .Builder()
+            .baseUrl("https://api.github.com/")
+            .client(
+                OkHttpClient
+                    .Builder()
+                    .addInterceptor(
+                        HttpLoggingInterceptor().apply {
+                            level =
+                                if (BuildConfig.DEBUG) {
+                                    HttpLoggingInterceptor.Level.BASIC
+                                } else {
+                                    HttpLoggingInterceptor.Level.NONE
+                                }
+                        },
+                    ).build(),
+            ).addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(GitHubApi::class.java)
 
     @Provides
     @Singleton
     fun provideClientApi(
         @Named("authenticated") client: OkHttpClient,
         json: Json,
-    ): ClientApi = Retrofit.Builder()
-        .baseUrl(BuildConfig.TBA_BASE_URL)
-        .client(client)
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-        .build()
-        .create(ClientApi::class.java)
+    ): ClientApi =
+        Retrofit
+            .Builder()
+            .baseUrl(BuildConfig.TBA_BASE_URL)
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(ClientApi::class.java)
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/MatchAdvancementMsgs.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/MatchAdvancementMsgs.kt
@@ -17,31 +17,34 @@ data class MatchAdvancementMsgs(
 fun Match.getAdvancement(playoffType: PlayoffType?): MatchAdvancementMsgs? {
     if (this.compLevel !in PLAYOFF_COMP_LEVELS || this.compLevel == CompLevel.FINAL) return null
 
-    val (winAdvancement, loseAdvancement) = when (playoffType) {
-        // 2023+
-        PlayoffType.DOUBLE_ELIM_8_TEAM -> when (this.setNumber) {
-            1, 2 -> "Advances to Upper Bracket - R2-7" to "Advances to Lower Bracket - R2-5"
-            3, 4 -> "Advances to Upper Bracket - R2-8" to "Advances to Lower Bracket - R2-6"
-            5 -> "Advances to Lower Bracket - R3-10" to "Eliminated"
-            6 -> "Advances to Lower Bracket - R3-9" to "Eliminated"
-            7 -> "Advances to Upper Bracket - R4-12" to "Advances to Lower Bracket - R3-9"
-            8 -> "Advances to Upper Bracket - R4-12" to "Advances to Lower Bracket - R3-10"
-            9 -> "Advances to Lower Bracket - R4-11" to "Eliminated"
-            10 -> "Advances to Lower Bracket - R4-11" to "Eliminated"
-            11 -> "Advances to Lower Bracket - R5-13" to "Eliminated"
-            12 -> "Advances to Finals" to "Advances to Lower Bracket - R5-13"
-            13 -> "Advances to Finals" to "Eliminated"
+    val (winAdvancement, loseAdvancement) =
+        when (playoffType) {
+            // 2023+
+            PlayoffType.DOUBLE_ELIM_8_TEAM ->
+                when (this.setNumber) {
+                    1, 2 -> "Advances to Upper Bracket - R2-7" to "Advances to Lower Bracket - R2-5"
+                    3, 4 -> "Advances to Upper Bracket - R2-8" to "Advances to Lower Bracket - R2-6"
+                    5 -> "Advances to Lower Bracket - R3-10" to "Eliminated"
+                    6 -> "Advances to Lower Bracket - R3-9" to "Eliminated"
+                    7 -> "Advances to Upper Bracket - R4-12" to "Advances to Lower Bracket - R3-9"
+                    8 -> "Advances to Upper Bracket - R4-12" to "Advances to Lower Bracket - R3-10"
+                    9 -> "Advances to Lower Bracket - R4-11" to "Eliminated"
+                    10 -> "Advances to Lower Bracket - R4-11" to "Eliminated"
+                    11 -> "Advances to Lower Bracket - R5-13" to "Eliminated"
+                    12 -> "Advances to Finals" to "Advances to Lower Bracket - R5-13"
+                    13 -> "Advances to Finals" to "Eliminated"
+                    else -> null
+                }
+            PlayoffType.DOUBLE_ELIM_4_TEAM ->
+                when (this.setNumber) {
+                    1, 2 -> "Advances to Upper Bracket - R2-3" to "Advances to Lower Bracket - R2-4"
+                    3 -> "Advances to Finals" to "Advances to Lower Bracket - R3-5"
+                    4 -> "Advances to Lower Bracket - R3-5" to "Eliminated"
+                    5 -> "Advances to Finals" to "Eliminated"
+                    else -> null
+                }
             else -> null
-        }
-        PlayoffType.DOUBLE_ELIM_4_TEAM -> when (this.setNumber) {
-            1, 2 -> "Advances to Upper Bracket - R2-3" to "Advances to Lower Bracket - R2-4"
-            3 -> "Advances to Finals" to "Advances to Lower Bracket - R3-5"
-            4 -> "Advances to Lower Bracket - R3-5" to "Eliminated"
-            5 -> "Advances to Finals" to "Eliminated"
-            else -> null
-        }
-        else -> null
-    }?: return null
+        } ?: return null
 
     return MatchAdvancementMsgs(
         red = if (this.winningAlliance == "red") winAdvancement else loseAdvancement,

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/MatchGroupExtension.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/MatchGroupExtension.kt
@@ -15,12 +15,13 @@ import com.thebluealliance.android.domain.model.PlayoffType
  * The logic here was largely lifted from https://github.com/the-blue-alliance/the-blue-alliance/blob/ad984d18edf671c37662d642b77ae20e6cbfeb38/src/backend/common/helpers/playoff_type_helper.py#L176
  */
 
-internal val PLAYOFF_COMP_LEVELS = setOf(
-    CompLevel.OCTOFINAL,
-    CompLevel.QUARTERFINAL,
-    CompLevel.SEMIFINAL,
-    CompLevel.FINAL,
-)
+internal val PLAYOFF_COMP_LEVELS =
+    setOf(
+        CompLevel.OCTOFINAL,
+        CompLevel.QUARTERFINAL,
+        CompLevel.SEMIFINAL,
+        CompLevel.FINAL,
+    )
 
 /**
  * Get a match's grouping.
@@ -76,75 +77,79 @@ private fun Match.getDoubleElim4Round(): MatchGroup.DoubleEliminationRound {
 /**
  * Get the double elimination round for pre-2023 double elim format
  */
-private fun Match.getLegacyDoubleElimRound(): MatchGroup.DoubleEliminationRound {
-    return when (compLevel) {
-        CompLevel.OCTOFINAL -> when {
-            setNumber <= 4 -> MatchGroup.DoubleEliminationRound.Round(1)
-            setNumber <= 6 -> MatchGroup.DoubleEliminationRound.Round(2)
-            else -> MatchGroup.DoubleEliminationRound.Unknown
-        }
+private fun Match.getLegacyDoubleElimRound(): MatchGroup.DoubleEliminationRound =
+    when (compLevel) {
+        CompLevel.OCTOFINAL ->
+            when {
+                setNumber <= 4 -> MatchGroup.DoubleEliminationRound.Round(1)
+                setNumber <= 6 -> MatchGroup.DoubleEliminationRound.Round(2)
+                else -> MatchGroup.DoubleEliminationRound.Unknown
+            }
 
-        CompLevel.QUARTERFINAL -> when {
-            setNumber <= 2 -> MatchGroup.DoubleEliminationRound.Round(2)
-            setNumber <= 4 -> MatchGroup.DoubleEliminationRound.Round(3)
-            else -> MatchGroup.DoubleEliminationRound.Unknown
-        }
+        CompLevel.QUARTERFINAL ->
+            when {
+                setNumber <= 2 -> MatchGroup.DoubleEliminationRound.Round(2)
+                setNumber <= 4 -> MatchGroup.DoubleEliminationRound.Round(3)
+                else -> MatchGroup.DoubleEliminationRound.Unknown
+            }
 
         CompLevel.SEMIFINAL -> MatchGroup.DoubleEliminationRound.Round(4)
-        CompLevel.FINAL -> when {
-            setNumber == 1 -> MatchGroup.DoubleEliminationRound.Round(5)
-            setNumber == 2 -> MatchGroup.DoubleEliminationRound.Finals
-            else -> MatchGroup.DoubleEliminationRound.Unknown
-        }
+        CompLevel.FINAL ->
+            when {
+                setNumber == 1 -> MatchGroup.DoubleEliminationRound.Round(5)
+                setNumber == 2 -> MatchGroup.DoubleEliminationRound.Finals
+                else -> MatchGroup.DoubleEliminationRound.Unknown
+            }
 
         else -> MatchGroup.DoubleEliminationRound.Unknown
     }
-}
 
 /**
  * Get a short label for this match
  *
  * Examples: "Q1", "SF2-1", "F1-1", "R1-8"
  */
-fun Match.getShortLabel(playoffType: PlayoffType): String {
-    return when (val group = getGroup(playoffType)) {
+fun Match.getShortLabel(playoffType: PlayoffType): String =
+    when (val group = getGroup(playoffType)) {
         is MatchGroup.DoubleEliminationRound.Round -> "R${group.number}-$setNumber"
         MatchGroup.DoubleEliminationRound.Finals -> "F-$matchNumber"
 
         is MatchGroup.CompetitionLevel,
-        MatchGroup.DoubleEliminationRound.Unknown -> getCompLevelShortLabel()
+        MatchGroup.DoubleEliminationRound.Unknown,
+        -> getCompLevelShortLabel()
     }
-}
 
 /**
  * Get a full label for this match
  *
  * Examples: "Qual 1", "Final 1-1", "Match 8 (Round 1)"
  */
-fun Match.getFullLabel(playoffType: PlayoffType): String {
-    return when (val group = getGroup(playoffType)) {
+fun Match.getFullLabel(playoffType: PlayoffType): String =
+    when (val group = getGroup(playoffType)) {
         is MatchGroup.DoubleEliminationRound.Round -> "Match $setNumber (Round ${group.number})"
         MatchGroup.DoubleEliminationRound.Finals -> "Final $matchNumber"
 
         is MatchGroup.CompetitionLevel,
-        MatchGroup.DoubleEliminationRound.Unknown -> getCompLevelFullLabel()
+        MatchGroup.DoubleEliminationRound.Unknown,
+        -> getCompLevelFullLabel()
     }
-}
 
-private fun Match.getCompLevelShortLabel(): String = when (compLevel) {
-    CompLevel.QUAL -> "Q$matchNumber"
-    CompLevel.OCTOFINAL -> "EF$setNumber-$matchNumber"
-    CompLevel.QUARTERFINAL -> "QF$setNumber-$matchNumber"
-    CompLevel.SEMIFINAL -> "SF$setNumber-$matchNumber"
-    CompLevel.FINAL -> "F$setNumber-$matchNumber"
-    else -> "${compLevel.code}$setNumber-$matchNumber"
-}
+private fun Match.getCompLevelShortLabel(): String =
+    when (compLevel) {
+        CompLevel.QUAL -> "Q$matchNumber"
+        CompLevel.OCTOFINAL -> "EF$setNumber-$matchNumber"
+        CompLevel.QUARTERFINAL -> "QF$setNumber-$matchNumber"
+        CompLevel.SEMIFINAL -> "SF$setNumber-$matchNumber"
+        CompLevel.FINAL -> "F$setNumber-$matchNumber"
+        else -> "${compLevel.code}$setNumber-$matchNumber"
+    }
 
-private fun Match.getCompLevelFullLabel(): String = when (compLevel) {
-    CompLevel.QUAL -> "Qual $matchNumber"
-    CompLevel.OCTOFINAL -> "Eights $setNumber-$matchNumber"
-    CompLevel.QUARTERFINAL -> "Quarters $setNumber-$matchNumber"
-    CompLevel.SEMIFINAL -> "Semis $setNumber-$matchNumber"
-    CompLevel.FINAL -> "Final $setNumber-$matchNumber"
-    else -> "${compLevel.code}$setNumber-$matchNumber"
-}
+private fun Match.getCompLevelFullLabel(): String =
+    when (compLevel) {
+        CompLevel.QUAL -> "Qual $matchNumber"
+        CompLevel.OCTOFINAL -> "Eights $setNumber-$matchNumber"
+        CompLevel.QUARTERFINAL -> "Quarters $setNumber-$matchNumber"
+        CompLevel.SEMIFINAL -> "Semis $setNumber-$matchNumber"
+        CompLevel.FINAL -> "Final $setNumber-$matchNumber"
+        else -> "${compLevel.code}$setNumber-$matchNumber"
+    }

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/MatchScoreBreakdown.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/MatchScoreBreakdown.kt
@@ -10,18 +10,20 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * Year-aware RP bonus field names from the TBA API score breakdown.
  */
-val rpBonusFieldsByYear = mapOf(
-    2026 to listOf("energizedAchieved", "superchargedAchieved", "traversalAchieved"),
-    2025 to listOf("autoBonusAchieved", "coralBonusAchieved", "bargeBonusAchieved"),
-    2024 to listOf("coopertitionBonusAchieved", "melodyBonusAchieved", "ensembleBonusAchieved"),
-    2023 to listOf("activationBonusAchieved", "sustainabilityBonusAchieved"),
-)
+val rpBonusFieldsByYear =
+    mapOf(
+        2026 to listOf("energizedAchieved", "superchargedAchieved", "traversalAchieved"),
+        2025 to listOf("autoBonusAchieved", "coralBonusAchieved", "bargeBonusAchieved"),
+        2024 to listOf("coopertitionBonusAchieved", "melodyBonusAchieved", "ensembleBonusAchieved"),
+        2023 to listOf("activationBonusAchieved", "sustainabilityBonusAchieved"),
+    )
 
 /** All RP bonus field names across all supported years. */
 val rpBonusFields: Set<String> = rpBonusFieldsByYear.values.flatten().toSet()
 
 /** Boolean fields that should display as ✓/✗ (RP bonuses + other booleans). */
-val booleanDisplayFields: Set<String> = rpBonusFields + setOf("coopertitionCriteriaMet", "g206Penalty")
+val booleanDisplayFields: Set<String> =
+    rpBonusFields + setOf("coopertitionCriteriaMet", "g206Penalty")
 
 data class AllianceRpBonuses(
     val red: List<Boolean>,
@@ -41,6 +43,7 @@ fun Match.rpBonuses(): AllianceRpBonuses? {
     val breakdown = scoreBreakdown ?: return null
     return try {
         val obj = breakdownJson.parseToJsonElement(breakdown) as? JsonObject ?: return null
+
         fun allianceBonuses(alliance: String): List<Boolean> {
             val allianceObj = obj[alliance] as? JsonObject ?: return fields.map { false }
             return fields.map { field ->
@@ -60,7 +63,10 @@ fun Match.rpBonuses(): AllianceRpBonuses? {
 /**
  * Formats a score breakdown value for display in the match detail screen.
  */
-fun formatBreakdownValue(apiKey: String, value: String): String {
+fun formatBreakdownValue(
+    apiKey: String,
+    value: String,
+): String {
     if (value == "-") return value
     return when {
         apiKey == "rp" -> "+$value RP"

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/Alliance.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/Alliance.kt
@@ -22,10 +22,13 @@ val Alliance.displayTitle: String
 
 val Alliance.displayTitleShort: String
     get() {
-        if (this.name.isNullOrBlank()
+        if (this.name.isNullOrBlank() ||
             // Regular playoff matches also have the property name = "Alliance #".
             // We want "A#" instead to be concise.
-            || this.name.startsWith("Alliance ")) return "A${this.number}"
+            this.name.startsWith("Alliance ")
+        ) {
+            return "A${this.number}"
+        }
 
         return this.name
     }
@@ -54,19 +57,21 @@ private fun String.toAllianceStatusLabel(): String =
         ?.lowercase()
         ?.replace('_', ' ')
         ?.let { status ->
-            if (status == "won") WINNER_LABEL
-            else status.replaceFirstChar { char ->
-                if (char.isLowerCase()) char.titlecase() else char.toString()
+            if (status == "won") {
+                WINNER_LABEL
+            } else {
+                status.replaceFirstChar { char ->
+                    if (char.isLowerCase()) char.titlecase() else char.toString()
+                }
             }
-        }
-        .orEmpty()
+        }.orEmpty()
 
-private fun String.toAllianceCompLevelLabel(): String = when (lowercase()) {
-    CompLevel.QUAL.code -> "Qualifications"
-    CompLevel.OCTOFINAL.code -> "Eighths"
-    CompLevel.QUARTERFINAL.code -> "Quarterfinals"
-    CompLevel.SEMIFINAL.code -> "Semifinals"
-    CompLevel.FINAL.code -> "Finals"
-    else -> trim().takeIf { it.isNotEmpty() }?.uppercase().orEmpty()
-}
-
+private fun String.toAllianceCompLevelLabel(): String =
+    when (lowercase()) {
+        CompLevel.QUAL.code -> "Qualifications"
+        CompLevel.OCTOFINAL.code -> "Eighths"
+        CompLevel.QUARTERFINAL.code -> "Quarterfinals"
+        CompLevel.SEMIFINAL.code -> "Semifinals"
+        CompLevel.FINAL.code -> "Finals"
+        else -> trim().takeIf { it.isNotEmpty() }?.uppercase().orEmpty()
+    }

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/CmpAdvancement.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/CmpAdvancement.kt
@@ -10,9 +10,10 @@ sealed class CmpAdvancement {
     ) : CmpAdvancement()
 
     /** Team qualified via the regional advancement pool for a given week. */
-    data class PoolQualified(val week: Int) : CmpAdvancement()
+    data class PoolQualified(
+        val week: Int,
+    ) : CmpAdvancement()
 
     /** Team has qualified but no further detail is available. */
     object Qualified : CmpAdvancement()
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/Event.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/Event.kt
@@ -1,8 +1,5 @@
 package com.thebluealliance.android.domain.model
 
-import android.R.attr.type
-import com.google.common.io.Files.map
-
 data class Event(
     val key: String,
     val name: String,
@@ -58,12 +55,12 @@ enum class PlayoffType(
     BEST_OF_5(typeInt = 6),
     BEST_OF_3(typeInt = 7),
 
-    OTHER(typeInt = 8);
+    OTHER(typeInt = 8),
+    ;
 
     companion object {
         private val typeIntMap = entries.associateBy(PlayoffType::typeInt)
-        fun fromInt(typeInt: Int): PlayoffType {
-            return typeIntMap[typeInt] ?: OTHER
-        }
+
+        fun fromInt(typeInt: Int): PlayoffType = typeIntMap[typeInt] ?: OTHER
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/EventCOPRs.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/EventCOPRs.kt
@@ -3,4 +3,3 @@ package com.thebluealliance.android.domain.model
 data class EventCOPRs(
     val coprs: Map<String, Map<String, Double>> = emptyMap(),
 )
-

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/EventInsights.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/EventInsights.kt
@@ -4,6 +4,3 @@ data class EventInsights(
     val qual: String? = null,
     val playoff: String? = null,
 )
-
-
-

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/Match.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/Match.kt
@@ -28,7 +28,10 @@ data class Match(
  * @param teamKeys Keys for a given Alliance (Red/Blue) in a Match
  * @return The Playoff Alliance or null if not found
  */
-private fun calculateAlliance(alliances: List<Alliance>, teamKeys: List<String>): Alliance? {
+private fun calculateAlliance(
+    alliances: List<Alliance>,
+    teamKeys: List<String>,
+): Alliance? {
     // Each team cannot belong to more than one alliance, and there can only be one backup team.
     // That is, at least two teams must be "picks"
 
@@ -65,10 +68,12 @@ enum class CompLevel(
     QUARTERFINAL("qf", 2),
     SEMIFINAL("sf", 3),
     FINAL("f", 4),
-    OTHER("", Int.MAX_VALUE);
+    OTHER("", Int.MAX_VALUE),
+    ;
 
     companion object {
         private val codeMap = entries.associateBy(CompLevel::code)
+
         fun fromCode(code: String) = codeMap[code] ?: OTHER
     }
 }
@@ -77,26 +82,31 @@ sealed interface MatchGroup {
     abstract val label: String
 
     data class CompetitionLevel(
-        val compLevel: CompLevel
+        val compLevel: CompLevel,
     ) : MatchGroup {
-        override val label = when(compLevel) {
-            CompLevel.QUAL -> "Qualifications"
-            CompLevel.OCTOFINAL -> "Eighths"
-            CompLevel.QUARTERFINAL -> "Quarterfinals"
-            CompLevel.SEMIFINAL -> "Semifinals"
-            CompLevel.FINAL -> "Finals"
-            CompLevel.OTHER -> compLevel.code
-        }
+        override val label =
+            when (compLevel) {
+                CompLevel.QUAL -> "Qualifications"
+                CompLevel.OCTOFINAL -> "Eighths"
+                CompLevel.QUARTERFINAL -> "Quarterfinals"
+                CompLevel.SEMIFINAL -> "Semifinals"
+                CompLevel.FINAL -> "Finals"
+                CompLevel.OTHER -> compLevel.code
+            }
     }
 
     sealed class DoubleEliminationRound : MatchGroup {
-        object Unknown: DoubleEliminationRound() {
+        object Unknown : DoubleEliminationRound() {
             override val label = "Round ?"
         }
-        object Finals: DoubleEliminationRound(){
+
+        object Finals : DoubleEliminationRound() {
             override val label = "Finals"
         }
-        data class Round(val number: Int): DoubleEliminationRound(){
+
+        data class Round(
+            val number: Int,
+        ) : DoubleEliminationRound() {
             override val label = "Round $number"
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/NotificationType.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/NotificationType.kt
@@ -25,14 +25,21 @@ enum class NotificationType(
     companion object {
         fun fromServerKey(key: String): NotificationType? = entries.find { it.serverKey == key }
 
-        fun forModelType(modelType: Int): List<NotificationType> = when (modelType) {
-            ModelType.EVENT -> listOf(
-                UPCOMING_MATCH, MATCH_SCORE, LEVEL_STARTING, ALLIANCE_SELECTION,
-                AWARDS, SCHEDULE_UPDATED, FINAL_RESULTS,
-            )
-            ModelType.TEAM -> listOf(UPCOMING_MATCH, MATCH_SCORE, AWARDS)
-            ModelType.MATCH -> listOf(UPCOMING_MATCH, MATCH_SCORE, MATCH_VIDEO)
-            else -> emptyList()
-        }
+        fun forModelType(modelType: Int): List<NotificationType> =
+            when (modelType) {
+                ModelType.EVENT ->
+                    listOf(
+                        UPCOMING_MATCH,
+                        MATCH_SCORE,
+                        LEVEL_STARTING,
+                        ALLIANCE_SELECTION,
+                        AWARDS,
+                        SCHEDULE_UPDATED,
+                        FINAL_RESULTS,
+                    )
+                ModelType.TEAM -> listOf(UPCOMING_MATCH, MATCH_SCORE, AWARDS)
+                ModelType.MATCH -> listOf(UPCOMING_MATCH, MATCH_SCORE, MATCH_VIDEO)
+                else -> emptyList()
+            }
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/RankingSortOrder.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/RankingSortOrder.kt
@@ -4,4 +4,3 @@ data class RankingSortOrder(
     val name: String,
     val precision: Int,
 )
-

--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/DeviceRegistrationManager.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/DeviceRegistrationManager.kt
@@ -20,110 +20,115 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class DeviceRegistrationManager @Inject constructor(
-    private val clientApi: ClientApi,
-    private val authRepository: AuthRepository,
-    private val sharedPreferences: SharedPreferences,
-    private val workManager: WorkManager,
-) {
-    companion object {
-        private const val TAG = "DeviceRegistration"
-        private const val PREF_DEVICE_UUID = "device_uuid"
-        internal const val PREF_REGISTERED_TOKEN = "registered_fcm_token"
-    }
-
-    val deviceUuid: String
-        get() {
-            val existing = sharedPreferences.getString(PREF_DEVICE_UUID, null)
-            if (existing != null) return existing
-            val uuid = java.util.UUID.randomUUID().toString()
-            sharedPreferences.edit().putString(PREF_DEVICE_UUID, uuid).apply()
-            return uuid
+class DeviceRegistrationManager
+    @Inject
+    constructor(
+        private val clientApi: ClientApi,
+        private val authRepository: AuthRepository,
+        private val sharedPreferences: SharedPreferences,
+        private val workManager: WorkManager,
+    ) {
+        companion object {
+            private const val TAG = "DeviceRegistration"
+            private const val PREF_DEVICE_UUID = "device_uuid"
+            internal const val PREF_REGISTERED_TOKEN = "registered_fcm_token"
         }
 
-    suspend fun registerIfNeeded() {
-        if (!authRepository.isSignedIn()) return
-        try {
-            val token = FirebaseMessaging.getInstance().token.await()
-            val lastRegistered = sharedPreferences.getString(PREF_REGISTERED_TOKEN, null)
-            if (token == lastRegistered) return
+        val deviceUuid: String
+            get() {
+                val existing = sharedPreferences.getString(PREF_DEVICE_UUID, null)
+                if (existing != null) return existing
+                val uuid =
+                    java.util.UUID
+                        .randomUUID()
+                        .toString()
+                sharedPreferences.edit().putString(PREF_DEVICE_UUID, uuid).apply()
+                return uuid
+            }
+
+        suspend fun registerIfNeeded() {
+            if (!authRepository.isSignedIn()) return
+            try {
+                val token = FirebaseMessaging.getInstance().token.await()
+                val lastRegistered = sharedPreferences.getString(PREF_REGISTERED_TOKEN, null)
+                if (token == lastRegistered) return
+                register(token)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to get FCM token", e)
+            }
+        }
+
+        suspend fun onNewToken(token: String) {
+            if (!authRepository.isSignedIn()) return
             register(token)
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to get FCM token", e)
         }
-    }
 
-    suspend fun onNewToken(token: String) {
-        if (!authRepository.isSignedIn()) return
-        register(token)
-    }
-
-    suspend fun onSignIn() {
-        try {
-            val token = FirebaseMessaging.getInstance().token.await()
-            register(token)
-        } catch (e: Exception) {
-            Log.e(TAG, "Registration failed after sign-in", e)
+        suspend fun onSignIn() {
+            try {
+                val token = FirebaseMessaging.getInstance().token.await()
+                register(token)
+            } catch (e: Exception) {
+                Log.e(TAG, "Registration failed after sign-in", e)
+            }
         }
-    }
 
-    suspend fun onSignOut() {
-        try {
-            val token = sharedPreferences.getString(PREF_REGISTERED_TOKEN, null)
-            if (token != null) {
-                clientApi.unregisterDevice(
+        suspend fun onSignOut() {
+            try {
+                val token = sharedPreferences.getString(PREF_REGISTERED_TOKEN, null)
+                if (token != null) {
+                    clientApi.unregisterDevice(
+                        RegisterDeviceRequestDto(
+                            mobileId = token,
+                            name = Build.MODEL,
+                            deviceUuid = deviceUuid,
+                        ),
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Unregister failed", e)
+            } finally {
+                sharedPreferences.edit().remove(PREF_REGISTERED_TOKEN).apply()
+            }
+        }
+
+        private suspend fun register(token: String) {
+            try {
+                clientApi.registerDevice(
                     RegisterDeviceRequestDto(
                         mobileId = token,
                         name = Build.MODEL,
                         deviceUuid = deviceUuid,
-                    )
+                    ),
                 )
+                sharedPreferences.edit().putString(PREF_REGISTERED_TOKEN, token).apply()
+                Log.d(TAG, "Registered device with token ${token.take(10)}...")
+            } catch (e: Exception) {
+                Log.e(TAG, "Registration failed, scheduling retry", e)
+                enqueueRetry(token)
             }
-        } catch (e: Exception) {
-            Log.e(TAG, "Unregister failed", e)
-        } finally {
-            sharedPreferences.edit().remove(PREF_REGISTERED_TOKEN).apply()
+        }
+
+        private fun enqueueRetry(token: String) {
+            val request =
+                OneTimeWorkRequestBuilder<DeviceRegistrationWorker>()
+                    .setInputData(
+                        workDataOf(
+                            DeviceRegistrationWorker.KEY_FCM_TOKEN to token,
+                            DeviceRegistrationWorker.KEY_DEVICE_UUID to deviceUuid,
+                        ),
+                    ).setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                    .setConstraints(
+                        Constraints
+                            .Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .build(),
+                    ).build()
+
+            workManager.enqueueUniqueWork(
+                "device_registration",
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+            Log.d(TAG, "Enqueued device registration retry worker")
         }
     }
-
-    private suspend fun register(token: String) {
-        try {
-            clientApi.registerDevice(
-                RegisterDeviceRequestDto(
-                    mobileId = token,
-                    name = Build.MODEL,
-                    deviceUuid = deviceUuid,
-                )
-            )
-            sharedPreferences.edit().putString(PREF_REGISTERED_TOKEN, token).apply()
-            Log.d(TAG, "Registered device with token ${token.take(10)}...")
-        } catch (e: Exception) {
-            Log.e(TAG, "Registration failed, scheduling retry", e)
-            enqueueRetry(token)
-        }
-    }
-
-    private fun enqueueRetry(token: String) {
-        val request = OneTimeWorkRequestBuilder<DeviceRegistrationWorker>()
-            .setInputData(
-                workDataOf(
-                    DeviceRegistrationWorker.KEY_FCM_TOKEN to token,
-                    DeviceRegistrationWorker.KEY_DEVICE_UUID to deviceUuid,
-                )
-            )
-            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
-            .setConstraints(
-                Constraints.Builder()
-                    .setRequiredNetworkType(NetworkType.CONNECTED)
-                    .build()
-            )
-            .build()
-
-        workManager.enqueueUniqueWork(
-            "device_registration",
-            ExistingWorkPolicy.REPLACE,
-            request,
-        )
-        Log.d(TAG, "Enqueued device registration retry worker")
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/DeviceRegistrationWorker.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/DeviceRegistrationWorker.kt
@@ -13,37 +13,43 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
 @HiltWorker
-class DeviceRegistrationWorker @AssistedInject constructor(
-    @Assisted appContext: Context,
-    @Assisted workerParams: WorkerParameters,
-    private val clientApi: ClientApi,
-    private val sharedPreferences: SharedPreferences,
-) : CoroutineWorker(appContext, workerParams) {
+class DeviceRegistrationWorker
+    @AssistedInject
+    constructor(
+        @Assisted appContext: Context,
+        @Assisted workerParams: WorkerParameters,
+        private val clientApi: ClientApi,
+        private val sharedPreferences: SharedPreferences,
+    ) : CoroutineWorker(appContext, workerParams) {
+        companion object {
+            const val KEY_FCM_TOKEN = "fcm_token"
+            const val KEY_DEVICE_UUID = "device_uuid"
+            private const val TAG = "DeviceRegWorker"
+        }
 
-    companion object {
-        const val KEY_FCM_TOKEN = "fcm_token"
-        const val KEY_DEVICE_UUID = "device_uuid"
-        private const val TAG = "DeviceRegWorker"
-    }
+        override suspend fun doWork(): Result {
+            val token = inputData.getString(KEY_FCM_TOKEN) ?: return Result.failure()
+            val deviceUuid = inputData.getString(KEY_DEVICE_UUID) ?: return Result.failure()
 
-    override suspend fun doWork(): Result {
-        val token = inputData.getString(KEY_FCM_TOKEN) ?: return Result.failure()
-        val deviceUuid = inputData.getString(KEY_DEVICE_UUID) ?: return Result.failure()
-
-        return try {
-            clientApi.registerDevice(
-                RegisterDeviceRequestDto(
-                    mobileId = token,
-                    name = Build.MODEL,
-                    deviceUuid = deviceUuid,
+            return try {
+                clientApi.registerDevice(
+                    RegisterDeviceRequestDto(
+                        mobileId = token,
+                        name = Build.MODEL,
+                        deviceUuid = deviceUuid,
+                    ),
                 )
-            )
-            sharedPreferences.edit().putString(DeviceRegistrationManager.PREF_REGISTERED_TOKEN, token).apply()
-            Log.d(TAG, "Registered device with token ${token.take(10)}...")
-            Result.success()
-        } catch (e: Exception) {
-            Log.e(TAG, "Registration failed, will retry", e)
-            Result.retry()
+                sharedPreferences
+                    .edit()
+                    .putString(
+                        DeviceRegistrationManager.PREF_REGISTERED_TOKEN,
+                        token,
+                    ).apply()
+                Log.d(TAG, "Registered device with token ${token.take(10)}...")
+                Result.success()
+            } catch (e: Exception) {
+                Log.e(TAG, "Registration failed, will retry", e)
+                Result.retry()
+            }
         }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/NotificationBuilder.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/NotificationBuilder.kt
@@ -14,66 +14,73 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class NotificationBuilder @Inject constructor(
-    @ApplicationContext private val context: Context,
-) {
-    fun buildFromRemoteMessage(message: RemoteMessage): Notification? {
-        val data = message.data
-        val typeKey = data["notification_type"] ?: return null
-        val type = NotificationType.fromServerKey(typeKey) ?: return null
-        if (type.isSilent) return null
+class NotificationBuilder
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) {
+        fun buildFromRemoteMessage(message: RemoteMessage): Notification? {
+            val data = message.data
+            val typeKey = data["notification_type"] ?: return null
+            val type = NotificationType.fromServerKey(typeKey) ?: return null
+            if (type.isSilent) return null
 
-        val title = message.notification?.title ?: return null
-        val body = message.notification?.body ?: ""
+            val title = message.notification?.title ?: return null
+            val body = message.notification?.body ?: ""
 
-        return build(
-            channelId = type.channelId,
-            title = title,
-            body = body,
-            eventKey = data["event_key"],
-            matchKey = data["match_key"],
-            teamKey = data["team_key"],
-            notificationType = typeKey,
-        )
-    }
-
-    fun build(
-        channelId: String,
-        title: String,
-        body: String,
-        eventKey: String? = null,
-        matchKey: String? = null,
-        teamKey: String? = null,
-        notificationType: String? = null,
-    ): Notification {
-        val intent = Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            notificationType?.let { putExtra(EXTRA_NOTIFICATION_TYPE, it) }
-            eventKey?.let { putExtra(EXTRA_EVENT_KEY, it) }
-            matchKey?.let { putExtra(EXTRA_MATCH_KEY, it) }
-            teamKey?.let { putExtra(EXTRA_TEAM_KEY, it) }
+            return build(
+                channelId = type.channelId,
+                title = title,
+                body = body,
+                eventKey = data["event_key"],
+                matchKey = data["match_key"],
+                teamKey = data["team_key"],
+                notificationType = typeKey,
+            )
         }
 
-        val requestCode = (eventKey ?: matchKey ?: teamKey ?: "").hashCode()
-        val pendingIntent = PendingIntent.getActivity(
-            context, requestCode, intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
+        fun build(
+            channelId: String,
+            title: String,
+            body: String,
+            eventKey: String? = null,
+            matchKey: String? = null,
+            teamKey: String? = null,
+            notificationType: String? = null,
+        ): Notification {
+            val intent =
+                Intent(context, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    notificationType?.let { putExtra(EXTRA_NOTIFICATION_TYPE, it) }
+                    eventKey?.let { putExtra(EXTRA_EVENT_KEY, it) }
+                    matchKey?.let { putExtra(EXTRA_MATCH_KEY, it) }
+                    teamKey?.let { putExtra(EXTRA_TEAM_KEY, it) }
+                }
 
-        return NotificationCompat.Builder(context, channelId)
-            .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle(title)
-            .setContentText(body)
-            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
-            .setAutoCancel(true)
-            .setContentIntent(pendingIntent)
-            .build()
-    }
+            val requestCode = (eventKey ?: matchKey ?: teamKey ?: "").hashCode()
+            val pendingIntent =
+                PendingIntent.getActivity(
+                    context,
+                    requestCode,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+                )
 
-    companion object {
-        const val EXTRA_NOTIFICATION_TYPE = "notification_type"
-        const val EXTRA_EVENT_KEY = "event_key"
-        const val EXTRA_MATCH_KEY = "match_key"
-        const val EXTRA_TEAM_KEY = "team_key"
+            return NotificationCompat
+                .Builder(context, channelId)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle(title)
+                .setContentText(body)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+                .setAutoCancel(true)
+                .setContentIntent(pendingIntent)
+                .build()
+        }
+
+        companion object {
+            const val EXTRA_NOTIFICATION_TYPE = "notification_type"
+            const val EXTRA_EVENT_KEY = "event_key"
+            const val EXTRA_MATCH_KEY = "match_key"
+            const val EXTRA_TEAM_KEY = "team_key"
+        }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/NotificationChannelManager.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/NotificationChannelManager.kt
@@ -8,41 +8,44 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class NotificationChannelManager @Inject constructor(
-    @ApplicationContext private val context: Context,
-) {
-    companion object {
-        const val CHANNEL_MATCH = "match_alerts"
-        const val CHANNEL_EVENT = "event_updates"
-        const val CHANNEL_GENERAL = "general"
-    }
+class NotificationChannelManager
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) {
+        companion object {
+            const val CHANNEL_MATCH = "match_alerts"
+            const val CHANNEL_EVENT = "event_updates"
+            const val CHANNEL_GENERAL = "general"
+        }
 
-    fun createChannels() {
-        val manager = context.getSystemService(NotificationManager::class.java)
-        manager.createNotificationChannels(
-            listOf(
-                NotificationChannel(
-                    CHANNEL_MATCH,
-                    "Match Alerts",
-                    NotificationManager.IMPORTANCE_HIGH,
-                ).apply {
-                    description = "Upcoming matches, scores, and match videos"
-                },
-                NotificationChannel(
-                    CHANNEL_EVENT,
-                    "Event Updates",
-                    NotificationManager.IMPORTANCE_DEFAULT,
-                ).apply {
-                    description = "Schedule changes, alliances, awards, and competition level updates"
-                },
-                NotificationChannel(
-                    CHANNEL_GENERAL,
-                    "General",
-                    NotificationManager.IMPORTANCE_DEFAULT,
-                ).apply {
-                    description = "Test notifications and broadcasts"
-                },
+        fun createChannels() {
+            val manager = context.getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannels(
+                listOf(
+                    NotificationChannel(
+                        CHANNEL_MATCH,
+                        "Match Alerts",
+                        NotificationManager.IMPORTANCE_HIGH,
+                    ).apply {
+                        description = "Upcoming matches, scores, and match videos"
+                    },
+                    NotificationChannel(
+                        CHANNEL_EVENT,
+                        "Event Updates",
+                        NotificationManager.IMPORTANCE_DEFAULT,
+                    ).apply {
+                        description =
+                            "Schedule changes, alliances, awards, and competition level updates"
+                    },
+                    NotificationChannel(
+                        CHANNEL_GENERAL,
+                        "General",
+                        NotificationManager.IMPORTANCE_DEFAULT,
+                    ).apply {
+                        description = "Test notifications and broadcasts"
+                    },
+                ),
             )
-        )
+        }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/TBAFirebaseMessagingService.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/TBAFirebaseMessagingService.kt
@@ -15,9 +15,10 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class TBAFirebaseMessagingService : FirebaseMessagingService() {
-
     @Inject lateinit var deviceRegistrationManager: DeviceRegistrationManager
+
     @Inject lateinit var notificationBuilder: NotificationBuilder
+
     @Inject lateinit var myTBARepository: MyTBARepository
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -37,13 +38,19 @@ class TBAFirebaseMessagingService : FirebaseMessagingService() {
         when (type) {
             NotificationType.UPDATE_FAVORITES -> {
                 scope.launch {
-                    try { myTBARepository.refreshFavorites() } catch (_: Exception) {}
+                    try {
+                        myTBARepository.refreshFavorites()
+                    } catch (_: Exception) {
+                    }
                 }
                 return
             }
             NotificationType.UPDATE_SUBSCRIPTIONS -> {
                 scope.launch {
-                    try { myTBARepository.refreshSubscriptions() } catch (_: Exception) {}
+                    try {
+                        myTBARepository.refreshSubscriptions()
+                    } catch (_: Exception) {
+                    }
                 }
                 return
             }

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/NavigationState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/NavigationState.kt
@@ -1,8 +1,5 @@
 package com.thebluealliance.android.navigation
 
-import android.app.Activity
-import android.content.Context
-import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
@@ -12,8 +9,6 @@ import androidx.compose.runtime.saveable.rememberSerializable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
-import androidx.core.app.TaskStackBuilder
-import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntry
@@ -31,39 +26,43 @@ fun rememberNavigationState(
     topLevelRoutes: List<NavKey>,
     startTopLevelRoute: NavKey,
 ): NavigationState {
-    val topLevelRoute = rememberSerializable(
-        startRoute, topLevelRoutes,
-        serializer = MutableStateSerializer(NavKeySerializer())
-    ) {
-        val startTopLevel = when (startRoute) {
-            in topLevelRoutes -> startRoute
-            else -> startTopLevelRoute
+    val topLevelRoute =
+        rememberSerializable(
+            startRoute,
+            topLevelRoutes,
+            serializer = MutableStateSerializer(NavKeySerializer()),
+        ) {
+            val startTopLevel =
+                when (startRoute) {
+                    in topLevelRoutes -> startRoute
+                    else -> startTopLevelRoute
+                }
+            mutableStateOf(startTopLevel)
         }
-        mutableStateOf(startTopLevel)
-    }
 
-    val backStacks = topLevelRoutes.associateWith { key ->
-        if (key == startTopLevelRoute && startRoute != startTopLevelRoute) {
-            val syntheticStack = buildBackStack(
-                startKey = startRoute,
-                parentRoute = startTopLevelRoute,
-                buildFullPath = isNewTask
-            )
-            rememberNavBackStack(*syntheticStack.toTypedArray())
-        } else {
-            rememberNavBackStack(key)
+    val backStacks =
+        topLevelRoutes.associateWith { key ->
+            if (key == startTopLevelRoute && startRoute != startTopLevelRoute) {
+                val syntheticStack =
+                    buildBackStack(
+                        startKey = startRoute,
+                        parentRoute = startTopLevelRoute,
+                        buildFullPath = isNewTask,
+                    )
+                rememberNavBackStack(*syntheticStack.toTypedArray())
+            } else {
+                rememberNavBackStack(key)
+            }
         }
-    }
 
     return remember(startRoute, topLevelRoutes) {
         NavigationState(
             startRoute = startRoute,
             topLevelRoute = topLevelRoute,
-            backStacks = backStacks
+            backStacks = backStacks,
         )
     }
 }
-
 
 /**
  * A function that build a synthetic backStack.
@@ -89,7 +88,7 @@ fun rememberNavigationState(
 internal fun buildBackStack(
     startKey: NavKey,
     parentRoute: NavKey,
-    buildFullPath: Boolean
+    buildFullPath: Boolean,
 ): List<NavKey> {
     if (!buildFullPath) return listOf(startKey)
     /**
@@ -98,7 +97,7 @@ internal fun buildBackStack(
     return listOf(
         // In the future each NavKey could define its own parent if we need a more complex nav graph
         parentRoute,
-        startKey
+        startKey,
     )
 }
 
@@ -110,11 +109,12 @@ class NavigationState(
     val topLevelRoutes = backStacks.keys
     var topLevelRoute: NavKey by topLevelRoute
     val stacksInUse: List<NavKey>
-        get() = if (topLevelRoute == startRoute) {
-            listOf(startRoute)
-        } else {
-            listOf(startRoute, topLevelRoute)
-        }
+        get() =
+            if (topLevelRoute == startRoute) {
+                listOf(startRoute)
+            } else {
+                listOf(startRoute, topLevelRoute)
+            }
 
     val currentStack: NavBackStack<NavKey>
         get() = backStacks[topLevelRoute] ?: error("Stack for $topLevelRoute not found")
@@ -124,19 +124,21 @@ class NavigationState(
 
 @Composable
 fun NavigationState.toEntries(
-    entryProvider: (NavKey) -> NavEntry<NavKey>
+    entryProvider: (NavKey) -> NavEntry<NavKey>,
 ): SnapshotStateList<NavEntry<NavKey>> {
-    val decoratedEntries = backStacks.mapValues { (_, stack) ->
-        val decorators = listOf(
-            rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
-            rememberViewModelStoreNavEntryDecorator<NavKey>(),
-        )
-        rememberDecoratedNavEntries(
-            backStack = stack,
-            entryDecorators = decorators,
-            entryProvider = entryProvider
-        )
-    }
+    val decoratedEntries =
+        backStacks.mapValues { (_, stack) ->
+            val decorators =
+                listOf(
+                    rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+                    rememberViewModelStoreNavEntryDecorator<NavKey>(),
+                )
+            rememberDecoratedNavEntries(
+                backStack = stack,
+                entryDecorators = decorators,
+                entryProvider = entryProvider,
+            )
+        }
 
     return stacksInUse
         .flatMap { decoratedEntries[it] ?: emptyList() }

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/Navigator.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/Navigator.kt
@@ -52,7 +52,7 @@ class Navigator(
         // If we're at the base of the current route, go back to the start route stack.
         if (state.currentRoute == state.topLevelRoute) {
             state.topLevelRoute = state.startRoute
-        } else if (state.currentStack.size > 1){
+        } else if (state.currentStack.size > 1) {
             state.currentStack.removeLastOrNull()
         }
     }
@@ -71,9 +71,7 @@ class Navigator(
      * restart the app in its own Task so that this app's screens are displayed within
      * this app instead of being displayed within the originating app that triggered the deeplink.
      */
-    private fun NavBackStack<NavKey>.navigateUp(
-        activity: Activity,
-    ) {
+    private fun NavBackStack<NavKey>.navigateUp(activity: Activity) {
         /**
          * The root key (the first key on synthetic backStack) would/should never display the Up button.
          * So if the backStack only contains a non-root key, it means a synthetic backStack had not
@@ -107,7 +105,7 @@ class Navigator(
     private fun createTaskStackBuilder(
         deeplinkKey: NavKey?,
         activity: Activity,
-        context: Context
+        context: Context,
     ): TaskStackBuilder {
         /**
          * The intent to restart the current activity.

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/Screen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/Screen.kt
@@ -6,24 +6,51 @@ import kotlinx.serialization.Serializable
 
 sealed interface Screen : NavKey {
     @Serializable data object Events : Screen
+
     @Serializable data object Teams : Screen
+
     @Serializable data object Districts : Screen
+
     @Serializable data object RegionalAdvancement : Screen
+
     @Serializable data object More : Screen
-    @Serializable data class EventDetail(val eventKey: String, val initialTab: EventDetailTab = EventDetailTab.INFO) : Screen
-    @Serializable data class TeamDetail(val teamKey: String, val initialTab: Int = TAB_INFO) : Screen {
+
+    @Serializable data class EventDetail(
+        val eventKey: String,
+        val initialTab: EventDetailTab = EventDetailTab.INFO,
+    ) : Screen
+
+    @Serializable data class TeamDetail(
+        val teamKey: String,
+        val initialTab: Int = TAB_INFO,
+    ) : Screen {
         companion object {
             const val TAB_INFO = 0
             const val TAB_EVENTS = 1
             const val TAB_MEDIA = 2
         }
     }
-    @Serializable data class MatchDetail(val matchKey: String) : Screen
-    @Serializable data class TeamEventDetail(val teamKey: String, val eventKey: String) : Screen
-    @Serializable data class DistrictDetail(val districtKey: String) : Screen
+
+    @Serializable data class MatchDetail(
+        val matchKey: String,
+    ) : Screen
+
+    @Serializable data class TeamEventDetail(
+        val teamKey: String,
+        val eventKey: String,
+    ) : Screen
+
+    @Serializable data class DistrictDetail(
+        val districtKey: String,
+    ) : Screen
+
     @Serializable data object MyTBA : Screen
+
     @Serializable data object Search : Screen
+
     @Serializable data object Settings : Screen
+
     @Serializable data object About : Screen
+
     @Serializable data object Thanks : Screen
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -1,13 +1,19 @@
 package com.thebluealliance.android.navigation
 
 import androidx.activity.compose.LocalActivity
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.entryProvider
@@ -27,6 +33,7 @@ import com.thebluealliance.android.ui.more.AboutScreen
 import com.thebluealliance.android.ui.more.MoreScreen
 import com.thebluealliance.android.ui.more.ThanksScreen
 import com.thebluealliance.android.ui.mytba.MyTBAScreen
+import com.thebluealliance.android.ui.regional.RegionalAdvancementScreen
 import com.thebluealliance.android.ui.search.SearchScreen
 import com.thebluealliance.android.ui.settings.SettingsScreen
 import com.thebluealliance.android.ui.teamevent.TeamEventDetailScreen
@@ -34,13 +41,6 @@ import com.thebluealliance.android.ui.teamevent.TeamEventDetailViewModel
 import com.thebluealliance.android.ui.teams.TeamDetailScreen
 import com.thebluealliance.android.ui.teams.TeamDetailViewModel
 import com.thebluealliance.android.ui.teams.TeamsScreen
-import com.thebluealliance.android.ui.regional.RegionalAdvancementScreen
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.togetherWith
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
@@ -53,25 +53,37 @@ fun TBANavigation(
     val activity = LocalActivity.current as MainActivity
     val navigator = remember { Navigator(navState, activity) }
 
-    val showBottomBar = navState.currentRoute in TOP_LEVEL_DESTINATIONS.map { it.key }.toSet() ||
-            navState.currentRoute in setOf(Screen.MyTBA, Screen.Settings, Screen.About, Screen.Thanks, Screen.RegionalAdvancement)
+    val showBottomBar =
+        navState.currentRoute in TOP_LEVEL_DESTINATIONS.map { it.key }.toSet() ||
+            navState.currentRoute in
+            setOf(
+                Screen.MyTBA,
+                Screen.Settings,
+                Screen.About,
+                Screen.Thanks,
+                Screen.RegionalAdvancement,
+            )
 
     val coroutineScope = rememberCoroutineScope()
-    val tabReselectFlows = remember {
-        TOP_LEVEL_DESTINATIONS.map { it.key }
-            .associateWith { MutableSharedFlow<Unit>() }
-    }
+    val tabReselectFlows =
+        remember {
+            TOP_LEVEL_DESTINATIONS
+                .map { it.key }
+                .associateWith { MutableSharedFlow<Unit>() }
+        }
 
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
-    ) {
-        NavDisplay(
-            modifier = Modifier
-                .weight(1f)
+        modifier =
+            modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background),
+    ) {
+        NavDisplay(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
             transitionSpec = {
                 slideInHorizontally(initialOffsetX = { it }) togetherWith
                     slideOutHorizontally(targetOffsetX = { -it })
@@ -85,217 +97,242 @@ fun TBANavigation(
                     slideOutHorizontally(targetOffsetX = { it })
             },
             onBack = { navigator.goBack() },
-            entries = navState.toEntries(
-                entryProvider = entryProvider {
-                entry<Screen.Events>(
-                    metadata = Transitions.topLevelTransitionSpec
-                ) {
-                    EventsScreen(
-                        onNavigateToEvent = { eventKey ->
-                            navigator.navigate(Screen.EventDetail(eventKey))
+            entries =
+                navState.toEntries(
+                    entryProvider =
+                        entryProvider {
+                            entry<Screen.Events>(
+                                metadata = Transitions.topLevelTransitionSpec,
+                            ) {
+                                EventsScreen(
+                                    onNavigateToEvent = { eventKey ->
+                                        navigator.navigate(Screen.EventDetail(eventKey))
+                                    },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                    reselectFlow = tabReselectFlows[Screen.Events] ?: emptyFlow(),
+                                )
+                            }
+                            entry<Screen.Teams>(
+                                metadata = Transitions.topLevelTransitionSpec,
+                            ) {
+                                TeamsScreen(
+                                    onNavigateToTeam = { teamKey ->
+                                        navigator.navigate(Screen.TeamDetail(teamKey))
+                                    },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                    reselectFlow = tabReselectFlows[Screen.Teams] ?: emptyFlow(),
+                                )
+                            }
+                            entry<Screen.Districts>(
+                                metadata = Transitions.topLevelTransitionSpec,
+                            ) {
+                                DistrictsScreen(
+                                    onNavigateToDistrict = { districtKey ->
+                                        navigator.navigate(Screen.DistrictDetail(districtKey))
+                                    },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                    reselectFlow =
+                                        tabReselectFlows[Screen.Districts] ?: emptyFlow(),
+                                )
+                            }
+                            entry<Screen.RegionalAdvancement>(
+                                metadata = Transitions.topLevelTransitionSpec,
+                            ) {
+                                RegionalAdvancementScreen(
+                                    onNavigateToTeam = { teamKey ->
+                                        navigator.navigate(Screen.TeamDetail(teamKey))
+                                    },
+                                    onNavigateToEvent = { eventKey ->
+                                        navigator.navigate(Screen.EventDetail(eventKey))
+                                    },
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                    reselectFlow =
+                                        tabReselectFlows[Screen.RegionalAdvancement] ?: emptyFlow(),
+                                )
+                            }
+                            entry<Screen.More>(
+                                metadata = Transitions.topLevelTransitionSpec,
+                            ) {
+                                MoreScreen(
+                                    onNavigateToMyTBA = { navigator.navigate(Screen.MyTBA) },
+                                    onNavigateToRegionalAdvancement = {
+                                        navigator.navigate(
+                                            Screen.RegionalAdvancement,
+                                        )
+                                    },
+                                    onNavigateToSettings = { navigator.navigate(Screen.Settings) },
+                                    onNavigateToAbout = { navigator.navigate(Screen.About) },
+                                    onNavigateToThanks = { navigator.navigate(Screen.Thanks) },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                )
+                            }
+                            entry<Screen.MyTBA>(
+                                metadata = Transitions.topLevelTransitionSpec,
+                            ) {
+                                MyTBAScreen(
+                                    onSignIn = { activity.startGoogleSignIn() },
+                                    onNavigateToTeam = { teamKey ->
+                                        navigator.navigate(Screen.TeamDetail(teamKey))
+                                    },
+                                    onNavigateToEvent = { eventKey ->
+                                        navigator.navigate(Screen.EventDetail(eventKey))
+                                    },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    reselectFlow = tabReselectFlows[Screen.MyTBA] ?: emptyFlow(),
+                                )
+                            }
+                            entry<Screen.Settings>(
+                                metadata = Transitions.topLevelTransitionSpec,
+                            ) {
+                                SettingsScreen(
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                )
+                            }
+                            entry<Screen.About>(
+                                metadata = Transitions.topLevelTransitionSpec,
+                            ) {
+                                AboutScreen(
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                )
+                            }
+                            entry<Screen.Thanks>(
+                                metadata = Transitions.topLevelTransitionSpec,
+                            ) {
+                                ThanksScreen(
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                )
+                            }
+                            entry<Screen.Search> {
+                                SearchScreen(
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    onNavigateToTeam = { teamKey ->
+                                        navigator.navigate(Screen.TeamDetail(teamKey))
+                                    },
+                                    onNavigateToEvent = { eventKey ->
+                                        navigator.navigate(Screen.EventDetail(eventKey))
+                                    },
+                                )
+                            }
+                            entry<Screen.EventDetail> { eventDetail ->
+                                val viewModel: EventDetailViewModel =
+                                    hiltViewModel(
+                                        creationCallback = { f: EventDetailViewModel.Factory ->
+                                            f.create(eventDetail)
+                                        },
+                                    )
+                                EventDetailScreen(
+                                    viewModel = viewModel,
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    onNavigateToTeam = { teamKey ->
+                                        navigator.navigate(Screen.TeamDetail(teamKey))
+                                    },
+                                    onNavigateToMatch = { matchKey ->
+                                        navigator.navigate(Screen.MatchDetail(matchKey))
+                                    },
+                                    onNavigateToMyTBA = { navigator.navigate(Screen.MyTBA) },
+                                    onNavigateToTeamEvent = { teamKey, eventKey ->
+                                        navigator.navigate(
+                                            Screen.TeamEventDetail(teamKey, eventKey),
+                                        )
+                                    },
+                                    onNavigateToDistrict = { districtKey ->
+                                        navigator.navigate(Screen.DistrictDetail(districtKey))
+                                    },
+                                    initialTab = eventDetail.initialTab,
+                                )
+                            }
+                            entry<Screen.MatchDetail> { matchDetail ->
+                                val viewModel: MatchDetailViewModel =
+                                    hiltViewModel(
+                                        creationCallback = { f: MatchDetailViewModel.Factory ->
+                                            f.create(matchDetail)
+                                        },
+                                    )
+                                MatchDetailScreen(
+                                    viewModel = viewModel,
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    onNavigateToTeamEvent = { teamKey, eventKey ->
+                                        navigator.navigate(
+                                            Screen.TeamEventDetail(teamKey, eventKey),
+                                        )
+                                    },
+                                    onNavigateToEvent = { eventKey ->
+                                        navigator.navigate(Screen.EventDetail(eventKey))
+                                    },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                )
+                            }
+                            entry<Screen.DistrictDetail> { districtDetail ->
+                                val viewModel: DistrictDetailViewModel =
+                                    hiltViewModel(
+                                        creationCallback = { f: DistrictDetailViewModel.Factory ->
+                                            f.create(districtDetail)
+                                        },
+                                    )
+                                DistrictDetailScreen(
+                                    viewModel = viewModel,
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    onNavigateToEvent = { eventKey ->
+                                        navigator.navigate(Screen.EventDetail(eventKey))
+                                    },
+                                    onNavigateToTeam = { teamKey ->
+                                        navigator.navigate(Screen.TeamDetail(teamKey))
+                                    },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                )
+                            }
+                            entry<Screen.TeamDetail> { teamDetail ->
+                                val viewModel =
+                                    hiltViewModel<TeamDetailViewModel, TeamDetailViewModel.Factory>(
+                                        creationCallback = { factory ->
+                                            factory.create(teamDetail)
+                                        },
+                                    )
+                                TeamDetailScreen(
+                                    viewModel = viewModel,
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    onNavigateToEvent = { eventKey ->
+                                        navigator.navigate(Screen.EventDetail(eventKey))
+                                    },
+                                    onNavigateToMyTBA = { navigator.navigate(Screen.MyTBA) },
+                                    onNavigateToTeamEvent = { teamKey, eventKey ->
+                                        navigator.navigate(
+                                            Screen.TeamEventDetail(teamKey, eventKey),
+                                        )
+                                    },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                    initialTab = teamDetail.initialTab,
+                                )
+                            }
+                            entry<Screen.TeamEventDetail> { teamEventDetail ->
+                                val viewModel: TeamEventDetailViewModel =
+                                    hiltViewModel(
+                                        creationCallback = { f: TeamEventDetailViewModel.Factory ->
+                                            f.create(teamEventDetail)
+                                        },
+                                    )
+                                TeamEventDetailScreen(
+                                    viewModel = viewModel,
+                                    onNavigateUp = { navigator.navigateUp() },
+                                    onNavigateToMatch = { matchKey ->
+                                        navigator.navigate(Screen.MatchDetail(matchKey))
+                                    },
+                                    onNavigateToTeam = { teamKey ->
+                                        navigator.navigate(Screen.TeamDetail(teamKey))
+                                    },
+                                    onNavigateToEvent = { eventKey, initialTab ->
+                                        navigator.navigate(Screen.EventDetail(eventKey, initialTab))
+                                    },
+                                    onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                )
+                            }
                         },
-                        onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        reselectFlow = tabReselectFlows[Screen.Events] ?: emptyFlow(),
-                    )
-                }
-                    entry<Screen.Teams>(
-                        metadata = Transitions.topLevelTransitionSpec
-                ) {
-                    TeamsScreen(
-                        onNavigateToTeam = { teamKey ->
-                            navigator.navigate(Screen.TeamDetail(teamKey))
-                        },
-                        onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        reselectFlow = tabReselectFlows[Screen.Teams] ?: emptyFlow(),
-                    )
-                }
-                    entry<Screen.Districts>(
-                        metadata = Transitions.topLevelTransitionSpec
-                ) {
-                    DistrictsScreen(
-                        onNavigateToDistrict = { districtKey ->
-                            navigator.navigate(Screen.DistrictDetail(districtKey))
-                        },
-                        onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        reselectFlow = tabReselectFlows[Screen.Districts] ?: emptyFlow(),
-                    )
-                }
-                entry<Screen.RegionalAdvancement>(
-                    metadata = Transitions.topLevelTransitionSpec
-                ) {
-                    RegionalAdvancementScreen(
-                        onNavigateToTeam = { teamKey ->
-                            navigator.navigate(Screen.TeamDetail(teamKey))
-                        },
-                        onNavigateToEvent = { eventKey ->
-                            navigator.navigate(Screen.EventDetail(eventKey))
-                        },
-                        onNavigateUp = { navigator.navigateUp() },
-                        onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        reselectFlow = tabReselectFlows[Screen.RegionalAdvancement] ?: emptyFlow(),
-                    )
-                }
-                    entry<Screen.More>(
-                        metadata = Transitions.topLevelTransitionSpec
-                    ) {
-                        MoreScreen(
-                            onNavigateToMyTBA = { navigator.navigate(Screen.MyTBA) },
-                            onNavigateToRegionalAdvancement = { navigator.navigate(Screen.RegionalAdvancement) },
-                            onNavigateToSettings = { navigator.navigate(Screen.Settings) },
-                            onNavigateToAbout = { navigator.navigate(Screen.About) },
-                            onNavigateToThanks = { navigator.navigate(Screen.Thanks) },
-                            onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        )
-                    }
-                entry<Screen.MyTBA>(
-                    metadata = Transitions.topLevelTransitionSpec
-                ) {
-                    MyTBAScreen(
-                        onSignIn = { activity.startGoogleSignIn() },
-                        onNavigateToTeam = { teamKey ->
-                            navigator.navigate(Screen.TeamDetail(teamKey))
-                        },
-                        onNavigateToEvent = { eventKey ->
-                            navigator.navigate(Screen.EventDetail(eventKey))
-                        },
-                        onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        onNavigateUp = { navigator.navigateUp() },
-                        reselectFlow = tabReselectFlows[Screen.MyTBA] ?: emptyFlow(),
-                    )
-                }
-                    entry<Screen.Settings>(
-                        metadata = Transitions.topLevelTransitionSpec
-                    ) {
-                        SettingsScreen(
-                            onNavigateUp = { navigator.navigateUp() },
-                            onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        )
-                    }
-                    entry<Screen.About>(
-                        metadata = Transitions.topLevelTransitionSpec
-                    ) {
-                        AboutScreen(
-                            onNavigateUp = { navigator.navigateUp() },
-                            onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        )
-                    }
-                    entry<Screen.Thanks>(
-                        metadata = Transitions.topLevelTransitionSpec
-                    ) {
-                        ThanksScreen(
-                            onNavigateUp = { navigator.navigateUp() },
-                            onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        )
-                    }
-                    entry<Screen.Search> {
-                        SearchScreen(
-                            onNavigateUp = { navigator.navigateUp() },
-                            onNavigateToTeam = { teamKey ->
-                                navigator.navigate(Screen.TeamDetail(teamKey))
-                            },
-                            onNavigateToEvent = { eventKey ->
-                                navigator.navigate(Screen.EventDetail(eventKey))
-                            },
-                        )
-                    }
-                    entry<Screen.EventDetail> { eventDetail ->
-                        val viewModel =
-                            hiltViewModel<EventDetailViewModel, EventDetailViewModel.Factory>(
-                                creationCallback = { factory -> factory.create(eventDetail) }
-                            )
-                        EventDetailScreen(
-                            viewModel = viewModel,
-                            onNavigateUp = { navigator.navigateUp() },
-                            onNavigateToTeam = { teamKey ->
-                                navigator.navigate(Screen.TeamDetail(teamKey))
-                            },
-                            onNavigateToMatch = { matchKey ->
-                                navigator.navigate(Screen.MatchDetail(matchKey))
-                            },
-                            onNavigateToMyTBA = { navigator.navigate(Screen.MyTBA) },
-                            onNavigateToTeamEvent = { teamKey, eventKey ->
-                                navigator.navigate(Screen.TeamEventDetail(teamKey, eventKey))
-                            },
-                            onNavigateToDistrict = { districtKey ->
-                                navigator.navigate(Screen.DistrictDetail(districtKey))
-                            },
-                            initialTab = eventDetail.initialTab,
-                        )
-                    }
-                    entry<Screen.MatchDetail> { matchDetail ->
-                        val viewModel =
-                            hiltViewModel<MatchDetailViewModel, MatchDetailViewModel.Factory>(
-                                creationCallback = { factory -> factory.create(matchDetail) }
-                            )
-                        MatchDetailScreen(
-                            viewModel = viewModel,
-                            onNavigateUp = { navigator.navigateUp() },
-                            onNavigateToTeamEvent = { teamKey, eventKey ->
-                                navigator.navigate(Screen.TeamEventDetail(teamKey, eventKey))
-                            },
-                            onNavigateToEvent = { eventKey ->
-                                navigator.navigate(Screen.EventDetail(eventKey))
-                            },
-                            onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        )
-                    }
-                    entry<Screen.DistrictDetail> { districtDetail ->
-                        val viewModel =
-                            hiltViewModel<DistrictDetailViewModel, DistrictDetailViewModel.Factory>(
-                                creationCallback = { factory -> factory.create(districtDetail) }
-                            )
-                        DistrictDetailScreen(
-                            viewModel = viewModel,
-                            onNavigateUp = { navigator.navigateUp() },
-                            onNavigateToEvent = { eventKey ->
-                                navigator.navigate(Screen.EventDetail(eventKey))
-                            },
-                            onNavigateToTeam = { teamKey ->
-                                navigator.navigate(Screen.TeamDetail(teamKey))
-                            },
-                            onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        )
-                    }
-                    entry<Screen.TeamDetail> { teamDetail ->
-                        val viewModel = hiltViewModel<TeamDetailViewModel, TeamDetailViewModel.Factory>(
-                            creationCallback = { factory -> factory.create(teamDetail) }
-                        )
-                        TeamDetailScreen(
-                            viewModel = viewModel,
-                            onNavigateUp = { navigator.navigateUp() },
-                            onNavigateToEvent = { eventKey ->
-                                navigator.navigate(Screen.EventDetail(eventKey))
-                            },
-                            onNavigateToMyTBA = { navigator.navigate(Screen.MyTBA) },
-                            onNavigateToTeamEvent = { teamKey, eventKey ->
-                                navigator.navigate(Screen.TeamEventDetail(teamKey, eventKey))
-                            },
-                            onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                            initialTab = teamDetail.initialTab,
-                        )
-                    }
-                    entry<Screen.TeamEventDetail> { teamEventDetail ->
-                        val viewModel =
-                            hiltViewModel<TeamEventDetailViewModel, TeamEventDetailViewModel.Factory>(
-                                creationCallback = { factory -> factory.create(teamEventDetail) }
-                            )
-                        TeamEventDetailScreen(
-                            viewModel = viewModel,
-                            onNavigateUp = { navigator.navigateUp() },
-                            onNavigateToMatch = { matchKey ->
-                                navigator.navigate(Screen.MatchDetail(matchKey))
-                            },
-                            onNavigateToTeam = { teamKey ->
-                                navigator.navigate(Screen.TeamDetail(teamKey))
-                            },
-                            onNavigateToEvent = { eventKey, initialTab ->
-                                navigator.navigate(Screen.EventDetail(eventKey, initialTab))
-                            },
-                            onNavigateToSearch = { navigator.navigate(Screen.Search) },
-                        )
-                    }
-                },
-            ),
+                ),
         )
 
         AnimatedVisibility(

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/Transitions.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/Transitions.kt
@@ -9,17 +9,20 @@ import androidx.navigation3.ui.NavDisplay
 
 object Transitions {
     private val tabTransition =
-            fadeIn(tween(200, easing = LinearOutSlowInEasing)) togetherWith
-                    ExitTransition.None
+        fadeIn(tween(200, easing = LinearOutSlowInEasing)) togetherWith
+            ExitTransition.None
 
     /**
      * Default transition for top-level tab transitions. Fades between the contents
      */
-    val topLevelTransitionSpec = NavDisplay.transitionSpec {
-        tabTransition
-    } + NavDisplay.popTransitionSpec {
-        tabTransition
-    } + NavDisplay.predictivePopTransitionSpec {
-        tabTransition
-    }
+    val topLevelTransitionSpec =
+        NavDisplay.transitionSpec {
+            tabTransition
+        } +
+            NavDisplay.popTransitionSpec {
+                tabTransition
+            } +
+            NavDisplay.predictivePopTransitionSpec {
+                tabTransition
+            }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/shortcuts/ReportShortcutVisitEffect.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/shortcuts/ReportShortcutVisitEffect.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.pm.ShortcutManagerCompat
-import com.thebluealliance.android.domain.model.ModelType
 
 /**
  * Report that an item that is a valid shortcut (i.e. a team or an event) was visited when this
@@ -16,9 +15,7 @@ import com.thebluealliance.android.domain.model.ModelType
  * This reports the use to ShortcutManager so that the system can rank shortcuts appropriately.
  */
 @Composable
-fun ReportShortcutVisitEffect(
-    modelKey: String?
-) {
+fun ReportShortcutVisitEffect(modelKey: String?) {
     val context = LocalContext.current
     LaunchedEffect(modelKey) {
         modelKey?.let {

--- a/app/src/main/kotlin/com/thebluealliance/android/shortcuts/TBAShortcutManager.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/shortcuts/TBAShortcutManager.kt
@@ -37,149 +37,155 @@ import javax.inject.Singleton
  * See https://developer.android.com/develop/ui/views/launch/shortcuts
  */
 @Singleton
-class TBAShortcutManager @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val tbaRepository: MyTBARepository,
-    private val eventRepository: EventRepository,
-    private val teamRepository: TeamRepository,
-    private val tbaApi: TbaApi,
-) {
+class TBAShortcutManager
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val tbaRepository: MyTBARepository,
+        private val eventRepository: EventRepository,
+        private val teamRepository: TeamRepository,
+        private val tbaApi: TbaApi,
+    ) {
+        /**
+         * Start watching the favorites repository for changes, syncing favorites to Android's shortcuts
+         * system.
+         */
+        fun beginSyncingShortcuts() {
+            ProcessLifecycleOwner.get().lifecycleScope.launch {
+                tbaRepository
+                    .observeFavorites()
+                    .collectLatest { favorites ->
+                        purgeUnfavoritedShortcuts(favorites)
 
-    /**
-     * Start watching the favorites repository for changes, syncing favorites to Android's shortcuts
-     * system.
-     */
-    fun beginSyncingShortcuts() {
-        ProcessLifecycleOwner.get().lifecycleScope.launch {
-            tbaRepository.observeFavorites()
-                .collectLatest { favorites ->
-                    purgeUnfavoritedShortcuts(favorites)
+                        val shortcuts =
+                            favorites
+                                .take(ShortcutManagerCompat.getMaxShortcutCountPerActivity(context))
+                                .mapNotNull { it.getShortcutInfo() }
+                        ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
+                    }
+            }
+        }
 
-                    val shortcuts = favorites
-                        .take(ShortcutManagerCompat.getMaxShortcutCountPerActivity(context))
-                        .mapNotNull { it.getShortcutInfo() }
-                    ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
+        /**
+         * Remove any shortcuts in ShortcutManager that are no longer favorites
+         */
+        private fun purgeUnfavoritedShortcuts(favorites: List<Favorite>) {
+            val shortcutIds = ShortcutManagerCompat.getDynamicShortcuts(context).map { it.id }
+            val favoriteIds = favorites.map { it.modelKey }.toSet()
+            val idsToRemove = shortcutIds - favoriteIds
+            ShortcutManagerCompat.removeDynamicShortcuts(context, idsToRemove)
+        }
+
+        private suspend fun Favorite.getShortcutInfo(): ShortcutInfoCompat? =
+            when (modelType) {
+                ModelType.TEAM -> getTeamShortcut(modelKey)
+                ModelType.EVENT -> getEventShortcut(modelKey)
+                else -> null
+            }
+
+        private suspend fun getTeamShortcut(teamKey: String): ShortcutInfoCompat? {
+            val currentSeason: Int =
+                try {
+                    tbaApi.getStatus().currentSeason
+                } catch (_: Exception) {
+                    Log.w("TBAShortcutManager", "Failed to fetch current season")
+                    return null
                 }
-        }
-    }
 
-    /**
-     * Remove any shortcuts in ShortcutManager that are no longer favorites
-     */
-    private fun purgeUnfavoritedShortcuts(favorites: List<Favorite>) {
-        val shortcutIds = ShortcutManagerCompat.getDynamicShortcuts(context).map { it.id }
-        val favoriteIds = favorites.map { it.modelKey }.toSet()
-        val idsToRemove = shortcutIds - favoriteIds
-        ShortcutManagerCompat.removeDynamicShortcuts(context, idsToRemove)
-    }
-
-    private suspend fun Favorite.getShortcutInfo(): ShortcutInfoCompat? {
-        return when (modelType) {
-            ModelType.TEAM -> getTeamShortcut(modelKey)
-            ModelType.EVENT -> getEventShortcut(modelKey)
-            else -> null
-        }
-    }
-
-    private suspend fun getTeamShortcut(teamKey: String): ShortcutInfoCompat? {
-        val currentSeason: Int = try {
-            tbaApi.getStatus().currentSeason
-        } catch(_: Exception) {
-            Log.w("TBAShortcutManager", "Failed to fetch current season")
-            return null
-        }
-
-        // Start by ensuring we have the latest team info in the repository
-        // Particularly important for teams, as we don't start loading teams on app launch
-        try {
-            teamRepository.refreshTeam(teamKey)
-            teamRepository.refreshTeamMedia(teamKey, currentSeason)
-        } catch (_: Exception) {
-            Log.w("TBAShortcutManager", "Failed to refresh team $teamKey")
-        }
-
-        val team = teamRepository.observeTeam(teamKey).first() ?: return null
-        val media = teamRepository.observeTeamMedia(teamKey, currentSeason).first()
-
-        val label = "${team.number} ${team.nickname}"
-        val uri = "https://www.thebluealliance.com/team/${team.number}".toUri()
-        val avatar = media.firstOrNull { it.isAvatar }
-
-        return ShortcutInfoCompat.Builder(context, teamKey)
-            .setShortLabel(label)
-            .setIcon(getTeamShortcutIcon(avatar))
-            .setIntent(generateIntent(uri))
-            .build()
-    }
-
-    private fun getTeamShortcutIcon(avatar: Media?): IconCompat {
-        if (avatar != null) {
+            // Start by ensuring we have the latest team info in the repository
+            // Particularly important for teams, as we don't start loading teams on app launch
             try {
-                val bytes = Base64.decode(avatar.base64Image, Base64.DEFAULT)
-                val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-                val density = context.resources.displayMetrics.density
-                val roundedBitmap = bitmap.addRoundedCorners(4f * density)
-                return IconCompat.createWithBitmap(roundedBitmap)
-            } catch (_: Exception) {}
+                teamRepository.refreshTeam(teamKey)
+                teamRepository.refreshTeamMedia(teamKey, currentSeason)
+            } catch (_: Exception) {
+                Log.w("TBAShortcutManager", "Failed to refresh team $teamKey")
+            }
+
+            val team = teamRepository.observeTeam(teamKey).first() ?: return null
+            val media = teamRepository.observeTeamMedia(teamKey, currentSeason).first()
+
+            val label = "${team.number} ${team.nickname}"
+            val uri = "https://www.thebluealliance.com/team/${team.number}".toUri()
+            val avatar = media.firstOrNull { it.isAvatar }
+
+            return ShortcutInfoCompat
+                .Builder(context, teamKey)
+                .setShortLabel(label)
+                .setIcon(getTeamShortcutIcon(avatar))
+                .setIntent(generateIntent(uri))
+                .build()
         }
 
-        return IconCompat.createWithResource(context, R.drawable.ic_team_shortcut)
-    }
+        private fun getTeamShortcutIcon(avatar: Media?): IconCompat {
+            if (avatar != null) {
+                try {
+                    val bytes = Base64.decode(avatar.base64Image, Base64.DEFAULT)
+                    val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                    val density = context.resources.displayMetrics.density
+                    val roundedBitmap = bitmap.addRoundedCorners(4f * density)
+                    return IconCompat.createWithBitmap(roundedBitmap)
+                } catch (_: Exception) {
+                }
+            }
 
-    private suspend fun getEventShortcut(eventKey: String): ShortcutInfoCompat? {
-        // Start by ensuring we have the latest event info in our repository
-        try {
-            eventRepository.refreshEvent(eventKey)
-        } catch (_: Exception) {
-            Log.w("TBAShortcutManager", "Failed to refresh event $eventKey")
+            return IconCompat.createWithResource(context, R.drawable.ic_team_shortcut)
         }
 
-        val event = eventRepository.observeEvent(eventKey).first() ?: return null
-        val label = "${event.year} ${event.name}"
-        val uri = "https://www.thebluealliance.com/event/${event.key}".toUri()
+        private suspend fun getEventShortcut(eventKey: String): ShortcutInfoCompat? {
+            // Start by ensuring we have the latest event info in our repository
+            try {
+                eventRepository.refreshEvent(eventKey)
+            } catch (_: Exception) {
+                Log.w("TBAShortcutManager", "Failed to refresh event $eventKey")
+            }
 
-        return ShortcutInfoCompat.Builder(context, eventKey)
-            .setShortLabel(label)
-            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_event_shortcut))
-            .setIntent(generateIntent(uri))
-            .build()
-    }
+            val event = eventRepository.observeEvent(eventKey).first() ?: return null
+            val label = "${event.year} ${event.name}"
+            val uri = "https://www.thebluealliance.com/event/${event.key}".toUri()
 
-    private fun generateIntent(uri: Uri): Intent {
-        return Intent(Intent.ACTION_VIEW, uri).apply {
-            setClassName(context, "com.thebluealliance.android.LaunchShortcutActivity")
-        }
-    }
-
-    /**
-     * Returns whether the device supports pinning shortcuts to the home screen.
-     */
-    fun canPinShortcuts(): Boolean {
-        return ShortcutManagerCompat.isRequestPinShortcutSupported(context)
-    }
-
-    /**
-     * Request to pin a shortcut for the given favorite to the user's home screen.
-     * This will prompt the user with the system's pinned shortcut dialog.
-     */
-    suspend fun requestPinShortcut(favorite: Favorite) {
-        val shortcutInfo = favorite.getShortcutInfo()
-        if (shortcutInfo == null) {
-            Toast.makeText(
-                context,
-                "Failed to create shortcut",
-                Toast.LENGTH_SHORT
-            ).show()
-            return
+            return ShortcutInfoCompat
+                .Builder(context, eventKey)
+                .setShortLabel(label)
+                .setIcon(IconCompat.createWithResource(context, R.drawable.ic_event_shortcut))
+                .setIntent(generateIntent(uri))
+                .build()
         }
 
-        val success = ShortcutManagerCompat.requestPinShortcut(context, shortcutInfo, null)
-        if (!success) {
-            Toast.makeText(
-                context,
-                "Failed to add shortcut to home screen",
-                Toast.LENGTH_SHORT
-            ).show()
+        private fun generateIntent(uri: Uri): Intent =
+            Intent(Intent.ACTION_VIEW, uri).apply {
+                setClassName(context, "com.thebluealliance.android.LaunchShortcutActivity")
+            }
+
+        /**
+         * Returns whether the device supports pinning shortcuts to the home screen.
+         */
+        fun canPinShortcuts(): Boolean =
+            ShortcutManagerCompat.isRequestPinShortcutSupported(context)
+
+        /**
+         * Request to pin a shortcut for the given favorite to the user's home screen.
+         * This will prompt the user with the system's pinned shortcut dialog.
+         */
+        suspend fun requestPinShortcut(favorite: Favorite) {
+            val shortcutInfo = favorite.getShortcutInfo()
+            if (shortcutInfo == null) {
+                Toast
+                    .makeText(
+                        context,
+                        "Failed to create shortcut",
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                return
+            }
+
+            val success = ShortcutManagerCompat.requestPinShortcut(context, shortcutInfo, null)
+            if (!success) {
+                Toast
+                    .makeText(
+                        context,
+                        "Failed to add shortcut to home screen",
+                        Toast.LENGTH_SHORT,
+                    ).show()
+            }
         }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/TBAApp.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/TBAApp.kt
@@ -13,11 +13,11 @@ import com.google.firebase.Firebase
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.analytics
 import com.google.firebase.analytics.logEvent
+import com.thebluealliance.android.config.ThemePreferences
 import com.thebluealliance.android.navigation.NavigationState
 import com.thebluealliance.android.navigation.Screen
 import com.thebluealliance.android.navigation.TBANavigation
 import com.thebluealliance.android.navigation.rememberNavigationState
-import com.thebluealliance.android.config.ThemePreferences
 import com.thebluealliance.android.ui.theme.TBATheme
 import com.thebluealliance.android.ui.theme.ThemeMode
 import kotlinx.coroutines.flow.collectLatest
@@ -28,22 +28,27 @@ fun TBAApp(
     isNewTask: Boolean,
     themePreferences: ThemePreferences? = null,
 ) {
-    val navState = rememberNavigationState(
-        startRoute = startRoute,
-        topLevelRoutes = TOP_LEVEL_DESTINATIONS.map { it.key },
-        startTopLevelRoute = TOP_LEVEL_DESTINATIONS.first().key,
-        isNewTask = isNewTask,
-    )
+    val navState =
+        rememberNavigationState(
+            startRoute = startRoute,
+            topLevelRoutes = TOP_LEVEL_DESTINATIONS.map { it.key },
+            startTopLevelRoute = TOP_LEVEL_DESTINATIONS.first().key,
+            isNewTask = isNewTask,
+        )
     FirebaseAnalyticsEffect(navState)
 
-    val themeMode by (themePreferences?.themeModeFlow
-        ?.collectAsStateWithLifecycle(ThemeMode.AUTO)
-        ?: remember { mutableStateOf(ThemeMode.AUTO) })
-    val darkTheme = when (themeMode) {
-        ThemeMode.AUTO -> isSystemInDarkTheme()
-        ThemeMode.LIGHT -> false
-        ThemeMode.DARK -> true
-    }
+    val themeMode by (
+        themePreferences
+            ?.themeModeFlow
+            ?.collectAsStateWithLifecycle(ThemeMode.AUTO)
+            ?: remember { mutableStateOf(ThemeMode.AUTO) }
+    )
+    val darkTheme =
+        when (themeMode) {
+            ThemeMode.AUTO -> isSystemInDarkTheme()
+            ThemeMode.LIGHT -> false
+            ThemeMode.DARK -> true
+        }
 
     TBATheme(darkTheme = darkTheme) {
         TBANavigation(
@@ -53,31 +58,30 @@ fun TBAApp(
 }
 
 @Composable
-private fun FirebaseAnalyticsEffect(
-    navState: NavigationState
-) {
+private fun FirebaseAnalyticsEffect(navState: NavigationState) {
     val firebaseAnalytics = remember { Firebase.analytics }
     LaunchedEffect(navState) {
         snapshotFlow { navState.currentRoute }
             .collectLatest { currentRoute ->
-                val screenName = when (currentRoute) {
-                    Screen.Events -> "Events"
-                    Screen.Teams -> "Teams"
-                    Screen.Districts -> "Districts"
-                    Screen.RegionalAdvancement -> "RegionalAdvancement"
-                    Screen.More -> "More"
-                    is Screen.EventDetail -> "EventDetail"
-                    is Screen.TeamDetail -> "TeamDetail"
-                    is Screen.MatchDetail -> "MatchDetail"
-                    is Screen.TeamEventDetail -> "TeamEventDetail"
-                    is Screen.DistrictDetail -> "DistrictDetail"
-                    Screen.MyTBA -> "MyTBA"
-                    Screen.Search -> "Search"
-                    Screen.Settings -> "Settings"
-                    Screen.About -> "About"
-                    Screen.Thanks -> "Thanks"
-                    else -> null
-                }
+                val screenName =
+                    when (currentRoute) {
+                        Screen.Events -> "Events"
+                        Screen.Teams -> "Teams"
+                        Screen.Districts -> "Districts"
+                        Screen.RegionalAdvancement -> "RegionalAdvancement"
+                        Screen.More -> "More"
+                        is Screen.EventDetail -> "EventDetail"
+                        is Screen.TeamDetail -> "TeamDetail"
+                        is Screen.MatchDetail -> "MatchDetail"
+                        is Screen.TeamEventDetail -> "TeamEventDetail"
+                        is Screen.DistrictDetail -> "DistrictDetail"
+                        Screen.MyTBA -> "MyTBA"
+                        Screen.Search -> "Search"
+                        Screen.Settings -> "Settings"
+                        Screen.About -> "About"
+                        Screen.Thanks -> "Thanks"
+                        else -> null
+                    }
                 if (screenName != null) {
                     firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
                         param(FirebaseAnalytics.Param.SCREEN_NAME, screenName)

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/TopLevelDestinations.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/TopLevelDestinations.kt
@@ -20,9 +20,15 @@ data class TopLevelDestination(
     val unselectedIcon: ImageVector,
 )
 
-val TOP_LEVEL_DESTINATIONS = listOf(
-    TopLevelDestination(Screen.Events, "Events", Icons.Filled.CalendarMonth, Icons.Outlined.CalendarMonth),
-    TopLevelDestination(Screen.Teams, "Teams", Icons.Filled.Groups, Icons.Outlined.Groups),
-    TopLevelDestination(Screen.Districts, "Districts", Icons.Filled.Map, Icons.Outlined.Map),
-    TopLevelDestination(Screen.More, "More", Icons.Filled.Menu, Icons.Outlined.Menu),
-)
+val TOP_LEVEL_DESTINATIONS =
+    listOf(
+        TopLevelDestination(
+            Screen.Events,
+            "Events",
+            Icons.Filled.CalendarMonth,
+            Icons.Outlined.CalendarMonth,
+        ),
+        TopLevelDestination(Screen.Teams, "Teams", Icons.Filled.Groups, Icons.Outlined.Groups),
+        TopLevelDestination(Screen.Districts, "Districts", Icons.Filled.Map, Icons.Outlined.Map),
+        TopLevelDestination(Screen.More, "More", Icons.Filled.Menu, Icons.Outlined.Menu),
+    )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/common/EmptyBox.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/common/EmptyBox.kt
@@ -22,4 +22,3 @@ fun EmptyBox(
         Text(message, style = MaterialTheme.typography.bodyLarge)
     }
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/common/LoadingBox.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/common/LoadingBox.kt
@@ -10,13 +10,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-fun LoadingBox(
-    modifier: Modifier = Modifier,
-) {
-  Box(
-      modifier.fillMaxSize().verticalScroll(rememberScrollState()),
-      contentAlignment = Alignment.Center,
-  ) {
-    CircularProgressIndicator()
-  }
+fun LoadingBox(modifier: Modifier = Modifier) {
+    Box(
+        modifier.fillMaxSize().verticalScroll(rememberScrollState()),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/common/ShareUtils.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/common/ShareUtils.kt
@@ -3,10 +3,14 @@ package com.thebluealliance.android.ui.common
 import android.content.Context
 import android.content.Intent
 
-fun Context.shareTbaUrl(title: String, url: String) {
-    val intent = Intent(Intent.ACTION_SEND).apply {
-        type = "text/plain"
-        putExtra(Intent.EXTRA_TEXT, "$title\n$url")
-    }
+fun Context.shareTbaUrl(
+    title: String,
+    url: String,
+) {
+    val intent =
+        Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, "$title\n$url")
+        }
     startActivity(Intent.createChooser(intent, null))
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/EventRow.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/EventRow.kt
@@ -28,10 +28,11 @@ fun EventRow(
     showChevron: Boolean = false,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
@@ -41,8 +42,9 @@ fun EventRow(
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Medium,
             )
-            val location = listOfNotNull(event.city, event.state, event.country)
-                .joinToString(", ")
+            val location =
+                listOfNotNull(event.city, event.state, event.country)
+                    .joinToString(", ")
             if (location.isNotEmpty()) {
                 Text(
                     text = location,
@@ -74,7 +76,10 @@ internal val fullFormat: DateTimeFormatter =
 internal val noYearFormat: DateTimeFormatter =
     DateTimeFormatter.ofPattern("EEE, MMM d", Locale.US)
 
-internal fun formatEventDateRange(startDate: String?, endDate: String?): String? {
+internal fun formatEventDateRange(
+    startDate: String?,
+    endDate: String?,
+): String? {
     if (startDate == null) return null
     val start = LocalDate.parse(startDate)
     val end = endDate?.let { LocalDate.parse(it) }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/FastScrollbar.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/FastScrollbar.kt
@@ -47,8 +47,11 @@ fun FastScrollbar(
     val totalItems by remember { derivedStateOf { listState.layoutInfo.totalItemsCount } }
     val thumbFraction by remember {
         derivedStateOf {
-            if (totalItems == 0) 0f
-            else listState.firstVisibleItemIndex.toFloat() / totalItems
+            if (totalItems == 0) {
+                0f
+            } else {
+                listState.firstVisibleItemIndex.toFloat() / totalItems
+            }
         }
     }
     val isScrolling by remember { derivedStateOf { listState.isScrollInProgress } }
@@ -73,43 +76,54 @@ fun FastScrollbar(
         if (totalItems > 0) {
             // Invisible touch target: full-height strip on the right edge for drag gestures
             Box(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .fillMaxHeight()
-                    .width(TouchTargetWidth)
-                    .onSizeChanged { trackHeightPx = it.height.toFloat() }
-                    .pointerInput(totalItems) {
-                        detectVerticalDragGestures(
-                            onDragStart = { isDragging = true },
-                            onDragEnd = { isDragging = false },
-                            onDragCancel = { isDragging = false },
-                            onVerticalDrag = { change, _ ->
-                                change.consume()
-                                val fraction = (change.position.y / trackHeightPx).coerceIn(0f, 1f)
-                                val targetIndex = (fraction * totalItems).roundToInt()
-                                    .coerceIn(0, (totalItems - 1).coerceAtLeast(0))
-                                listState.requestScrollToItem(targetIndex)
-                            },
-                        )
-                    },
+                modifier =
+                    Modifier
+                        .align(Alignment.TopEnd)
+                        .fillMaxHeight()
+                        .width(TouchTargetWidth)
+                        .onSizeChanged { trackHeightPx = it.height.toFloat() }
+                        .pointerInput(totalItems) {
+                            detectVerticalDragGestures(
+                                onDragStart = { isDragging = true },
+                                onDragEnd = { isDragging = false },
+                                onDragCancel = { isDragging = false },
+                                onVerticalDrag = { change, _ ->
+                                    change.consume()
+                                    val fraction =
+                                        (change.position.y / trackHeightPx).coerceIn(
+                                            0f,
+                                            1f,
+                                        )
+                                    val targetIndex =
+                                        (fraction * totalItems)
+                                            .roundToInt()
+                                            .coerceIn(0, (totalItems - 1).coerceAtLeast(0))
+                                    listState.requestScrollToItem(targetIndex)
+                                },
+                            )
+                        },
             )
 
             // Visible thumb indicator
             Box(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(end = 4.dp)
-                    .alpha(alpha.value)
-                    .offset {
-                        val thumbHeightPx = ThumbHeight.toPx()
-                        val scrollableTrack = (trackHeightPx - thumbHeightPx).coerceAtLeast(0f)
-                        val offsetY = (thumbFraction * scrollableTrack).coerceIn(0f, scrollableTrack)
-                        IntOffset(0, offsetY.roundToInt())
-                    }
-                    .width(ThumbWidth)
-                    .height(ThumbHeight)
-                    .clip(RoundedCornerShape(ThumbWidth / 2))
-                    .background(MaterialTheme.colorScheme.onSurfaceVariant),
+                modifier =
+                    Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(end = 4.dp)
+                        .alpha(alpha.value)
+                        .offset {
+                            val thumbHeightPx = ThumbHeight.toPx()
+                            val scrollableTrack = (trackHeightPx - thumbHeightPx).coerceAtLeast(0f)
+                            val offsetY =
+                                (thumbFraction * scrollableTrack).coerceIn(
+                                    0f,
+                                    scrollableTrack,
+                                )
+                            IntOffset(0, offsetY.roundToInt())
+                        }.width(ThumbWidth)
+                        .height(ThumbHeight)
+                        .clip(RoundedCornerShape(ThumbWidth / 2))
+                        .background(MaterialTheme.colorScheme.onSurfaceVariant),
             )
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -60,36 +60,42 @@ fun MatchList(
             item {
                 Box(
                     Modifier.fillParentMaxSize().padding(32.dp),
-                    contentAlignment = Alignment.Center
+                    contentAlignment = Alignment.Center,
                 ) {
-                    if (matches == null) CircularProgressIndicator()
-                    else Text("No matches", style = MaterialTheme.typography.bodyLarge)
+                    if (matches == null) {
+                        CircularProgressIndicator()
+                    } else {
+                        Text("No matches", style = MaterialTheme.typography.bodyLarge)
+                    }
                 }
             }
         }
         return
     }
 
-    val grouped = remember(matches) {
-        val sorted = matches.sortedWith(
-            compareBy({ it.compLevel.order }, { it.setNumber }, { it.matchNumber })
-        )
-        sorted.groupBy { it.getGroup(playoffType) }
-    }
+    val grouped =
+        remember(matches) {
+            val sorted =
+                matches.sortedWith(
+                    compareBy({ it.compLevel.order }, { it.setNumber }, { it.matchNumber }),
+                )
+            sorted.groupBy { it.getGroup(playoffType) }
+        }
 
     // Calculate index of first unplayed match for auto-scroll
     val headerOffset = headerItemCount
-    val firstUnplayedIndex = run {
-        var index = headerOffset
-        for ((_, levelMatches) in grouped) {
-            index++ // group header
-            for (match in levelMatches) {
-                if (match.redScore < 0) return@run index
-                index++
+    val firstUnplayedIndex =
+        run {
+            var index = headerOffset
+            for ((_, levelMatches) in grouped) {
+                index++ // group header
+                for (match in levelMatches) {
+                    if (match.redScore < 0) return@run index
+                    index++
+                }
             }
+            -1
         }
-        -1
-    }
     // Scroll so the last few played matches are visible above the first unplayed
     val scrollTarget = if (firstUnplayedIndex > 2) firstUnplayedIndex - 2 else 0
     val listState = rememberLazyListState()
@@ -99,26 +105,28 @@ fun MatchList(
         }
     }
 
-    val headerInfos = remember(grouped, headerOffset) {
-        buildList {
-            var index = headerOffset
-            grouped.forEach { (group, levelMatches) ->
-                val headerKey = "match_header_${group.label}"
-                add(SectionHeaderInfo(headerKey, group.label, index))
-                index += 1 + levelMatches.size // header + items
+    val headerInfos =
+        remember(grouped, headerOffset) {
+            buildList {
+                var index = headerOffset
+                grouped.forEach { (group, levelMatches) ->
+                    val headerKey = "match_header_${group.label}"
+                    add(SectionHeaderInfo(headerKey, group.label, index))
+                    index += 1 + levelMatches.size // header + items
+                }
             }
         }
-    }
 
     val headerKeys = remember(headerInfos) { headerInfos.map { it.key }.toSet() }
 
     val stuckHeaderKey by remember {
         derivedStateOf {
-            val stuck = listState.layoutInfo.visibleItemsInfo
-                .firstOrNull { item ->
-                    val key = item.key as? String
-                    key != null && key in headerKeys && item.offset <= 0
-                }?.key as? String
+            val stuck =
+                listState.layoutInfo.visibleItemsInfo
+                    .firstOrNull { item ->
+                        val key = item.key as? String
+                        key != null && key in headerKeys && item.offset <= 0
+                    }?.key as? String
             stuck ?: headerInfos.firstOrNull()?.key
         }
     }
@@ -151,7 +159,7 @@ fun MatchList(
                 MatchItem(
                     match = match,
                     playoffType = playoffType,
-                    onClick = { onNavigateToMatch(match.key) }
+                    onClick = { onNavigateToMatch(match.key) },
                 )
                 HorizontalDivider()
             }
@@ -163,7 +171,7 @@ fun MatchList(
 fun MatchItem(
     match: Match,
     playoffType: PlayoffType,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     val label = match.getShortLabel(playoffType)
     val isPlayed = match.redScore >= 0
@@ -171,10 +179,11 @@ fun MatchItem(
     val rpBonuses = remember(match.scoreBreakdown) { match.rpBonuses() }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 6.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -187,15 +196,25 @@ fun MatchItem(
         Column(modifier = Modifier.weight(0.35f)) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(3.dp)
+                horizontalArrangement = Arrangement.spacedBy(3.dp),
             ) {
                 match.redPlayoffAlliance?.let { alliance ->
                     Surface(
                         shape = MaterialTheme.shapes.extraSmall,
-                        color = if (match.winningAlliance == "red") MaterialTheme.colorScheme.error
-                            else MaterialTheme.colorScheme.errorContainer,
-                        contentColor = if (match.winningAlliance == "red") MaterialTheme.colorScheme.onError
-                            else MaterialTheme.colorScheme.onErrorContainer,
+                        color =
+                            if (match.winningAlliance == "red") {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.errorContainer
+                            },
+                        contentColor =
+                            if (match.winningAlliance ==
+                                "red"
+                            ) {
+                                MaterialTheme.colorScheme.onError
+                            } else {
+                                MaterialTheme.colorScheme.onErrorContainer
+                            },
                     ) {
                         Text(
                             text = alliance.displayTitleShort,
@@ -207,22 +226,41 @@ fun MatchItem(
                 Text(
                     text = match.redTeamKeys.joinToString(", ") { it.removePrefix("frc") },
                     style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = if (match.winningAlliance == "red") FontWeight.Bold else FontWeight.Normal,
+                    fontWeight =
+                        if (match.winningAlliance ==
+                            "red"
+                        ) {
+                            FontWeight.Bold
+                        } else {
+                            FontWeight.Normal
+                        },
                     color = MaterialTheme.colorScheme.error,
                 )
             }
 
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(3.dp)
+                horizontalArrangement = Arrangement.spacedBy(3.dp),
             ) {
                 match.bluePlayoffAlliance?.let { alliance ->
                     Surface(
                         shape = MaterialTheme.shapes.extraSmall,
-                        color = if (match.winningAlliance == "blue") MaterialTheme.colorScheme.primary
-                            else MaterialTheme.colorScheme.primaryContainer,
-                        contentColor = if (match.winningAlliance == "blue") MaterialTheme.colorScheme.onPrimary
-                            else MaterialTheme.colorScheme.onPrimaryContainer,
+                        color =
+                            if (match.winningAlliance ==
+                                "blue"
+                            ) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.primaryContainer
+                            },
+                        contentColor =
+                            if (match.winningAlliance ==
+                                "blue"
+                            ) {
+                                MaterialTheme.colorScheme.onPrimary
+                            } else {
+                                MaterialTheme.colorScheme.onPrimaryContainer
+                            },
                     ) {
                         Text(
                             text = alliance.displayTitleShort,
@@ -234,7 +272,14 @@ fun MatchItem(
                 Text(
                     text = match.blueTeamKeys.joinToString(", ") { it.removePrefix("frc") },
                     style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = if (match.winningAlliance == "blue") FontWeight.Bold else FontWeight.Normal,
+                    fontWeight =
+                        if (match.winningAlliance ==
+                            "blue"
+                        ) {
+                            FontWeight.Bold
+                        } else {
+                            FontWeight.Normal
+                        },
                     color = MaterialTheme.colorScheme.primary,
                 )
             }
@@ -256,13 +301,27 @@ fun MatchItem(
                 Text(
                     text = match.redScore.toString(),
                     style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = if (match.winningAlliance == "red") FontWeight.Bold else FontWeight.Normal,
+                    fontWeight =
+                        if (match.winningAlliance ==
+                            "red"
+                        ) {
+                            FontWeight.Bold
+                        } else {
+                            FontWeight.Normal
+                        },
                     color = MaterialTheme.colorScheme.error,
                 )
                 Text(
                     text = match.blueScore.toString(),
                     style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = if (match.winningAlliance == "blue") FontWeight.Bold else FontWeight.Normal,
+                    fontWeight =
+                        if (match.winningAlliance ==
+                            "blue"
+                        ) {
+                            FontWeight.Bold
+                        } else {
+                            FontWeight.Normal
+                        },
                     color = MaterialTheme.colorScheme.primary,
                 )
             }
@@ -272,8 +331,10 @@ fun MatchItem(
                 horizontalAlignment = Alignment.End,
             ) {
                 val displayTime = match.predictedTime ?: match.time
-                val isEstimate = match.predictedTime != null && match.time != null &&
-                    kotlin.math.abs(match.predictedTime - match.time) > 60
+                val isEstimate =
+                    match.predictedTime != null &&
+                        match.time != null &&
+                        kotlin.math.abs(match.predictedTime - match.time) > 60
                 Text(
                     text = formatMatchTime(displayTime),
                     style = MaterialTheme.typography.bodyMedium,
@@ -291,19 +352,26 @@ fun MatchItem(
     }
 }
 
-private val matchTimeFormat = java.time.format.DateTimeFormatter.ofPattern(
-    "EEE h:mma", java.util.Locale.US,
-)
+private val matchTimeFormat =
+    java.time.format.DateTimeFormatter.ofPattern(
+        "EEE h:mma",
+        java.util.Locale.US,
+    )
 
 fun formatMatchTime(epochSeconds: Long?): String {
     if (epochSeconds == null) return "\u2014"
     val instant = java.time.Instant.ofEpochSecond(epochSeconds)
-    return matchTimeFormat.format(instant.atZone(java.time.ZoneId.systemDefault()))
-        .replace("AM", "a").replace("PM", "p")
+    return matchTimeFormat
+        .format(instant.atZone(java.time.ZoneId.systemDefault()))
+        .replace("AM", "a")
+        .replace("PM", "p")
 }
 
 @Composable
-private fun RpDots(bonuses: List<Boolean>, achievedColor: Color) {
+private fun RpDots(
+    bonuses: List<Boolean>,
+    achievedColor: Color,
+) {
     Row(
         modifier = Modifier.padding(end = 3.dp),
         horizontalArrangement = Arrangement.spacedBy(2.dp),
@@ -327,4 +395,3 @@ private fun RpDots(bonuses: List<Boolean>, achievedColor: Color) {
         }
     }
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MediaGrid.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MediaGrid.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -46,26 +45,34 @@ data class MediaGridItem(
 /**
  * Returns a thumbnail URL for a media item, or null if the type isn't supported.
  */
-fun mediaUrl(type: String, foreignKey: String): String? = when (type) {
-    "imgur" -> "https://i.imgur.com/${foreignKey}.png"
-    "cdphotothread" -> "https://www.chiefdelphi.com/media/img/${foreignKey}"
-    "instagram-image" -> "https://www.instagram.com/p/${foreignKey}/media/"
-    "youtube" -> "https://img.youtube.com/vi/${foreignKey}/hqdefault.jpg"
-    "grabcad" -> null
-    "onshape" -> null
-    else -> null
-}
+fun mediaUrl(
+    type: String,
+    foreignKey: String,
+): String? =
+    when (type) {
+        "imgur" -> "https://i.imgur.com/$foreignKey.png"
+        "cdphotothread" -> "https://www.chiefdelphi.com/media/img/$foreignKey"
+        "instagram-image" -> "https://www.instagram.com/p/$foreignKey/media/"
+        "youtube" -> "https://img.youtube.com/vi/$foreignKey/hqdefault.jpg"
+        "grabcad" -> null
+        "onshape" -> null
+        else -> null
+    }
 
 /**
  * Returns the external link URL for a media item, or null if the type isn't supported.
  */
-fun mediaLinkUrl(type: String, foreignKey: String): String? = when (type) {
-    "imgur" -> "https://imgur.com/${foreignKey}"
-    "cdphotothread" -> "https://www.chiefdelphi.com/media/img/${foreignKey}"
-    "instagram-image" -> "https://www.instagram.com/p/${foreignKey}/"
-    "youtube" -> "https://www.youtube.com/watch?v=${foreignKey}"
-    else -> null
-}
+fun mediaLinkUrl(
+    type: String,
+    foreignKey: String,
+): String? =
+    when (type) {
+        "imgur" -> "https://imgur.com/$foreignKey"
+        "cdphotothread" -> "https://www.chiefdelphi.com/media/img/$foreignKey"
+        "instagram-image" -> "https://www.instagram.com/p/$foreignKey/"
+        "youtube" -> "https://www.youtube.com/watch?v=$foreignKey"
+        else -> null
+    }
 
 /**
  * A single media item with thumbnail, optional play overlay for YouTube, and click-to-open.
@@ -81,18 +88,19 @@ fun MediaItem(
     val context = LocalContext.current
 
     Box(
-        modifier = modifier
-            .aspectRatio(1f)
-            .clip(MaterialTheme.shapes.medium)
-            .then(
-                if (linkUrl != null) {
-                    Modifier.clickable {
-                        context.openUrl(linkUrl)
-                    }
-                } else {
-                    Modifier
-                }
-            ),
+        modifier =
+            modifier
+                .aspectRatio(1f)
+                .clip(MaterialTheme.shapes.medium)
+                .then(
+                    if (linkUrl != null) {
+                        Modifier.clickable {
+                            context.openUrl(linkUrl)
+                        }
+                    } else {
+                        Modifier
+                    },
+                ),
     ) {
         AsyncImage(
             model = url,
@@ -102,10 +110,11 @@ fun MediaItem(
         )
         if (type == "youtube") {
             Box(
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .size(48.dp)
-                    .background(Color.Black.copy(alpha = 0.5f), CircleShape),
+                modifier =
+                    Modifier
+                        .align(Alignment.Center)
+                        .size(48.dp)
+                        .background(Color.Black.copy(alpha = 0.5f), CircleShape),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
@@ -164,20 +173,24 @@ fun MediaTab(
     if (filtered.isEmpty()) {
         EmptyBox(
             modifier = Modifier.padding(innerPadding),
-            message = "No media"
+            message = "No media",
         )
         return
     }
-    val gridItems = filtered.mapNotNull { item ->
-        if (mediaUrl(item.type, item.foreignKey) != null) {
-            MediaGridItem(type = item.type, foreignKey = item.foreignKey)
-        } else null
-    }
+    val gridItems =
+        filtered.mapNotNull { item ->
+            if (mediaUrl(item.type, item.foreignKey) != null) {
+                MediaGridItem(type = item.type, foreignKey = item.foreignKey)
+            } else {
+                null
+            }
+        }
     LazyVerticalGrid(
         columns = GridCells.Fixed(2),
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(8.dp),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         contentPadding = innerPadding,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/NotificationPreferencesSheet.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/NotificationPreferencesSheet.kt
@@ -32,9 +32,10 @@ fun NotificationPreferencesSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val availableTypes = NotificationType.forModelType(modelType)
-    val selectedNotifications = remember {
-        mutableStateListOf<String>().apply { addAll(currentNotifications) }
-    }
+    val selectedNotifications =
+        remember {
+            mutableStateListOf<String>().apply { addAll(currentNotifications) }
+        }
     val favoriteState = remember { androidx.compose.runtime.mutableStateOf(isFavorite) }
 
     ModalBottomSheet(
@@ -85,8 +86,11 @@ fun NotificationPreferencesSheet(
                     Switch(
                         checked = type.serverKey in selectedNotifications,
                         onCheckedChange = { checked ->
-                            if (checked) selectedNotifications.add(type.serverKey)
-                            else selectedNotifications.remove(type.serverKey)
+                            if (checked) {
+                                selectedNotifications.add(type.serverKey)
+                            } else {
+                                selectedNotifications.remove(type.serverKey)
+                            }
                         },
                     )
                 }
@@ -94,9 +98,10 @@ fun NotificationPreferencesSheet(
 
             TextButton(
                 onClick = { onSave(favoriteState.value, selectedNotifications.toList()) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp, bottom = 24.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp, bottom = 24.dp),
             ) {
                 Text("Save")
             }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/SectionHeader.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/SectionHeader.kt
@@ -28,7 +28,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.ui.theme.TBAIndigo400
 
-data class SectionHeaderInfo(val key: String, val label: String, val itemIndex: Int)
+data class SectionHeaderInfo(
+    val key: String,
+    val label: String,
+    val itemIndex: Int,
+)
 
 @Composable
 fun SectionHeader(
@@ -40,15 +44,17 @@ fun SectionHeader(
     var menuExpanded by remember { mutableStateOf(false) }
 
     Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(TBAIndigo400)
-            .clickable(enabled = isStuck) { menuExpanded = true },
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(TBAIndigo400)
+                .clickable(enabled = isStuck) { menuExpanded = true },
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -77,12 +83,20 @@ fun SectionHeader(
                     text = {
                         Text(
                             text = info.label,
-                            fontWeight = if (info.label == label) FontWeight.Bold else FontWeight.Normal,
-                            color = if (info.label == label) {
-                                TBAIndigo400
-                            } else {
-                                MaterialTheme.colorScheme.onSurface
-                            },
+                            fontWeight =
+                                if (info.label ==
+                                    label
+                                ) {
+                                    FontWeight.Bold
+                                } else {
+                                    FontWeight.Normal
+                                },
+                            color =
+                                if (info.label == label) {
+                                    TBAIndigo400
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                },
                         )
                     },
                     onClick = {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBABottomBar.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBABottomBar.kt
@@ -25,16 +25,18 @@ fun TBABottomBar(
         modifier = modifier,
     ) {
         TOP_LEVEL_DESTINATIONS.forEach { dest ->
-            val selected = currentRoute == dest.key || (dest.key == Screen.More && isOnMoreSubScreen)
+            val selected =
+                currentRoute == dest.key || (dest.key == Screen.More && isOnMoreSubScreen)
             NavigationBarItem(
                 selected = selected,
-                onClick = dropUnlessResumed {
-                    if (currentRoute == dest.key) {
-                        onReselect()
-                    } else {
-                        onNavigate(dest.key)
-                    }
-                },
+                onClick =
+                    dropUnlessResumed {
+                        if (currentRoute == dest.key) {
+                            onReselect()
+                        } else {
+                            onNavigate(dest.key)
+                        }
+                    },
                 icon = {
                     Icon(
                         imageVector = if (selected) dest.selectedIcon else dest.unselectedIcon,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBATabRow.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBATabRow.kt
@@ -14,7 +14,7 @@ import com.thebluealliance.android.ui.theme.TBABlue
 fun TBATabRow(
     selectedTabIndex: Int,
     modifier: Modifier = Modifier,
-    tabs: @Composable () -> Unit
+    tabs: @Composable () -> Unit,
 ) {
     PrimaryScrollableTabRow(
         selectedTabIndex = selectedTabIndex,
@@ -29,9 +29,9 @@ fun TBATabRow(
             SecondaryIndicator(
                 modifier = Modifier.tabIndicatorOffset(selectedTabIndex),
                 height = 3.dp,
-                color = Color.White
+                color = Color.White,
             )
         },
-        tabs = tabs
+        tabs = tabs,
     )
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBATopAppBar.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBATopAppBar.kt
@@ -1,17 +1,15 @@
 package com.thebluealliance.android.ui.components
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -27,34 +25,36 @@ fun TBATopAppBar(
     navigationIcon: @Composable () -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {},
     windowInsets: androidx.compose.foundation.layout.WindowInsets = TopAppBarDefaults.windowInsets,
-    colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(
-        containerColor = TBABlue,
-        titleContentColor = Color.White,
-        navigationIconContentColor = Color.White,
-        actionIconContentColor = Color.White,
-    ),
+    colors: TopAppBarColors =
+        TopAppBarDefaults.topAppBarColors(
+            containerColor = TBABlue,
+            titleContentColor = Color.White,
+            navigationIconContentColor = Color.White,
+            actionIconContentColor = Color.White,
+        ),
     scrollBehavior: TopAppBarScrollBehavior? = null,
     showLamp: Boolean = false,
 ) {
     TopAppBar(
         title = title,
         modifier = modifier,
-        navigationIcon = if (showLamp) {
-            {
-                // Use IconButton container (48dp) to match back button width in detail views,
-                // so title text shares a consistent left edge across all screens.
-                IconButton(onClick = {}, enabled = false) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.tba_lamp),
-                        contentDescription = null,
-                        modifier = Modifier.size(24.dp),
-                        tint = Color.White,
-                    )
+        navigationIcon =
+            if (showLamp) {
+                {
+                    // Use IconButton container (48dp) to match back button width in detail views,
+                    // so title text shares a consistent left edge across all screens.
+                    IconButton(onClick = {}, enabled = false) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.tba_lamp),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                            tint = Color.White,
+                        )
+                    }
                 }
-            }
-        } else {
-            navigationIcon
-        },
+            } else {
+                navigationIcon
+            },
         actions = actions,
         windowInsets = windowInsets,
         colors = colors,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/TeamRow.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/TeamRow.kt
@@ -25,10 +25,11 @@ fun TeamRow(
     subtitlePrefix: String? = null,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
@@ -38,7 +39,11 @@ fun TeamRow(
                 fontWeight = FontWeight.Medium,
             )
             val location = listOfNotNull(team.city, team.state, team.country).joinToString(", ")
-            val subtitle = listOfNotNull(subtitlePrefix, location.ifEmpty { null }).joinToString(" \u00B7 ")
+            val subtitle =
+                listOfNotNull(
+                    subtitlePrefix,
+                    location.ifEmpty { null },
+                ).joinToString(" \u00B7 ")
             if (subtitle.isNotEmpty()) {
                 Text(
                     text = subtitle,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
@@ -40,11 +40,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.DistrictRanking
+import com.thebluealliance.android.ui.common.EmptyBox
+import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.components.EventRow
 import com.thebluealliance.android.ui.components.SectionHeader
 import com.thebluealliance.android.ui.components.SectionHeaderInfo
-import com.thebluealliance.android.ui.common.EmptyBox
-import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.components.TBATabRow
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.TopBarYearPicker
@@ -99,7 +99,7 @@ fun DistrictDetailScreen(
                         IconButton(onClick = onNavigateUp) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = "Back"
+                                contentDescription = "Back",
                             )
                         }
                     },
@@ -114,11 +114,24 @@ fun DistrictDetailScreen(
                     TABS.forEachIndexed { index, title ->
                         Tab(
                             selected = pagerState.currentPage == index,
-                            onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
+                            onClick = {
+                                coroutineScope.launch {
+                                    pagerState.animateScrollToPage(
+                                        index,
+                                    )
+                                }
+                            },
                             text = {
                                 Text(
                                     text = title,
-                                    color = if (pagerState.currentPage == index) Color.White else Color.White.copy(alpha = 0.7f)
+                                    color =
+                                        if (pagerState.currentPage ==
+                                            index
+                                        ) {
+                                            Color.White
+                                        } else {
+                                            Color.White.copy(alpha = 0.7f)
+                                        },
                                 )
                             },
                         )
@@ -130,26 +143,31 @@ fun DistrictDetailScreen(
         val bottomPadding = PaddingValues(bottom = innerPadding.calculateBottomPadding())
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier.fillMaxSize()
-                .padding(top = innerPadding.calculateTopPadding())
-                .background(MaterialTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(top = innerPadding.calculateTopPadding())
+                    .background(MaterialTheme.colorScheme.background),
         ) { page ->
             PullToRefreshBox(
-                isRefreshing = isRefreshing && uiState.eventSections != null && uiState.rankings != null,
+                isRefreshing =
+                    isRefreshing && uiState.eventSections != null && uiState.rankings != null,
                 onRefresh = { viewModel.refreshTab(page) },
                 modifier = Modifier.fillMaxSize(),
             ) {
                 when (page) {
-                    DistrictDetailTabs.EVENTS -> EventsTab(
-                        sections = uiState.eventSections,
-                        onNavigateToEvent = onNavigateToEvent,
-                        innerPadding = bottomPadding,
-                    )
-                    DistrictDetailTabs.RANKINGS -> RankingsTab(
-                        rankings = uiState.rankings,
-                        onNavigateToTeam = onNavigateToTeam,
-                        innerPadding = bottomPadding,
-                    )
+                    DistrictDetailTabs.EVENTS ->
+                        EventsTab(
+                            sections = uiState.eventSections,
+                            onNavigateToEvent = onNavigateToEvent,
+                            innerPadding = bottomPadding,
+                        )
+                    DistrictDetailTabs.RANKINGS ->
+                        RankingsTab(
+                            rankings = uiState.rankings,
+                            onNavigateToTeam = onNavigateToTeam,
+                            innerPadding = bottomPadding,
+                        )
                 }
             }
         }
@@ -174,37 +192,40 @@ private fun EventsTab(
 
     val allEvents = sections.flatMap { it.events }
     val today = remember { LocalDate.now() }
-    val thisWeekResult = remember(allEvents, today) {
-        computeThisWeekEvents(allEvents, today, today.year)
-    }
+    val thisWeekResult =
+        remember(allEvents, today) {
+            computeThisWeekEvents(allEvents, today, today.year)
+        }
 
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
 
-    val headerInfos = remember(sections, thisWeekResult) {
-        buildList {
-            var index = 0
-            if (thisWeekResult != null) {
-                add(SectionHeaderInfo("this_week_header", thisWeekResult.label, index))
-                index += 1 + thisWeekResult.events.size + 1 // header + items + divider
-            }
-            sections.forEach { section ->
-                val headerKey = "header_${section.label}"
-                add(SectionHeaderInfo(headerKey, section.label, index))
-                index += 1 + section.events.size // header + items
+    val headerInfos =
+        remember(sections, thisWeekResult) {
+            buildList {
+                var index = 0
+                if (thisWeekResult != null) {
+                    add(SectionHeaderInfo("this_week_header", thisWeekResult.label, index))
+                    index += 1 + thisWeekResult.events.size + 1 // header + items + divider
+                }
+                sections.forEach { section ->
+                    val headerKey = "header_${section.label}"
+                    add(SectionHeaderInfo(headerKey, section.label, index))
+                    index += 1 + section.events.size // header + items
+                }
             }
         }
-    }
 
     val headerKeys = remember(headerInfos) { headerInfos.map { it.key }.toSet() }
 
     val stuckHeaderKey by remember {
         derivedStateOf {
-            val stuck = listState.layoutInfo.visibleItemsInfo
-                .firstOrNull { item ->
-                    val key = item.key as? String
-                    key != null && key in headerKeys && item.offset <= 0
-                }?.key as? String
+            val stuck =
+                listState.layoutInfo.visibleItemsInfo
+                    .firstOrNull { item ->
+                        val key = item.key as? String
+                        key != null && key in headerKeys && item.offset <= 0
+                    }?.key as? String
             stuck ?: headerInfos.firstOrNull()?.key
         }
     }
@@ -264,14 +285,14 @@ private fun RankingsTab(
 ) {
     if (rankings == null) {
         LoadingBox(
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
         )
         return
     }
     if (rankings.isEmpty()) {
         EmptyBox(
             modifier = Modifier.padding(innerPadding),
-            message = "No rankings"
+            message = "No rankings",
         )
         return
     }
@@ -281,11 +302,12 @@ private fun RankingsTab(
     ) {
         stickyHeader {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(TBAIndigo400)
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .background(TBAIndigo400)
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
                     text = "Rank",
@@ -293,7 +315,7 @@ private fun RankingsTab(
                     fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.weight(0.10f)
+                    modifier = Modifier.weight(0.10f),
                 )
                 Text(
                     text = "Team",
@@ -301,7 +323,7 @@ private fun RankingsTab(
                     fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.weight(0.15f)
+                    modifier = Modifier.weight(0.15f),
                 )
                 Text(
                     text = "Event\n1",
@@ -309,7 +331,7 @@ private fun RankingsTab(
                     fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.weight(0.15f)
+                    modifier = Modifier.weight(0.15f),
                 )
                 Text(
                     text = "Event\n2",
@@ -317,7 +339,7 @@ private fun RankingsTab(
                     fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.weight(0.15f)
+                    modifier = Modifier.weight(0.15f),
                 )
                 Text(
                     text = "DCMP",
@@ -325,7 +347,7 @@ private fun RankingsTab(
                     fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.weight(0.15f)
+                    modifier = Modifier.weight(0.15f),
                 )
                 Text(
                     text = "Rookie\nBonus",
@@ -333,7 +355,7 @@ private fun RankingsTab(
                     fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.weight(0.15f)
+                    modifier = Modifier.weight(0.15f),
                 )
                 Text(
                     text = "Total\nPoints",
@@ -341,21 +363,43 @@ private fun RankingsTab(
                     fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.weight(0.15f)
+                    modifier = Modifier.weight(0.15f),
                 )
             }
         }
 
         items(rankings, key = { "${it.districtKey}_${it.teamKey}" }) { ranking ->
-            val event1Points = ranking.eventPoints.filter { !it.districtCmp }.getOrNull(0)?.total?.toInt()?.toString() ?: "-"
-            val event2Points = ranking.eventPoints.filter { !it.districtCmp }.getOrNull(1)?.total?.toInt()?.toString() ?: "-"
-            val dcmpPoints = ranking.eventPoints.find { it.districtCmp }?.total?.toInt()?.toString() ?: "-"
+            val event1Points =
+                ranking.eventPoints
+                    .filter { !it.districtCmp }
+                    .getOrNull(
+                        0,
+                    )?.total
+                    ?.toInt()
+                    ?.toString()
+                    ?: "-"
+            val event2Points =
+                ranking.eventPoints
+                    .filter { !it.districtCmp }
+                    .getOrNull(
+                        1,
+                    )?.total
+                    ?.toInt()
+                    ?.toString()
+                    ?: "-"
+            val dcmpPoints =
+                ranking.eventPoints
+                    .find { it.districtCmp }
+                    ?.total
+                    ?.toInt()
+                    ?.toString() ?: "-"
 
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onNavigateToTeam(ranking.teamKey) }
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable { onNavigateToTeam(ranking.teamKey) }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailViewModel.kt
@@ -23,99 +23,124 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel(assistedFactory = DistrictDetailViewModel.Factory::class)
-class DistrictDetailViewModel @AssistedInject constructor(
-    @Assisted val navKey: Screen.DistrictDetail,
-    private val districtRepository: DistrictRepository,
-    private val eventRepository: EventRepository,
-) : ViewModel() {
+class DistrictDetailViewModel
+    @AssistedInject
+    constructor(
+        @Assisted val navKey: Screen.DistrictDetail,
+        private val districtRepository: DistrictRepository,
+        private val eventRepository: EventRepository,
+    ) : ViewModel() {
+        private val initialDistrictKey: String = navKey.districtKey
+        private val districtAbbreviation: String = initialDistrictKey.drop(4)
+        private val initialYear: Int = initialDistrictKey.take(4).toInt()
 
-    private val initialDistrictKey: String = navKey.districtKey
-    private val districtAbbreviation: String = initialDistrictKey.drop(4)
-    private val initialYear: Int = initialDistrictKey.take(4).toInt()
+        private val _selectedYear = MutableStateFlow(initialYear)
+        val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
 
-    private val _selectedYear = MutableStateFlow(initialYear)
-    val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
+        private val _availableYears = MutableStateFlow<List<Int>>(emptyList())
+        val availableYears: StateFlow<List<Int>> = _availableYears.asStateFlow()
 
-    private val _availableYears = MutableStateFlow<List<Int>>(emptyList())
-    val availableYears: StateFlow<List<Int>> = _availableYears.asStateFlow()
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+        val uiState: StateFlow<DistrictDetailUiState> =
+            combine(
+                _selectedYear.flatMapLatest { year ->
+                    districtRepository.observeDistrict("$year$districtAbbreviation")
+                },
+                _selectedYear.flatMapLatest { year ->
+                    eventRepository.observeDistrictEvents("$year$districtAbbreviation")
+                },
+                _selectedYear.flatMapLatest { year ->
+                    districtRepository.observeDistrictRankings("$year$districtAbbreviation")
+                },
+            ) { district, events, rankings ->
+                DistrictDetailUiState(
+                    district = district,
+                    eventSections = if (events.isEmpty()) null else buildEventSections(events),
+                    rankings = rankings,
+                )
+            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DistrictDetailUiState())
 
-    val uiState: StateFlow<DistrictDetailUiState> = combine(
-        _selectedYear.flatMapLatest { year ->
-            districtRepository.observeDistrict("$year$districtAbbreviation")
-        },
-        _selectedYear.flatMapLatest { year ->
-            eventRepository.observeDistrictEvents("$year$districtAbbreviation")
-        },
-        _selectedYear.flatMapLatest { year ->
-            districtRepository.observeDistrictRankings("$year$districtAbbreviation")
-        },
-    ) { district, events, rankings ->
-        DistrictDetailUiState(
-            district = district,
-            eventSections = if (events.isEmpty()) null else buildEventSections(events),
-            rankings = rankings,
-        )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DistrictDetailUiState())
-
-    init {
-        fetchAvailableYears()
-        refreshAll()
-    }
-
-    private fun fetchAvailableYears() {
-        viewModelScope.launch {
-            try {
-                val years = districtRepository.getDistrictHistory(districtAbbreviation)
-                _availableYears.value = years
-            } catch (_: Exception) { }
+        init {
+            fetchAvailableYears()
+            refreshAll()
         }
-    }
 
-    fun selectYear(year: Int) {
-        if (_selectedYear.value == year) return
-        _selectedYear.value = year
-        viewModelScope.launch { refreshYearData() }
-    }
-
-    fun refreshAll() {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                refreshYearData()
-            } finally {
-                _isRefreshing.value = false
-            }
-        }
-    }
-
-    private suspend fun refreshYearData() {
-        val key = "${_selectedYear.value}$districtAbbreviation"
-        coroutineScope {
-            launch { try { eventRepository.refreshDistrictEvents(key) } catch (_: Exception) { } }
-            launch { try { districtRepository.refreshDistrictRankings(key) } catch (_: Exception) { } }
-        }
-    }
-
-    fun refreshTab(tab: Int) {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                val key = "${_selectedYear.value}$districtAbbreviation"
-                when (tab) {
-                    0 -> try { eventRepository.refreshDistrictEvents(key) } catch (_: Exception) {}
-                    1 -> try { districtRepository.refreshDistrictRankings(key) } catch (_: Exception) {}
+        private fun fetchAvailableYears() {
+            viewModelScope.launch {
+                try {
+                    val years = districtRepository.getDistrictHistory(districtAbbreviation)
+                    _availableYears.value = years
+                } catch (_: Exception) {
                 }
-            } finally {
-                _isRefreshing.value = false
             }
         }
-    }
 
-    @AssistedFactory
-    interface Factory {
-        fun create(navKey: Screen.DistrictDetail): DistrictDetailViewModel
+        fun selectYear(year: Int) {
+            if (_selectedYear.value == year) return
+            _selectedYear.value = year
+            viewModelScope.launch { refreshYearData() }
+        }
+
+        fun refreshAll() {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    refreshYearData()
+                } finally {
+                    _isRefreshing.value = false
+                }
+            }
+        }
+
+        private suspend fun refreshYearData() {
+            val key = "${_selectedYear.value}$districtAbbreviation"
+            coroutineScope {
+                launch {
+                    try {
+                        eventRepository.refreshDistrictEvents(key)
+                    } catch (_: Exception) {
+                    }
+                }
+                launch {
+                    try {
+                        districtRepository.refreshDistrictRankings(key)
+                    } catch (
+                        _: Exception,
+                    ) {
+                    }
+                }
+            }
+        }
+
+        fun refreshTab(tab: Int) {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    val key = "${_selectedYear.value}$districtAbbreviation"
+                    when (tab) {
+                        0 ->
+                            try {
+                                eventRepository.refreshDistrictEvents(key)
+                            } catch (_: Exception) {
+                            }
+                        1 ->
+                            try {
+                                districtRepository.refreshDistrictRankings(key)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                    }
+                } finally {
+                    _isRefreshing.value = false
+                }
+            }
+        }
+
+        @AssistedFactory
+        interface Factory {
+            fun create(navKey: Screen.DistrictDetail): DistrictDetailViewModel
+        }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsScreen.kt
@@ -4,16 +4,18 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -37,8 +39,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.District
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.TopBarYearPicker
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Search
 import kotlinx.coroutines.flow.Flow
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -77,7 +77,14 @@ fun DistrictsScreen(
                 title = {
                     TopBarYearPicker(
                         selectedYear = selectedYear,
-                        years = if (selectedYear > 0) (maxYear downTo 2009).toList() else emptyList(),
+                        years =
+                            if (selectedYear >
+                                0
+                            ) {
+                                (maxYear downTo 2009).toList()
+                            } else {
+                                emptyList()
+                            },
                         onYearSelected = viewModel::selectYear,
                         title = { Text("Districts") },
                     )
@@ -92,10 +99,11 @@ fun DistrictsScreen(
         },
     ) { innerPadding ->
         Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
         ) {
             PullToRefreshBox(
                 isRefreshing = isRefreshing && uiState !is DistrictsUiState.Loading,
@@ -140,9 +148,10 @@ private fun DistrictItem(
         text = district.displayName,
         style = MaterialTheme.typography.bodyLarge,
         fontWeight = FontWeight.Medium,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
     )
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsUiState.kt
@@ -4,5 +4,8 @@ import com.thebluealliance.android.domain.model.District
 
 sealed interface DistrictsUiState {
     data object Loading : DistrictsUiState
-    data class Success(val districts: List<District>) : DistrictsUiState
+
+    data class Success(
+        val districts: List<District>,
+    ) : DistrictsUiState
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsViewModel.kt
@@ -18,62 +18,70 @@ import javax.inject.Inject
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @HiltViewModel
-class DistrictsViewModel @Inject constructor(
-    private val districtRepository: DistrictRepository,
-    private val tbaApi: TbaApi,
-) : ViewModel() {
+class DistrictsViewModel
+    @Inject
+    constructor(
+        private val districtRepository: DistrictRepository,
+        private val tbaApi: TbaApi,
+    ) : ViewModel() {
+        private val _maxYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
+        val maxYear: StateFlow<Int> = _maxYear.asStateFlow()
 
-    private val _maxYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
-    val maxYear: StateFlow<Int> = _maxYear.asStateFlow()
+        private val _selectedYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
+        val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
 
-    private val _selectedYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
-    val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+        val uiState: StateFlow<DistrictsUiState> =
+            _selectedYear
+                .flatMapLatest { year ->
+                    districtRepository.observeDistrictsForYear(year).map { districts ->
+                        if (districts.isEmpty()) {
+                            DistrictsUiState.Loading
+                        } else {
+                            DistrictsUiState.Success(districts)
+                        }
+                    }
+                }.stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5000),
+                    DistrictsUiState.Loading,
+                )
 
-    val uiState: StateFlow<DistrictsUiState> = _selectedYear
-        .flatMapLatest { year ->
-            districtRepository.observeDistrictsForYear(year).map { districts ->
-                if (districts.isEmpty()) DistrictsUiState.Loading
-                else DistrictsUiState.Success(districts)
-            }
+        init {
+            fetchMaxYear()
+            refreshDistricts()
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DistrictsUiState.Loading)
 
-    init {
-        fetchMaxYear()
-        refreshDistricts()
-    }
-
-    private fun fetchMaxYear() {
-        viewModelScope.launch {
-            try {
-                val status = tbaApi.getStatus()
-                _maxYear.value = status.maxSeason
-                if (_selectedYear.value < status.maxSeason) {
-                    _selectedYear.value = status.maxSeason
+        private fun fetchMaxYear() {
+            viewModelScope.launch {
+                try {
+                    val status = tbaApi.getStatus()
+                    _maxYear.value = status.maxSeason
+                    if (_selectedYear.value < status.maxSeason) {
+                        _selectedYear.value = status.maxSeason
+                    }
+                } catch (_: Exception) {
+                    // Fall back to calendar year (already set)
                 }
-            } catch (_: Exception) {
-                // Fall back to calendar year (already set)
+            }
+        }
+
+        fun selectYear(year: Int) {
+            _selectedYear.value = year
+            refreshDistricts()
+        }
+
+        fun refreshDistricts() {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    districtRepository.refreshDistrictsForYear(_selectedYear.value)
+                } catch (_: Exception) {
+                } finally {
+                    _isRefreshing.value = false
+                }
             }
         }
     }
-
-    fun selectYear(year: Int) {
-        _selectedYear.value = year
-        refreshDistricts()
-    }
-
-    fun refreshDistricts() {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                districtRepository.refreshDistrictsForYear(_selectedYear.value)
-            } catch (_: Exception) {
-            } finally {
-                _isRefreshing.value = false
-            }
-        }
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -1,7 +1,6 @@
 package com.thebluealliance.android.ui.events
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,7 +22,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
@@ -98,7 +96,14 @@ fun EventsScreen(
                 title = {
                     TopBarYearPicker(
                         selectedYear = selectedYear,
-                        years = if (selectedYear > 0) (maxYear downTo 1992).toList() else emptyList(),
+                        years =
+                            if (selectedYear >
+                                0
+                            ) {
+                                (maxYear downTo 1992).toList()
+                            } else {
+                                emptyList()
+                            },
                         onYearSelected = viewModel::selectYear,
                         title = { Text("Events") },
                     )
@@ -108,15 +113,16 @@ fun EventsScreen(
                         Icon(Icons.Default.Search, contentDescription = "Search")
                     }
                 },
-                showLamp = true
+                showLamp = true,
             )
         },
     ) { innerPadding ->
         Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
         ) {
             PullToRefreshBox(
                 isRefreshing = isRefreshing && uiState !is EventsUiState.Loading,
@@ -180,23 +186,30 @@ private fun EventsList(
     val allEvents = remember(sections) { sections.flatMap { it.events } }
     val today = remember { LocalDate.now() }
 
-    val favoriteEvents = remember(allEvents, favoriteEventKeys) {
-        if (favoriteEventKeys.isEmpty()) emptyList()
-        else allEvents.filter { it.key in favoriteEventKeys }
-    }
+    val favoriteEvents =
+        remember(allEvents, favoriteEventKeys) {
+            if (favoriteEventKeys.isEmpty()) {
+                emptyList()
+            } else {
+                allEvents.filter { it.key in favoriteEventKeys }
+            }
+        }
     val hasFavorites = favoriteEvents.isNotEmpty()
 
-    val weekChipLabels = remember(sections) {
-        sections.map { it.label }
-    }
+    val weekChipLabels =
+        remember(sections) {
+            sections.map { it.label }
+        }
 
-    val currentWeekLabel = remember(allEvents, today, selectedYear) {
-        currentWeekChipLabel(allEvents, today, selectedYear)
-    }
+    val currentWeekLabel =
+        remember(allEvents, today, selectedYear) {
+            currentWeekChipLabel(allEvents, today, selectedYear)
+        }
 
-    val headerInfos = remember(sections, favoriteEventKeys) {
-        buildHeaderInfos(sections, favoriteEventKeys)
-    }
+    val headerInfos =
+        remember(sections, favoriteEventKeys) {
+            buildHeaderInfos(sections, favoriteEventKeys)
+        }
 
     val weekChipLabelSet = remember(weekChipLabels) { weekChipLabels.toSet() }
 
@@ -326,7 +339,10 @@ private fun EventsList(
                         item(key = "${headerKey}_sub_Favorites") {
                             SubSectionHeader(label = "Favorites")
                         }
-                        items(sectionFavorites, key = { "fav_${section.label}_${it.key}" }) { event ->
+                        items(
+                            sectionFavorites,
+                            key = { "fav_${section.label}_${it.key}" },
+                        ) { event ->
                             EventRow(event = event, onClick = { onNavigateToEvent(event.key) })
                         }
                     }
@@ -371,30 +387,33 @@ private fun WeekFilterChips(
         }
     }
 
-    val weekChipColors = FilterChipDefaults.filterChipColors(
-        containerColor = Color.Transparent,
-        labelColor = Color.White.copy(alpha = 0.7f),
-        selectedContainerColor = Color.White,
-        selectedLabelColor = TBABlue,
-    )
-    val weekChipBorder = FilterChipDefaults.filterChipBorder(
-        enabled = true,
-        selected = false,
-        borderColor = Color.White.copy(alpha = 0.5f),
-        selectedBorderColor = Color.Transparent,
-    )
+    val weekChipColors =
+        FilterChipDefaults.filterChipColors(
+            containerColor = Color.Transparent,
+            labelColor = Color.White.copy(alpha = 0.7f),
+            selectedContainerColor = Color.White,
+            selectedLabelColor = TBABlue,
+        )
+    val weekChipBorder =
+        FilterChipDefaults.filterChipBorder(
+            enabled = true,
+            selected = false,
+            borderColor = Color.White.copy(alpha = 0.5f),
+            selectedBorderColor = Color.Transparent,
+        )
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(TBABlue)
-            .layout { measurable, constraints ->
-                val placeable = measurable.measure(constraints)
-                val overlapPx = 4.dp.roundToPx()
-                layout(placeable.width, (placeable.height - overlapPx).coerceAtLeast(0)) {
-                    placeable.placeRelative(0, -overlapPx)
-                }
-            },
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(TBABlue)
+                .layout { measurable, constraints ->
+                    val placeable = measurable.measure(constraints)
+                    val overlapPx = 4.dp.roundToPx()
+                    layout(placeable.width, (placeable.height - overlapPx).coerceAtLeast(0)) {
+                        placeable.placeRelative(0, -overlapPx)
+                    }
+                },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (hasFavorites) {
@@ -414,45 +433,52 @@ private fun WeekFilterChips(
             )
             // Vertical divider between pinned star and scrollable chips
             Box(
-                modifier = Modifier
-                    .padding(start = 8.dp, bottom = 4.dp)
-                    .height(24.dp)
-                    .width(1.dp)
-                    .background(Color.White.copy(alpha = 0.3f))
+                modifier =
+                    Modifier
+                        .padding(start = 8.dp, bottom = 4.dp)
+                        .height(24.dp)
+                        .width(1.dp)
+                        .background(Color.White.copy(alpha = 0.3f)),
             )
         }
         val fadeWidth = 24.dp
         LazyRow(
             state = chipRowState,
-            modifier = Modifier
-                .weight(1f)
-                .then(
-                    if (hasFavorites) {
-                        Modifier.drawWithContent {
-                            drawContent()
-                            if (chipRowState.canScrollBackward) {
-                                val solidZone = 4.dp.toPx()
-                                val totalWidth = fadeWidth.toPx()
-                                drawRect(
-                                    brush = Brush.horizontalGradient(
-                                        colorStops = arrayOf(
-                                            0f to TBABlue,
-                                            solidZone / totalWidth to TBABlue,
-                                            1f to Color.Transparent,
-                                        ),
-                                        endX = totalWidth,
-                                    ),
-                                    size = size.copy(width = totalWidth),
-                                )
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .then(
+                        if (hasFavorites) {
+                            Modifier.drawWithContent {
+                                drawContent()
+                                if (chipRowState.canScrollBackward) {
+                                    val solidZone = 4.dp.toPx()
+                                    val totalWidth = fadeWidth.toPx()
+                                    drawRect(
+                                        brush =
+                                            Brush.horizontalGradient(
+                                                colorStops =
+                                                    arrayOf(
+                                                        0f to TBABlue,
+                                                        solidZone / totalWidth to TBABlue,
+                                                        1f to Color.Transparent,
+                                                    ),
+                                                endX = totalWidth,
+                                            ),
+                                        size = size.copy(width = totalWidth),
+                                    )
+                                }
                             }
-                        }
-                    } else Modifier
+                        } else {
+                            Modifier
+                        },
+                    ),
+            contentPadding =
+                PaddingValues(
+                    start = 8.dp,
+                    end = 12.dp,
+                    bottom = 4.dp,
                 ),
-            contentPadding = PaddingValues(
-                start = 8.dp,
-                end = 12.dp,
-                bottom = 4.dp,
-            ),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             items(weekLabels.size) { index ->
@@ -472,10 +498,11 @@ private fun WeekFilterChips(
 @Composable
 private fun SimpleSectionHeader(label: String) {
     Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(TBAIndigo400)
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(TBAIndigo400)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         Text(
             text = label,
@@ -489,16 +516,17 @@ private fun SimpleSectionHeader(label: String) {
 @Composable
 private fun SubSectionHeader(label: String) {
     Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
-            .padding(horizontal = 16.dp, vertical = 4.dp)
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                .padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
         Text(
             text = label,
             style = MaterialTheme.typography.labelLarge,
             fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
@@ -6,25 +6,41 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
-data class EventSubSection(val label: String, val events: List<Event>)
+data class EventSubSection(
+    val label: String,
+    val events: List<Event>,
+)
 
-data class EventSection(val label: String, val subSections: List<EventSubSection>) {
+data class EventSection(
+    val label: String,
+    val subSections: List<EventSubSection>,
+) {
     val events: List<Event> get() = subSections.flatMap { it.events }
 }
 
 sealed interface EventsUiState {
     data object Loading : EventsUiState
+
     data class Success(
         val sections: List<EventSection>,
         val favoriteEventKeys: Set<String> = emptySet(),
         val districtNames: Map<String, String> = emptyMap(),
     ) : EventsUiState
-    data class Error(val message: String) : EventsUiState
+
+    data class Error(
+        val message: String,
+    ) : EventsUiState
 }
 
-private data class SectionKey(val sortOrder: Int, val label: String)
+private data class SectionKey(
+    val sortOrder: Int,
+    val label: String,
+)
 
-private fun eventSectionKey(event: Event, preseasonOver: Boolean): SectionKey {
+private fun eventSectionKey(
+    event: Event,
+    preseasonOver: Boolean,
+): SectionKey {
     return when (event.type) {
         100 -> if (preseasonOver) SectionKey(1500, "Preseason") else SectionKey(-1, "Preseason")
         0, 1, 2, 5 -> {
@@ -52,10 +68,11 @@ fun buildEventSections(
     today: LocalDate = LocalDate.now(),
     districtNames: Map<String, String> = emptyMap(),
 ): List<EventSection> {
-    val lastPreseasonEnd = events
-        .filter { it.type == 100 }
-        .mapNotNull { it.endDate?.let { d -> runCatching { LocalDate.parse(d) }.getOrNull() } }
-        .maxOrNull()
+    val lastPreseasonEnd =
+        events
+            .filter { it.type == 100 }
+            .mapNotNull { it.endDate?.let { d -> runCatching { LocalDate.parse(d) }.getOrNull() } }
+            .maxOrNull()
     val preseasonOver = lastPreseasonEnd != null && today.isAfter(lastPreseasonEnd)
 
     return events
@@ -72,87 +89,109 @@ fun buildEventSections(
 private fun buildSubSections(
     events: List<Event>,
     districtNames: Map<String, String>,
-): List<EventSubSection> = buildList {
-    val regionals = events
-        .filter { it.district == null && it.type == 0 }
-        .sortedBy { it.name }
-    if (regionals.isNotEmpty()) {
-        add(EventSubSection("Regional Events", regionals))
-    }
+): List<EventSubSection> =
+    buildList {
+        val regionals =
+            events
+                .filter { it.district == null && it.type == 0 }
+                .sortedBy { it.name }
+        if (regionals.isNotEmpty()) {
+            add(EventSubSection("Regional Events", regionals))
+        }
 
-    val others = events.filter { it.district == null && it.type != 0 }
-    if (others.isNotEmpty()) {
-        val offseasons = others.filter { it.type == 99 }
-        val nonOffseasonOthers = others.filter { it.type != 99 }
+        val others = events.filter { it.district == null && it.type != 0 }
+        if (others.isNotEmpty()) {
+            val offseasons = others.filter { it.type == 99 }
+            val nonOffseasonOthers = others.filter { it.type != 99 }
 
-        if (offseasons.isNotEmpty()) {
-            offseasons.groupBy {
-                it.startDate?.let { s -> runCatching { LocalDate.parse(s) }.getOrNull() }?.month
-            }.forEach { (month, monthEvents) ->
-                val monthName = month?.name?.lowercase()?.replaceFirstChar { it.uppercase() }
-                val label = if (monthName != null) "$monthName Offseason Events" else "Offseason Events"
-                add(EventSubSection(label, monthEvents))
+            if (offseasons.isNotEmpty()) {
+                offseasons
+                    .groupBy {
+                        it.startDate
+                            ?.let { s ->
+                                runCatching { LocalDate.parse(s) }.getOrNull()
+                            }?.month
+                    }.forEach { (month, monthEvents) ->
+                        val monthName =
+                            month?.name?.lowercase()?.replaceFirstChar {
+                                it.uppercase()
+                            }
+                        val label =
+                            if (monthName !=
+                                null
+                            ) {
+                                "$monthName Offseason Events"
+                            } else {
+                                "Offseason Events"
+                            }
+                        add(EventSubSection(label, monthEvents))
+                    }
+            }
+
+            if (nonOffseasonOthers.isNotEmpty()) {
+                add(EventSubSection("", nonOffseasonOthers))
             }
         }
 
-        if (nonOffseasonOthers.isNotEmpty()) {
-            add(EventSubSection("", nonOffseasonOthers))
+        val districts = events.filter { it.district != null }
+        if (districts.isNotEmpty()) {
+            districts
+                .groupBy { it.district!! }
+                .map { (districtKey, districtEvents) ->
+                    val abbrev = districtKey.replace(Regex("^\\d{4}"), "").lowercase()
+                    val name = districtNames[districtKey.lowercase()] ?: districtNames[abbrev]
+
+                    var label = name ?: abbrev.uppercase()
+                    if (label.isBlank()) label = districtKey
+
+                    // Append "District" if we're falling back to a code/abbreviation
+                    if (name == null && !label.contains("District", ignoreCase = true)) {
+                        label = "$label District"
+                    }
+
+                    EventSubSection(label, districtEvents)
+                }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.label })
+                .let { addAll(it) }
         }
     }
-
-    val districts = events.filter { it.district != null }
-    if (districts.isNotEmpty()) {
-        districts.groupBy { it.district!! }
-            .map { (districtKey, districtEvents) ->
-                val abbrev = districtKey.replace(Regex("^\\d{4}"), "").lowercase()
-                val name = districtNames[districtKey.lowercase()] ?: districtNames[abbrev]
-
-                var label = name ?: abbrev.uppercase()
-                if (label.isBlank()) label = districtKey
-
-                // Append "District" if we're falling back to a code/abbreviation
-                if (name == null && !label.contains("District", ignoreCase = true)) {
-                    label = "$label District"
-                }
-
-                EventSubSection(label, districtEvents)
-            }
-            .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.label })
-            .let { addAll(it) }
-    }
-}
 
 fun buildHeaderInfos(
     sections: List<EventSection>,
     favoriteEventKeys: Set<String>,
-): List<SectionHeaderInfo> = buildList {
-    var index = 0
-    // Top-level Favorites section
-    val totalFavorites = sections.sumOf { section ->
-        section.events.count { it.key in favoriteEventKeys }
-    }
-    if (totalFavorites > 0) {
-        add(SectionHeaderInfo("favorites_header", "Favorites", index))
-        index += 1 + totalFavorites // header + favorite items
-    }
-    // Week sections
-    sections.forEach { section ->
-        val headerKey = "header_${section.label}"
-        add(SectionHeaderInfo(headerKey, section.label, index))
-        index += 1 // header item
-        // Per-week favorites sub-section
-        val favCount = section.events.count { it.key in favoriteEventKeys }
-        if (favCount > 0) {
-            index += 1 + favCount // sub-header + favorite items
+): List<SectionHeaderInfo> =
+    buildList {
+        var index = 0
+        // Top-level Favorites section
+        val totalFavorites =
+            sections.sumOf { section ->
+                section.events.count { it.key in favoriteEventKeys }
+            }
+        if (totalFavorites > 0) {
+            add(SectionHeaderInfo("favorites_header", "Favorites", index))
+            index += 1 + totalFavorites // header + favorite items
         }
-        // Regular sub-sections
-        index += section.subSections.sumOf {
-            (if (it.label.isNotEmpty()) 1 else 0) + it.events.size
+        // Week sections
+        sections.forEach { section ->
+            val headerKey = "header_${section.label}"
+            add(SectionHeaderInfo(headerKey, section.label, index))
+            index += 1 // header item
+            // Per-week favorites sub-section
+            val favCount = section.events.count { it.key in favoriteEventKeys }
+            if (favCount > 0) {
+                index += 1 + favCount // sub-header + favorite items
+            }
+            // Regular sub-sections
+            index +=
+                section.subSections.sumOf {
+                    (if (it.label.isNotEmpty()) 1 else 0) + it.events.size
+                }
         }
     }
-}
 
-data class ThisWeekResult(val label: String, val subSections: List<EventSubSection>) {
+data class ThisWeekResult(
+    val label: String,
+    val subSections: List<EventSubSection>,
+) {
     val events: List<Event> get() = subSections.flatMap { it.events }
 }
 
@@ -183,14 +222,16 @@ fun computeThisWeekEvents(
         val weekStartDate = weekEvents.mapNotNull { parseDate(it.startDate) }.minOrNull()
         val weekEndDate = weekEvents.mapNotNull { parseDate(it.endDate) }.maxOrNull()
 
-        val championshipEvents = if (weekStartDate != null && weekEndDate != null) {
-            allEvents.filter { event ->
-                event.type in listOf(3, 4) && event.week == null &&
-                    datesOverlap(event, weekStartDate, weekEndDate)
+        val championshipEvents =
+            if (weekStartDate != null && weekEndDate != null) {
+                allEvents.filter { event ->
+                    event.type in listOf(3, 4) &&
+                        event.week == null &&
+                        datesOverlap(event, weekStartDate, weekEndDate)
+                }
+            } else {
+                emptyList()
             }
-        } else {
-            emptyList()
-        }
 
         rawEvents = (weekEvents + championshipEvents).distinctBy { it.key }
         label = "Upcoming This Week \u2014 Week ${currentWeek + 1}"
@@ -203,10 +244,11 @@ fun computeThisWeekEvents(
     }
 
     // Remove events that have already ended
-    val activeEvents = rawEvents.filter { event ->
-        val end = parseDate(event.endDate)
-        end == null || !end.isBefore(today)
-    }
+    val activeEvents =
+        rawEvents.filter { event ->
+            val end = parseDate(event.endDate)
+            end == null || !end.isBefore(today)
+        }
 
     if (activeEvents.isEmpty()) return null
 
@@ -216,32 +258,38 @@ fun computeThisWeekEvents(
     return ThisWeekResult(label, subSections)
 }
 
-internal fun findCurrentCompetitionWeek(allEvents: List<Event>, today: LocalDate): Int? {
+internal fun findCurrentCompetitionWeek(
+    allEvents: List<Event>,
+    today: LocalDate,
+): Int? {
     val weekedEvents = allEvents.filter { it.week != null }
 
     // 1. If any event with a week is happening today → use that week
-    val happeningToday = weekedEvents.filter { event ->
-        val start = parseDate(event.startDate)
-        val end = parseDate(event.endDate)
-        start != null && end != null && !today.isBefore(start) && !today.isAfter(end)
-    }
+    val happeningToday =
+        weekedEvents.filter { event ->
+            val start = parseDate(event.startDate)
+            val end = parseDate(event.endDate)
+            start != null && end != null && !today.isBefore(start) && !today.isAfter(end)
+        }
     if (happeningToday.isNotEmpty()) {
         return happeningToday.first().week
     }
 
     // Steps 2 and 3 only apply once the season has started — at least one weeked event
     // must have already ended. This prevents reaching forward from preseason into Week 1.
-    val recentlyEnded = weekedEvents
-        .filter { event -> parseDate(event.endDate)?.isBefore(today) == true }
-        .maxByOrNull { parseDate(it.endDate) ?: LocalDate.MIN }
+    val recentlyEnded =
+        weekedEvents
+            .filter { event -> parseDate(event.endDate)?.isBefore(today) == true }
+            .maxByOrNull { parseDate(it.endDate) ?: LocalDate.MIN }
 
     val seasonHasStarted = recentlyEnded != null
 
     // 2. Upcoming event with a week within 7 days → use that week (bridges gap between weeks)
     if (seasonHasStarted) {
-        val upcoming = weekedEvents
-            .filter { event -> parseDate(event.startDate)?.isAfter(today) == true }
-            .minByOrNull { parseDate(it.startDate) ?: LocalDate.MAX }
+        val upcoming =
+            weekedEvents
+                .filter { event -> parseDate(event.startDate)?.isAfter(today) == true }
+                .minByOrNull { parseDate(it.startDate) ?: LocalDate.MAX }
 
         if (upcoming != null) {
             val upcomingStart = parseDate(upcoming.startDate)
@@ -265,9 +313,12 @@ internal fun findCurrentCompetitionWeek(allEvents: List<Event>, today: LocalDate
 private fun parseDate(dateStr: String?): LocalDate? =
     dateStr?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
 
-private fun datesOverlap(event: Event, rangeStart: LocalDate, rangeEnd: LocalDate): Boolean {
+private fun datesOverlap(
+    event: Event,
+    rangeStart: LocalDate,
+    rangeEnd: LocalDate,
+): Boolean {
     val eventStart = parseDate(event.startDate) ?: return false
     val eventEnd = parseDate(event.endDate) ?: return false
     return !eventEnd.isBefore(rangeStart) && !eventStart.isAfter(rangeEnd)
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsViewModel.kt
@@ -22,108 +22,119 @@ import javax.inject.Inject
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @HiltViewModel
-class EventsViewModel @Inject constructor(
-    private val eventRepository: EventRepository,
-    private val districtRepository: DistrictRepository,
-    private val tbaApi: TbaApi,
-    private val myTBARepository: MyTBARepository,
-    private val authRepository: AuthRepository,
-) : ViewModel() {
+class EventsViewModel
+    @Inject
+    constructor(
+        private val eventRepository: EventRepository,
+        private val districtRepository: DistrictRepository,
+        private val tbaApi: TbaApi,
+        private val myTBARepository: MyTBARepository,
+        private val authRepository: AuthRepository,
+    ) : ViewModel() {
+        private val _maxYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
+        val maxYear: StateFlow<Int> = _maxYear.asStateFlow()
 
-    private val _maxYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
-    val maxYear: StateFlow<Int> = _maxYear.asStateFlow()
+        private val _selectedYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
+        val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
 
-    private val _selectedYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
-    val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+        private val hasLoaded = MutableStateFlow(false)
 
-    private val _hasLoaded = MutableStateFlow(false)
-
-    val uiState: StateFlow<EventsUiState> = _selectedYear
-        .flatMapLatest { year ->
-            _hasLoaded.value = false
-            combine(
-                eventRepository.observeEventsForYear(year),
-                districtRepository.observeDistrictsForYear(year),
-                _hasLoaded,
-                myTBARepository.observeFavorites(),
-            ) { events, districts, hasLoaded, favorites ->
-                if (events.isEmpty() && !hasLoaded) {
-                    EventsUiState.Loading
-                } else {
-                    val districtNames = buildMap {
-                        districts.forEach {
-                            put(it.key.lowercase(), it.displayName)
-                            put(it.abbreviation.lowercase(), it.displayName)
+        val uiState: StateFlow<EventsUiState> =
+            _selectedYear
+                .flatMapLatest { year ->
+                    hasLoaded.value = false
+                    combine(
+                        eventRepository.observeEventsForYear(year),
+                        districtRepository.observeDistrictsForYear(year),
+                        hasLoaded,
+                        myTBARepository.observeFavorites(),
+                    ) { events, districts, hasLoaded, favorites ->
+                        if (events.isEmpty() && !hasLoaded) {
+                            EventsUiState.Loading
+                        } else {
+                            val districtNames =
+                                buildMap {
+                                    districts.forEach {
+                                        put(it.key.lowercase(), it.displayName)
+                                        put(it.abbreviation.lowercase(), it.displayName)
+                                    }
+                                }
+                            val sections = buildEventSections(events, districtNames = districtNames)
+                            val favoriteEventKeys =
+                                favorites
+                                    .filter { it.modelType == ModelType.EVENT }
+                                    .map { it.modelKey }
+                                    .toSet()
+                            EventsUiState.Success(sections, favoriteEventKeys, districtNames)
                         }
                     }
-                    val sections = buildEventSections(events, districtNames = districtNames)
-                    val favoriteEventKeys = favorites
-                        .filter { it.modelType == ModelType.EVENT }
-                        .map { it.modelKey }
-                        .toSet()
-                    EventsUiState.Success(sections, favoriteEventKeys, districtNames)
+                }.stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5000),
+                    EventsUiState.Loading,
+                )
+
+        init {
+            fetchMaxYear()
+            refreshEvents()
+            refreshFavorites()
+        }
+
+        private fun refreshFavorites() {
+            viewModelScope.launch {
+                if (!authRepository.isSignedIn()) return@launch
+                try {
+                    myTBARepository.refreshFavorites()
+                } catch (_: Exception) {
                 }
             }
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), EventsUiState.Loading)
 
-    init {
-        fetchMaxYear()
-        refreshEvents()
-        refreshFavorites()
-    }
-
-    private fun refreshFavorites() {
-        viewModelScope.launch {
-            if (!authRepository.isSignedIn()) return@launch
-            try { myTBARepository.refreshFavorites() } catch (_: Exception) {}
-        }
-    }
-
-    private fun fetchMaxYear() {
-        viewModelScope.launch {
-            try {
-                val status = tbaApi.getStatus()
-                _maxYear.value = status.maxSeason
-                // If current selection is below max, update to max
-                if (_selectedYear.value < status.maxSeason) {
-                    _selectedYear.value = status.maxSeason
+        private fun fetchMaxYear() {
+            viewModelScope.launch {
+                try {
+                    val status = tbaApi.getStatus()
+                    _maxYear.value = status.maxSeason
+                    // If current selection is below max, update to max
+                    if (_selectedYear.value < status.maxSeason) {
+                        _selectedYear.value = status.maxSeason
+                    }
+                } catch (_: Exception) {
+                    // Fall back to calendar year (already set)
                 }
-            } catch (_: Exception) {
-                // Fall back to calendar year (already set)
+            }
+        }
+
+        fun selectYear(year: Int) {
+            _selectedYear.value = year
+            refreshEvents()
+            refreshDistricts()
+        }
+
+        private fun refreshDistricts() {
+            viewModelScope.launch {
+                try {
+                    districtRepository.refreshDistrictsForYear(_selectedYear.value)
+                } catch (_: Exception) {
+                }
+            }
+        }
+
+        fun refreshEvents() {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    eventRepository.refreshEventsForYear(_selectedYear.value)
+                    districtRepository.refreshDistrictsForYear(_selectedYear.value)
+                } catch (e: Exception) {
+                    // Data will come from Room cache if available
+                } finally {
+                    hasLoaded.value = true
+                    _isRefreshing.value = false
+                }
             }
         }
     }
-
-    fun selectYear(year: Int) {
-        _selectedYear.value = year
-        refreshEvents()
-        refreshDistricts()
-    }
-
-    private fun refreshDistricts() {
-        viewModelScope.launch {
-            try {
-                districtRepository.refreshDistrictsForYear(_selectedYear.value)
-            } catch (_: Exception) {}
-        }
-    }
-
-    fun refreshEvents() {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                eventRepository.refreshEventsForYear(_selectedYear.value)
-                districtRepository.refreshDistrictsForYear(_selectedYear.value)
-            } catch (e: Exception) {
-                // Data will come from Room cache if available
-            } finally {
-                _hasLoaded.value = true
-                _isRefreshing.value = false
-            }
-        }
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -13,8 +13,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.NotificationsNone
@@ -58,9 +58,9 @@ import com.thebluealliance.android.shortcuts.ReportShortcutVisitEffect
 import com.thebluealliance.android.ui.common.shareTbaUrl
 import com.thebluealliance.android.ui.components.NotificationPreferencesSheet
 import com.thebluealliance.android.ui.components.TBATopAppBar
+import com.thebluealliance.android.ui.events.detail.tabs.EventAdvancementTab
 import com.thebluealliance.android.ui.events.detail.tabs.EventAlliancesTab
 import com.thebluealliance.android.ui.events.detail.tabs.EventAwardsTab
-import com.thebluealliance.android.ui.events.detail.tabs.EventAdvancementTab
 import com.thebluealliance.android.ui.events.detail.tabs.EventInfoTab
 import com.thebluealliance.android.ui.events.detail.tabs.EventInsightsTab
 import com.thebluealliance.android.ui.events.detail.tabs.EventMatchesTab
@@ -69,7 +69,9 @@ import com.thebluealliance.android.ui.events.detail.tabs.EventTeamsTab
 import com.thebluealliance.android.ui.theme.TBABlue
 import kotlinx.coroutines.launch
 
-enum class EventDetailTab(val readableName: (Event?) -> String) {
+enum class EventDetailTab(
+    val readableName: (Event?) -> String,
+) {
     INFO({ "Info" }),
     TEAMS({ "Teams" }),
     RANKINGS({ "Rankings" }),
@@ -96,7 +98,11 @@ fun EventDetailScreen(
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val isFavorite by viewModel.isFavorite.collectAsStateWithLifecycle()
     val subscription by viewModel.subscription.collectAsStateWithLifecycle()
-    val pagerState = rememberPagerState(initialPage = initialTab.ordinal, pageCount = { EventDetailTab.entries.size })
+    val pagerState =
+        rememberPagerState(
+            initialPage = initialTab.ordinal,
+            pageCount = { EventDetailTab.entries.size },
+        )
     val coroutineScope = rememberCoroutineScope()
 
     var showSignInDialog by remember { mutableStateOf(false) }
@@ -172,14 +178,29 @@ fun EventDetailScreen(
                         }) {
                             val hasSubscription = subscription?.notifications?.isNotEmpty() == true
                             Icon(
-                                imageVector = if (hasSubscription) Icons.Filled.Notifications else Icons.Outlined.NotificationsNone,
+                                imageVector =
+                                    if (hasSubscription) {
+                                        Icons.Filled.Notifications
+                                    } else {
+                                        Icons.Outlined.NotificationsNone
+                                    },
                                 contentDescription = "Notification preferences",
                             )
                         }
                         IconButton(onClick = viewModel::toggleFavorite) {
                             Icon(
-                                imageVector = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarBorder,
-                                contentDescription = if (isFavorite) "Remove from favorites" else "Add to favorites",
+                                imageVector =
+                                    if (isFavorite) {
+                                        Icons.Filled.Star
+                                    } else {
+                                        Icons.Outlined.StarBorder
+                                    },
+                                contentDescription =
+                                    if (isFavorite) {
+                                        "Remove from favorites"
+                                    } else {
+                                        "Add to favorites"
+                                    },
                             )
                         }
                         var menuExpanded by remember { mutableStateOf(false) }
@@ -200,14 +221,16 @@ fun EventDetailScreen(
                                         leadingIcon = {
                                             Icon(
                                                 Icons.Filled.Share,
-                                                contentDescription = null
+                                                contentDescription = null,
                                             )
                                         },
                                         onClick = {
                                             menuExpanded = false
                                             context.shareTbaUrl(
                                                 title = "${event.year} ${event.name}",
-                                                url = "https://www.thebluealliance.com/event/${event.key}",
+                                                url =
+                                                    "https://www.thebluealliance.com/event/" +
+                                                        event.key,
                                             )
                                         },
                                     )
@@ -217,7 +240,10 @@ fun EventDetailScreen(
                                         text = { Text("Add to home screen") },
                                         leadingIcon = {
                                             Icon(
-                                                painter = painterResource(R.drawable.ic_add_to_home_screen),
+                                                painter =
+                                                    painterResource(
+                                                        R.drawable.ic_add_to_home_screen,
+                                                    ),
                                                 contentDescription = null,
                                             )
                                         },
@@ -244,14 +270,20 @@ fun EventDetailScreen(
                         SecondaryIndicator(
                             modifier = Modifier.tabIndicatorOffset(pagerState.currentPage),
                             height = 3.dp,
-                            color = Color.White
+                            color = Color.White,
                         )
-                    }
+                    },
                 ) {
                     EventDetailTab.entries.forEach { tab ->
                         Tab(
                             selected = pagerState.currentPage == tab.ordinal,
-                            onClick = { coroutineScope.launch { pagerState.animateScrollToPage(tab.ordinal) } },
+                            onClick = {
+                                coroutineScope.launch {
+                                    pagerState.animateScrollToPage(
+                                        tab.ordinal,
+                                    )
+                                }
+                            },
                             text = {
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,
@@ -259,7 +291,7 @@ fun EventDetailScreen(
                                 ) {
                                     Text(
                                         text = tab.readableName(uiState.event),
-                                        color = Color.White
+                                        color = Color.White,
                                     )
 
                                     // Show number of teams as a badge
@@ -267,15 +299,19 @@ fun EventDetailScreen(
                                         Surface(
                                             shape = MaterialTheme.shapes.small,
                                             color = MaterialTheme.colorScheme.surfaceVariant,
-                                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            contentColor =
+                                                MaterialTheme.colorScheme.onSurfaceVariant,
                                         ) {
                                             Text(
                                                 text = "${uiState.teams?.size}",
                                                 style = MaterialTheme.typography.labelMedium,
-                                                modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
+                                                modifier =
+                                                    Modifier.padding(
+                                                        horizontal = 4.dp,
+                                                        vertical = 2.dp,
+                                                    ),
                                             )
                                         }
-
                                     }
                                 }
                             },
@@ -288,10 +324,11 @@ fun EventDetailScreen(
         val bottomPadding = PaddingValues(bottom = innerPadding.calculateBottomPadding())
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = innerPadding.calculateTopPadding())
-                .background(MaterialTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(top = innerPadding.calculateTopPadding())
+                    .background(MaterialTheme.colorScheme.background),
         ) { page ->
             PullToRefreshBox(
                 isRefreshing = isRefreshing,
@@ -299,74 +336,91 @@ fun EventDetailScreen(
                 modifier = Modifier.fillMaxSize(),
             ) {
                 when (EventDetailTab.entries[page]) {
-                    EventDetailTab.INFO -> EventInfoTab(
-                        event = uiState.event,
-                        districtDisplayName = uiState.districtDisplayName,
-                        onNavigateToDistrict = onNavigateToDistrict,
-                        innerPadding = bottomPadding,
-                    )
-                    EventDetailTab.TEAMS -> EventTeamsTab(
-                        teams = uiState.teams,
-                        pitLocations = uiState.pitLocations,
-                        onNavigateToTeam = { teamKey ->
-                            val eventKey = uiState.event?.key
-                            if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
-                            else onNavigateToTeam(teamKey)
-                        },
-                        innerPadding = bottomPadding,
-                    )
-                    EventDetailTab.RANKINGS -> EventRankingsTab(
-                        rankings = uiState.rankings,
-                        rankingSortOrders = uiState.rankingSortOrders,
-                        rankingExtraStatsInfo = uiState.rankingExtraStatsInfo,
-                        onTeamClick = { teamKey ->
-                            val eventKey = uiState.event?.key
-                            if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
-                        },
-                        innerPadding = bottomPadding,
-                    )
-                    EventDetailTab.MATCHES -> EventMatchesTab(
-                        matches = uiState.matches,
-                        playoffType = uiState.event?.playoffType ?: PlayoffType.OTHER,
-                        onNavigateToMatch = onNavigateToMatch,
-                        innerPadding = bottomPadding,
-                    )
-                    EventDetailTab.ALLIANCES -> EventAlliancesTab(
-                        alliances = uiState.alliances,
-                        onTeamClick = { teamKey ->
-                            val eventKey = uiState.event?.key
-                            if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
-                        },
-                        innerPadding = bottomPadding,
-                    )
-                    EventDetailTab.INSIGHTS -> EventInsightsTab(
-                        oprs = uiState.oprs,
-                        coprs = uiState.coprs,
-                        insights = uiState.insights,
-                        isRefreshing = isRefreshing,
-                        innerPadding = bottomPadding,
-                    )
-                    EventDetailTab.ADVANCEMENT_POINTS -> EventAdvancementTab(
-                        uiState.advancementPoints,
-                        uiState.event,
-                        uiState.teams,
-                        uiState.regionalCmpAdvancementByTeam,
-                        onTeamClick = { teamKey ->
-                            val eventKey = uiState.event?.key
-                            if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
-                            else onNavigateToTeam(teamKey)
-                        },
-                        innerPadding = bottomPadding,
-                    )
-                    EventDetailTab.AWARDS -> EventAwardsTab(
-                        awards = uiState.awards,
-                        onTeamClick = { teamKey ->
-                            val eventKey = uiState.event?.key
-                            if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
-                            else onNavigateToTeam(teamKey)
-                        },
-                        innerPadding = bottomPadding,
-                    )
+                    EventDetailTab.INFO ->
+                        EventInfoTab(
+                            event = uiState.event,
+                            districtDisplayName = uiState.districtDisplayName,
+                            onNavigateToDistrict = onNavigateToDistrict,
+                            innerPadding = bottomPadding,
+                        )
+                    EventDetailTab.TEAMS ->
+                        EventTeamsTab(
+                            teams = uiState.teams,
+                            pitLocations = uiState.pitLocations,
+                            onNavigateToTeam = { teamKey ->
+                                val eventKey = uiState.event?.key
+                                if (eventKey != null) {
+                                    onNavigateToTeamEvent(teamKey, eventKey)
+                                } else {
+                                    onNavigateToTeam(teamKey)
+                                }
+                            },
+                            innerPadding = bottomPadding,
+                        )
+                    EventDetailTab.RANKINGS ->
+                        EventRankingsTab(
+                            rankings = uiState.rankings,
+                            rankingSortOrders = uiState.rankingSortOrders,
+                            rankingExtraStatsInfo = uiState.rankingExtraStatsInfo,
+                            onTeamClick = { teamKey ->
+                                val eventKey = uiState.event?.key
+                                if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
+                            },
+                            innerPadding = bottomPadding,
+                        )
+                    EventDetailTab.MATCHES ->
+                        EventMatchesTab(
+                            matches = uiState.matches,
+                            playoffType = uiState.event?.playoffType ?: PlayoffType.OTHER,
+                            onNavigateToMatch = onNavigateToMatch,
+                            innerPadding = bottomPadding,
+                        )
+                    EventDetailTab.ALLIANCES ->
+                        EventAlliancesTab(
+                            alliances = uiState.alliances,
+                            onTeamClick = { teamKey ->
+                                val eventKey = uiState.event?.key
+                                if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
+                            },
+                            innerPadding = bottomPadding,
+                        )
+                    EventDetailTab.INSIGHTS ->
+                        EventInsightsTab(
+                            oprs = uiState.oprs,
+                            coprs = uiState.coprs,
+                            insights = uiState.insights,
+                            isRefreshing = isRefreshing,
+                            innerPadding = bottomPadding,
+                        )
+                    EventDetailTab.ADVANCEMENT_POINTS ->
+                        EventAdvancementTab(
+                            uiState.advancementPoints,
+                            uiState.event,
+                            uiState.teams,
+                            uiState.regionalCmpAdvancementByTeam,
+                            onTeamClick = { teamKey ->
+                                val eventKey = uiState.event?.key
+                                if (eventKey != null) {
+                                    onNavigateToTeamEvent(teamKey, eventKey)
+                                } else {
+                                    onNavigateToTeam(teamKey)
+                                }
+                            },
+                            innerPadding = bottomPadding,
+                        )
+                    EventDetailTab.AWARDS ->
+                        EventAwardsTab(
+                            awards = uiState.awards,
+                            onTeamClick = { teamKey ->
+                                val eventKey = uiState.event?.key
+                                if (eventKey != null) {
+                                    onNavigateToTeamEvent(teamKey, eventKey)
+                                } else {
+                                    onNavigateToTeam(teamKey)
+                                }
+                            },
+                            innerPadding = bottomPadding,
+                        )
                 }
             }
         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailUiState.kt
@@ -4,8 +4,8 @@ import com.thebluealliance.android.domain.model.Alliance
 import com.thebluealliance.android.domain.model.Award
 import com.thebluealliance.android.domain.model.CmpAdvancement
 import com.thebluealliance.android.domain.model.Event
-import com.thebluealliance.android.domain.model.EventCOPRs
 import com.thebluealliance.android.domain.model.EventAdvancementPoints
+import com.thebluealliance.android.domain.model.EventCOPRs
 import com.thebluealliance.android.domain.model.EventInsights
 import com.thebluealliance.android.domain.model.EventOPRs
 import com.thebluealliance.android.domain.model.Match

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
@@ -2,7 +2,6 @@ package com.thebluealliance.android.ui.events.detail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.thebluealliance.android.navigation.Screen
 import com.thebluealliance.android.data.repository.AuthRepository
 import com.thebluealliance.android.data.repository.DistrictRepository
 import com.thebluealliance.android.data.repository.EventRepository
@@ -14,6 +13,7 @@ import com.thebluealliance.android.domain.model.Favorite
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.domain.model.Subscription
 import com.thebluealliance.android.domain.model.withPlayoffAlliances
+import com.thebluealliance.android.navigation.Screen
 import com.thebluealliance.android.shortcuts.TBAShortcutManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -36,254 +36,484 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel(assistedFactory = EventDetailViewModel.Factory::class)
-class EventDetailViewModel @AssistedInject constructor(
-    @Assisted val navKey: Screen.EventDetail,
-    private val eventRepository: EventRepository,
-    private val teamRepository: TeamRepository,
-    private val matchRepository: MatchRepository,
-    private val districtRepository: DistrictRepository,
-    private val myTBARepository: MyTBARepository,
-    private val authRepository: AuthRepository,
-    private val shortcutManager: TBAShortcutManager,
-) : ViewModel() {
+class EventDetailViewModel
+    @AssistedInject
+    constructor(
+        @Assisted val navKey: Screen.EventDetail,
+        private val eventRepository: EventRepository,
+        private val teamRepository: TeamRepository,
+        private val matchRepository: MatchRepository,
+        private val districtRepository: DistrictRepository,
+        private val myTBARepository: MyTBARepository,
+        private val authRepository: AuthRepository,
+        private val shortcutManager: TBAShortcutManager,
+    ) : ViewModel() {
+        private val eventKey: String = navKey.eventKey
+        private val eventYear: Int = eventKey.take(4).toIntOrNull() ?: 0
 
-    private val eventKey: String = navKey.eventKey
-    private val eventYear: Int = eventKey.take(4).toIntOrNull() ?: 0
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+        private val regionalCmpAdvancementByTeam =
+            MutableStateFlow<Map<String, CmpAdvancement>>(emptyMap())
 
-    private val _regionalCmpAdvancementByTeam = MutableStateFlow<Map<String, CmpAdvancement>>(emptyMap())
+        private val teamKeysFlow = teamRepository.observeEventTeamKeys(eventKey)
 
-
-    private val teamKeysFlow = teamRepository.observeEventTeamKeys(eventKey)
-
-    private val teamsFlow = teamKeysFlow.flatMapLatest { keys ->
-        if (keys.isEmpty()) flowOf(emptyList()) else teamRepository.observeTeams(keys)
-    }
-
-    val uiState: StateFlow<EventDetailUiState> = eventRepository.observeEvent(eventKey)
-        .flatMapLatest { event ->
-            val coreBaseFlow = combine(
-                flowOf(event),
-                teamsFlow,
-                matchRepository.observeEventMatches(eventKey),
-                eventRepository.observeEventRankings(eventKey),
-            ) { currentEvent, teams, matches, rankings ->
-                EventCoreBaseState(currentEvent, teams, matches, rankings)
+        private val teamsFlow =
+            teamKeysFlow.flatMapLatest { keys ->
+                if (keys.isEmpty()) flowOf(emptyList()) else teamRepository.observeTeams(keys)
             }
 
-            val coreFlow = combine(
-                coreBaseFlow,
-                eventRepository.observeEventRankingSortOrders(eventKey),
-                eventRepository.observeEventRankingExtraStatsInfo(eventKey),
-            ) { coreBase, rankingSortOrders, rankingExtraStatsInfo ->
-                EventCoreState(
-                    event = coreBase.event,
-                    teams = coreBase.teams,
-                    matches = coreBase.matches,
-                    rankings = coreBase.rankings,
-                    rankingSortOrders = rankingSortOrders,
-                    rankingExtraStatsInfo = rankingExtraStatsInfo,
-                )
-            }
+        val uiState: StateFlow<EventDetailUiState> =
+            eventRepository
+                .observeEvent(eventKey)
+                .flatMapLatest { event ->
+                    val coreBaseFlow =
+                        combine(
+                            flowOf(event),
+                            teamsFlow,
+                            matchRepository.observeEventMatches(eventKey),
+                            eventRepository.observeEventRankings(eventKey),
+                        ) { currentEvent, teams, matches, rankings ->
+                            EventCoreBaseState(currentEvent, teams, matches, rankings)
+                        }
 
-            val extrasLeftFlow = combine(
-                eventRepository.observeEventAlliances(eventKey),
-                eventRepository.observeEventAwards(eventKey),
-            ) { alliances, awards ->
-                Pair(alliances, awards)
-            }
+                    val coreFlow =
+                        combine(
+                            coreBaseFlow,
+                            eventRepository.observeEventRankingSortOrders(eventKey),
+                            eventRepository.observeEventRankingExtraStatsInfo(eventKey),
+                        ) { coreBase, rankingSortOrders, rankingExtraStatsInfo ->
+                            EventCoreState(
+                                event = coreBase.event,
+                                teams = coreBase.teams,
+                                matches = coreBase.matches,
+                                rankings = coreBase.rankings,
+                                rankingSortOrders = rankingSortOrders,
+                                rankingExtraStatsInfo = rankingExtraStatsInfo,
+                            )
+                        }
 
-            val extrasRightFlow = combine(
-                if (event?.district != null) eventRepository.observeEventDistrictPoints(eventKey) else eventRepository.observeEventRegionalPoints(eventKey),
-                eventRepository.observeEventOPRs(eventKey),
-                eventRepository.observeEventCOPRs(eventKey),
-                _regionalCmpAdvancementByTeam,
-            ) { advancementPoints, oprs, coprs, regionalCmpAdvancementByTeam ->
-                EventExtrasRightState(advancementPoints, oprs, coprs, regionalCmpAdvancementByTeam)
-            }
+                    val extrasLeftFlow =
+                        combine(
+                            eventRepository.observeEventAlliances(eventKey),
+                            eventRepository.observeEventAwards(eventKey),
+                        ) { alliances, awards ->
+                            Pair(alliances, awards)
+                        }
 
-            val extrasFlow = combine(extrasLeftFlow, extrasRightFlow) { left, right ->
-                EventExtrasState(
-                    alliances = left.first,
-                    awards = left.second,
-                    advancementPoints = right.advancementPoints,
-                    oprs = right.oprs,
-                    coprs = right.coprs,
-                    regionalCmpAdvancementByTeam = right.regionalCmpAdvancementByTeam,
-                )
-            }
+                    val extrasRightFlow =
+                        combine(
+                            if (event?.district !=
+                                null
+                            ) {
+                                eventRepository.observeEventDistrictPoints(eventKey)
+                            } else {
+                                eventRepository.observeEventRegionalPoints(eventKey)
+                            },
+                            eventRepository.observeEventOPRs(eventKey),
+                            eventRepository.observeEventCOPRs(eventKey),
+                            regionalCmpAdvancementByTeam,
+                        ) { advancementPoints, oprs, coprs, regionalCmpAdvancementByTeam ->
+                            EventExtrasRightState(
+                                advancementPoints,
+                                oprs,
+                                coprs,
+                                regionalCmpAdvancementByTeam,
+                            )
+                        }
 
-            combine(coreFlow, extrasFlow) { core, extras ->
-                EventDetailUiState(
-                    event = core.event,
-                    teams = core.teams,
-                    matches = core.matches.map { it.withPlayoffAlliances(extras.alliances) },
-                    rankings = core.rankings,
-                    rankingSortOrders = core.rankingSortOrders,
-                    rankingExtraStatsInfo = core.rankingExtraStatsInfo,
-                    alliances = extras.alliances,
-                    awards = extras.awards,
-                    advancementPoints = extras.advancementPoints,
-                    oprs = extras.oprs,
-                    coprs = extras.coprs,
-                    insights = null,
-                    regionalCmpAdvancementByTeam = extras.regionalCmpAdvancementByTeam,
-                )
-            }
-        }.flatMapLatest { baseState ->
-            combine(
-                eventRepository.observeEventInsights(eventKey),
-                baseState.event?.district?.let { districtRepository.observeDistrict(it) } ?: flowOf(null),
-                eventRepository.observeEventPitLocations(eventKey),
-            ) { insights, district, pitLocations ->
-                baseState.copy(
-                    insights = insights,
-                    districtDisplayName = district?.displayName,
-                    pitLocations = pitLocations,
-                )
-            }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), EventDetailUiState())
+                    val extrasFlow =
+                        combine(extrasLeftFlow, extrasRightFlow) { left, right ->
+                            EventExtrasState(
+                                alliances = left.first,
+                                awards = left.second,
+                                advancementPoints = right.advancementPoints,
+                                oprs = right.oprs,
+                                coprs = right.coprs,
+                                regionalCmpAdvancementByTeam = right.regionalCmpAdvancementByTeam,
+                            )
+                        }
 
-    val isFavorite: StateFlow<Boolean> = myTBARepository.isFavorite(eventKey, ModelType.EVENT)
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
-
-    val subscription: StateFlow<Subscription?> = myTBARepository
-        .observeSubscription(eventKey, ModelType.EVENT)
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
-
-    private val _showSignInPrompt = MutableSharedFlow<Unit>()
-    val showSignInPrompt: SharedFlow<Unit> = _showSignInPrompt.asSharedFlow()
-
-    private val _userMessage = MutableSharedFlow<String>()
-    val userMessage: SharedFlow<String> = _userMessage.asSharedFlow()
-
-    init {
-        refreshAll()
-    }
-
-    fun toggleFavorite() {
-        viewModelScope.launch {
-            if (!authRepository.isSignedIn()) {
-                _showSignInPrompt.emit(Unit)
-                return@launch
-            }
-            try {
-                if (isFavorite.value) {
-                    myTBARepository.removeFavorite(eventKey, ModelType.EVENT)
-                } else {
-                    myTBARepository.addFavorite(eventKey, ModelType.EVENT)
-                }
-            } catch (_: Exception) {}
-        }
-    }
-
-    fun updatePreferences(favorite: Boolean, notifications: List<String>) {
-        viewModelScope.launch {
-            try {
-                myTBARepository.updatePreferences(eventKey, ModelType.EVENT, favorite, notifications)
-            } catch (_: Exception) {
-                _userMessage.emit("Failed to save notification preferences")
-            }
-        }
-    }
-
-    val canPinShortcuts: Boolean = shortcutManager.canPinShortcuts()
-
-    fun requestPinShortcut() {
-        viewModelScope.launch {
-            shortcutManager.requestPinShortcut(
-                Favorite(modelKey = eventKey, modelType = ModelType.EVENT)
-            )
-        }
-    }
-
-    fun isSignedIn(): Boolean = authRepository.isSignedIn()
-
-    fun refreshAll() {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                coroutineScope {
-                    launch { try { eventRepository.refreshEvent(eventKey) } catch (_: Exception) {} }
-                    launch { try { teamRepository.refreshEventTeams(eventKey) } catch (_: Exception) {} }
-                    launch { try { matchRepository.refreshEventMatches(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventRankings(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventAlliances(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventAwards(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventDistrictPoints(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventRegionalPoints(eventKey) } catch (_: Exception) {} }
-                    launch {
-                        try {
-                            _regionalCmpAdvancementByTeam.value = eventRepository.fetchRegionalCmpAdvancementByTeam(eventYear)
-                        } catch (_: Exception) {}
+                    combine(coreFlow, extrasFlow) { core, extras ->
+                        EventDetailUiState(
+                            event = core.event,
+                            teams = core.teams,
+                            matches =
+                                core.matches.map {
+                                    it.withPlayoffAlliances(
+                                        extras.alliances,
+                                    )
+                                },
+                            rankings = core.rankings,
+                            rankingSortOrders = core.rankingSortOrders,
+                            rankingExtraStatsInfo = core.rankingExtraStatsInfo,
+                            alliances = extras.alliances,
+                            awards = extras.awards,
+                            advancementPoints = extras.advancementPoints,
+                            oprs = extras.oprs,
+                            coprs = extras.coprs,
+                            insights = null,
+                            regionalCmpAdvancementByTeam = extras.regionalCmpAdvancementByTeam,
+                        )
                     }
-                    launch { try { eventRepository.refreshEventOPRs(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventCOPRs(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventInsights(eventKey) } catch (_: Exception) {} }
-                    launch { try { districtRepository.refreshDistrictsForYear(eventYear) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventPitLocations(eventKey) } catch (_: Exception) {} }
+                }.flatMapLatest { baseState ->
+                    combine(
+                        eventRepository.observeEventInsights(eventKey),
+                        baseState.event?.district?.let { districtRepository.observeDistrict(it) }
+                            ?: flowOf(null),
+                        eventRepository.observeEventPitLocations(eventKey),
+                    ) { insights, district, pitLocations ->
+                        baseState.copy(
+                            insights = insights,
+                            districtDisplayName = district?.displayName,
+                            pitLocations = pitLocations,
+                        )
+                    }
+                }.stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5000),
+                    EventDetailUiState(),
+                )
+
+        val isFavorite: StateFlow<Boolean> =
+            myTBARepository
+                .isFavorite(eventKey, ModelType.EVENT)
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+        val subscription: StateFlow<Subscription?> =
+            myTBARepository
+                .observeSubscription(eventKey, ModelType.EVENT)
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+        private val _showSignInPrompt = MutableSharedFlow<Unit>()
+        val showSignInPrompt: SharedFlow<Unit> = _showSignInPrompt.asSharedFlow()
+
+        private val _userMessage = MutableSharedFlow<String>()
+        val userMessage: SharedFlow<String> = _userMessage.asSharedFlow()
+
+        init {
+            refreshAll()
+        }
+
+        fun toggleFavorite() {
+            viewModelScope.launch {
+                if (!authRepository.isSignedIn()) {
+                    _showSignInPrompt.emit(Unit)
+                    return@launch
                 }
-            } finally {
-                _isRefreshing.value = false
+                try {
+                    if (isFavorite.value) {
+                        myTBARepository.removeFavorite(eventKey, ModelType.EVENT)
+                    } else {
+                        myTBARepository.addFavorite(eventKey, ModelType.EVENT)
+                    }
+                } catch (_: Exception) {
+                }
             }
         }
-    }
 
-    fun refreshTab(tab: EventDetailTab) {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                coroutineScope {
-                    when (tab) {
-                        EventDetailTab.INFO -> {
-                            launch { try { eventRepository.refreshEvent(eventKey) } catch (_: Exception) {} }
-                            launch { try { districtRepository.refreshDistrictsForYear(eventYear) } catch (_: Exception) {} }
-                        }
-                        EventDetailTab.TEAMS -> {
-                            launch { try { teamRepository.refreshEventTeams(eventKey) } catch (_: Exception) {} }
-                            launch { try { eventRepository.refreshEventPitLocations(eventKey) } catch (_: Exception) {} }
-                        }
-                        EventDetailTab.RANKINGS -> {
-                            launch { try { eventRepository.refreshEventRankings(eventKey) } catch (_: Exception) {} }
-                        }
-                        EventDetailTab.MATCHES -> {
-                            launch { try { matchRepository.refreshEventMatches(eventKey) } catch (_: Exception) {} }
-                        }
-                        EventDetailTab.ALLIANCES -> {
-                            launch { try { eventRepository.refreshEventAlliances(eventKey) } catch (_: Exception) {} }
-                        }
-                        EventDetailTab.INSIGHTS -> {
-                            launch { try { eventRepository.refreshEventOPRs(eventKey) } catch (_: Exception) {} }
-                            launch { try { eventRepository.refreshEventCOPRs(eventKey) } catch (_: Exception) {} }
-                            launch { try { eventRepository.refreshEventInsights(eventKey) } catch (_: Exception) {} }
-                        }
-                        EventDetailTab.ADVANCEMENT_POINTS -> {
-                            launch { try { eventRepository.refreshEventDistrictPoints(eventKey) } catch (_: Exception) {} }
-                            launch { try { eventRepository.refreshEventRegionalPoints(eventKey) } catch (_: Exception) {} }
-                            launch {
-                                try {
-                                    _regionalCmpAdvancementByTeam.value = eventRepository.fetchRegionalCmpAdvancementByTeam(eventYear)
-                                } catch (_: Exception) {}
+        fun updatePreferences(
+            favorite: Boolean,
+            notifications: List<String>,
+        ) {
+            viewModelScope.launch {
+                try {
+                    myTBARepository.updatePreferences(
+                        eventKey,
+                        ModelType.EVENT,
+                        favorite,
+                        notifications,
+                    )
+                } catch (_: Exception) {
+                    _userMessage.emit("Failed to save notification preferences")
+                }
+            }
+        }
+
+        val canPinShortcuts: Boolean = shortcutManager.canPinShortcuts()
+
+        fun requestPinShortcut() {
+            viewModelScope.launch {
+                shortcutManager.requestPinShortcut(
+                    Favorite(modelKey = eventKey, modelType = ModelType.EVENT),
+                )
+            }
+        }
+
+        fun isSignedIn(): Boolean = authRepository.isSignedIn()
+
+        fun refreshAll() {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    coroutineScope {
+                        launch {
+                            try {
+                                eventRepository.refreshEvent(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
                             }
                         }
-                        EventDetailTab.AWARDS -> {
-                            launch { try { eventRepository.refreshEventAwards(eventKey) } catch (_: Exception) {} }
+                        launch {
+                            try {
+                                teamRepository.refreshEventTeams(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                matchRepository.refreshEventMatches(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventRankings(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventAlliances(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventAwards(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventDistrictPoints(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventRegionalPoints(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                regionalCmpAdvancementByTeam.value =
+                                    eventRepository.fetchRegionalCmpAdvancementByTeam(eventYear)
+                            } catch (_: Exception) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventOPRs(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventCOPRs(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventInsights(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                districtRepository.refreshDistrictsForYear(eventYear)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventPitLocations(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
                         }
                     }
+                } finally {
+                    _isRefreshing.value = false
                 }
-            } finally {
-                _isRefreshing.value = false
             }
         }
-    }
 
-    @AssistedFactory
-    interface Factory {
-        fun create(navKey: Screen.EventDetail): EventDetailViewModel
+        fun refreshTab(tab: EventDetailTab) {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    coroutineScope {
+                        when (tab) {
+                            EventDetailTab.INFO -> {
+                                launch {
+                                    try {
+                                        eventRepository.refreshEvent(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        districtRepository.refreshDistrictsForYear(eventYear)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            EventDetailTab.TEAMS -> {
+                                launch {
+                                    try {
+                                        teamRepository.refreshEventTeams(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventPitLocations(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            EventDetailTab.RANKINGS -> {
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventRankings(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            EventDetailTab.MATCHES -> {
+                                launch {
+                                    try {
+                                        matchRepository.refreshEventMatches(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            EventDetailTab.ALLIANCES -> {
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventAlliances(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            EventDetailTab.INSIGHTS -> {
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventOPRs(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventCOPRs(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventInsights(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            EventDetailTab.ADVANCEMENT_POINTS -> {
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventDistrictPoints(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventRegionalPoints(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        regionalCmpAdvancementByTeam.value =
+                                            eventRepository.fetchRegionalCmpAdvancementByTeam(
+                                                eventYear,
+                                            )
+                                    } catch (_: Exception) {
+                                    }
+                                }
+                            }
+                            EventDetailTab.AWARDS -> {
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventAwards(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } finally {
+                    _isRefreshing.value = false
+                }
+            }
+        }
+
+        @AssistedFactory
+        interface Factory {
+            fun create(navKey: Screen.EventDetail): EventDetailViewModel
+        }
     }
-}
 
 private data class EventCoreBaseState(
     val event: com.thebluealliance.android.domain.model.Event?,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.HorizontalDivider
@@ -29,10 +30,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.shape.RoundedCornerShape
 import com.thebluealliance.android.domain.model.CmpAdvancement
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.EventAdvancementPoints
@@ -43,15 +43,16 @@ import com.thebluealliance.android.ui.common.LoadingBox
 internal fun advancementBreakdownRows(
     points: EventAdvancementPoints,
     isDistrictEvent: Boolean,
-): List<Pair<String, Int>> = buildList {
-    add("Qualification" to points.qualPoints)
-    add((if (isDistrictEvent) "Elimination" else "Playoff") to points.elimPoints)
-    add("Alliance" to points.alliancePoints)
-    add("Awards" to points.awardPoints)
-    if (!isDistrictEvent) {
-        add("Team Age" to points.rookieBonus)
+): List<Pair<String, Int>> =
+    buildList {
+        add("Qualification" to points.qualPoints)
+        add((if (isDistrictEvent) "Elimination" else "Playoff") to points.elimPoints)
+        add("Alliance" to points.alliancePoints)
+        add("Awards" to points.awardPoints)
+        if (!isDistrictEvent) {
+            add("Team Age" to points.rookieBonus)
+        }
     }
-}
 
 @Composable
 fun EventAdvancementTab(
@@ -64,14 +65,14 @@ fun EventAdvancementTab(
 ) {
     if (advancementPoints == null) {
         LoadingBox(
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
         )
         return
     }
     if (advancementPoints.isEmpty()) {
         EmptyBox(
             modifier = Modifier.padding(innerPadding),
-            message = if (event?.district != null) "No district points" else "No regional points"
+            message = if (event?.district != null) "No district points" else "No regional points",
         )
         return
     }
@@ -89,7 +90,12 @@ fun EventAdvancementTab(
                 points = points,
                 teamName = teamName,
                 isDistrictEvent = isDistrictEvent,
-                cmpAdvancement = if (isDistrictEvent) null else regionalCmpAdvancementByTeam[points.teamKey],
+                cmpAdvancement =
+                    if (isDistrictEvent) {
+                        null
+                    } else {
+                        regionalCmpAdvancementByTeam[points.teamKey]
+                    },
                 onTeamClick = onTeamClick,
             )
         }
@@ -113,10 +119,11 @@ private fun AdvancementPointsItem(
 
     Column(modifier = Modifier.fillMaxWidth()) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { expanded = !expanded }
-                .padding(horizontal = 16.dp, vertical = 10.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { expanded = !expanded }
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -163,10 +170,11 @@ private fun AdvancementPointsItem(
 
         AnimatedVisibility(visible = expanded) {
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(start = 56.dp, bottom = 8.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(start = 56.dp, bottom = 8.dp),
             ) {
                 advancementBreakdownRows(points, isDistrictEvent).forEach { (label, value) ->
                     AdvancementBreakdownRow(label, value)
@@ -220,14 +228,15 @@ private fun AdvancementPointsItem(
 }
 
 /** Returns a human-readable detail string describing how the team qualified, or null. */
-private fun cmpAdvancementDetail(advancement: CmpAdvancement): String? = when (advancement) {
-    is CmpAdvancement.EventQualified -> {
-        val name = advancement.eventShortName ?: advancement.eventKey.ifBlank { null }
-        name?.let { "via $it" }
+private fun cmpAdvancementDetail(advancement: CmpAdvancement): String? =
+    when (advancement) {
+        is CmpAdvancement.EventQualified -> {
+            val name = advancement.eventShortName ?: advancement.eventKey.ifBlank { null }
+            name?.let { "via $it" }
+        }
+        is CmpAdvancement.PoolQualified -> "via Week ${advancement.week} Pool"
+        is CmpAdvancement.Qualified -> null
     }
-    is CmpAdvancement.PoolQualified -> "via Week ${advancement.week} Pool"
-    is CmpAdvancement.Qualified -> null
-}
 
 @Composable
 private fun CmpAdvancementBadge(advancement: CmpAdvancement) {
@@ -237,18 +246,23 @@ private fun CmpAdvancementBadge(advancement: CmpAdvancement) {
         color = MaterialTheme.colorScheme.onPrimaryContainer,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
-        modifier = Modifier
-            .background(MaterialTheme.colorScheme.primaryContainer, RoundedCornerShape(4.dp))
-            .padding(horizontal = 8.dp, vertical = 4.dp),
+        modifier =
+            Modifier
+                .background(MaterialTheme.colorScheme.primaryContainer, RoundedCornerShape(4.dp))
+                .padding(horizontal = 8.dp, vertical = 4.dp),
     )
 }
 
 @Composable
-private fun AdvancementBreakdownRow(label: String, value: Int) {
+private fun AdvancementBreakdownRow(
+    label: String,
+    value: Int,
+) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 2.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 2.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
@@ -16,8 +16,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Alliance
@@ -35,7 +35,7 @@ fun EventAlliancesTab(
 ) {
     if (alliances == null) {
         LoadingBox(
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
         )
         return
     }
@@ -52,9 +52,10 @@ fun EventAlliancesTab(
     ) {
         items(alliances, key = { "${it.eventKey}_${it.number}" }) { alliance ->
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -86,7 +87,9 @@ fun EventAlliancesTab(
                 ) {
                     alliance.picks.forEachIndexed { index, teamKey ->
                         Text(
-                            text = teamKey.removePrefix("frc") + if (index < alliance.picks.lastIndex) "," else "",
+                            text =
+                                teamKey.removePrefix("frc") +
+                                    if (index < alliance.picks.lastIndex) "," else "",
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.clickable { onTeamClick(teamKey) },

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAwardsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAwardsTab.kt
@@ -26,7 +26,7 @@ fun EventAwardsTab(
 ) {
     if (awards == null) {
         LoadingBox(
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
         )
         return
     }
@@ -41,28 +41,37 @@ fun EventAwardsTab(
         modifier = Modifier.fillMaxSize(),
         contentPadding = innerPadding,
     ) {
-        items(awards, key = { "${it.eventKey}_${it.awardType}_${it.teamKey}_${it.awardee.orEmpty()}" }) { award ->
+        items(awards, key = {
+            "${it.eventKey}_${it.awardType}_${it.teamKey}_${it.awardee.orEmpty()}"
+        }) { award ->
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .then(
-                        if (award.teamKey.isNotEmpty()) Modifier.clickable { onTeamClick(award.teamKey) }
-                        else Modifier
-                    )
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (award.teamKey.isNotEmpty()) {
+                                Modifier.clickable { onTeamClick(award.teamKey) }
+                            } else {
+                                Modifier
+                            },
+                        ).padding(horizontal = 16.dp, vertical = 8.dp),
             ) {
                 Text(
                     text = award.name,
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Medium,
                 )
-                val recipient = buildString {
-                    if (award.awardee != null) append(award.awardee)
-                    if (award.teamKey.isNotEmpty()) {
-                        if (isNotEmpty()) append(" (${award.teamKey.removePrefix("frc")})")
-                        else append(award.teamKey.removePrefix("frc"))
+                val recipient =
+                    buildString {
+                        if (award.awardee != null) append(award.awardee)
+                        if (award.teamKey.isNotEmpty()) {
+                            if (isNotEmpty()) {
+                                append(" (${award.teamKey.removePrefix("frc")})")
+                            } else {
+                                append(award.teamKey.removePrefix("frc"))
+                            }
+                        }
                     }
-                }
                 if (recipient.isNotEmpty()) {
                     Text(
                         text = recipient,
@@ -74,4 +83,3 @@ fun EventAwardsTab(
         }
     }
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Language
@@ -29,8 +28,8 @@ import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.Webcast
 import com.thebluealliance.android.ui.common.LoadingBox
-import com.thebluealliance.android.util.openUrl
 import com.thebluealliance.android.ui.components.formatEventDateRange
+import com.thebluealliance.android.util.openUrl
 
 @Composable
 fun EventInfoTab(
@@ -41,15 +40,16 @@ fun EventInfoTab(
 ) {
     if (event == null) {
         LoadingBox(
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
         )
         return
     }
     val context = LocalContext.current
     LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(16.dp),
         contentPadding = innerPadding,
     ) {
         item {
@@ -91,9 +91,10 @@ fun EventInfoTab(
                     text = "District: $districtLabel",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .padding(top = 4.dp)
-                        .clickable { onNavigateToDistrict(event.district) },
+                    modifier =
+                        Modifier
+                            .padding(top = 4.dp)
+                            .clickable { onNavigateToDistrict(event.district) },
                 )
             }
         }
@@ -113,12 +114,13 @@ fun EventInfoTab(
         if (event.address != null) {
             item {
                 Row(
-                    modifier = Modifier
-                        .padding(top = 8.dp)
-                        .clickable {
-                            val url = event.gmapsUrl ?: "geo:0,0?q=${Uri.encode(event.address)}"
-                            context.openUrl(url)
-                        },
+                    modifier =
+                        Modifier
+                            .padding(top = 8.dp)
+                            .clickable {
+                                val url = event.gmapsUrl ?: "geo:0,0?q=${Uri.encode(event.address)}"
+                                context.openUrl(url)
+                            },
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
@@ -141,11 +143,12 @@ fun EventInfoTab(
         if (event.website != null) {
             item {
                 Row(
-                    modifier = Modifier
-                        .padding(top = 8.dp)
-                        .clickable {
-                            context.openUrl(event.website)
-                        },
+                    modifier =
+                        Modifier
+                            .padding(top = 8.dp)
+                            .clickable {
+                                context.openUrl(event.website)
+                            },
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
@@ -174,16 +177,22 @@ fun EventInfoTab(
                     fontWeight = FontWeight.Bold,
                 )
             }
-            itemsIndexed(event.webcasts, key = { index, it -> "${it.type}_${it.channel}_$index" }) { _, webcast ->
+            itemsIndexed(event.webcasts, key = {
+                index,
+                it,
+                ->
+                "${it.type}_${it.channel}_$index"
+            }) { _, webcast ->
                 val url = webcastUrl(webcast)
                 val label = webcastLabel(webcast)
                 if (url != null) {
                     Row(
-                        modifier = Modifier
-                            .padding(top = 4.dp)
-                            .clickable {
-                                context.openUrl(url)
-                            },
+                        modifier =
+                            Modifier
+                                .padding(top = 4.dp)
+                                .clickable {
+                                    context.openUrl(url)
+                                },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(
@@ -205,31 +214,36 @@ fun EventInfoTab(
     }
 }
 
-private fun webcastUrl(webcast: Webcast): String? = when (webcast.type) {
-    "twitch" -> "https://twitch.tv/${webcast.channel}"
-    "youtube" -> "https://youtube.com/watch?v=${webcast.channel}"
-    "livestream" -> "https://livestream.com/accounts/${webcast.channel}/events/${webcast.file ?: ""}"
-    else -> null
-}
+private fun webcastUrl(webcast: Webcast): String? =
+    when (webcast.type) {
+        "twitch" -> "https://twitch.tv/${webcast.channel}"
+        "youtube" -> "https://youtube.com/watch?v=${webcast.channel}"
+        "livestream" ->
+            "https://livestream.com/accounts/${webcast.channel}/events/${webcast.file ?: ""}"
+        else -> null
+    }
 
 private fun webcastLabel(webcast: Webcast): String {
-    val base = when (webcast.type) {
-        "twitch" -> "Watch on Twitch"
-        "youtube" -> "Watch on YouTube"
-        "livestream" -> "Watch on Livestream"
-        else -> "Watch (${webcast.type})"
-    }
+    val base =
+        when (webcast.type) {
+            "twitch" -> "Watch on Twitch"
+            "youtube" -> "Watch on YouTube"
+            "livestream" -> "Watch on Livestream"
+            else -> "Watch (${webcast.type})"
+        }
     val dateSuffix = webcast.date?.let { formatWebcastDate(it) } ?: ""
     return if (dateSuffix.isNotEmpty()) "$base $dateSuffix" else base
 }
 
-private fun formatWebcastDate(dateStr: String): String {
-    return try {
+private fun formatWebcastDate(dateStr: String): String =
+    try {
         val date = java.time.LocalDate.parse(dateStr)
-        val formatter = java.time.format.DateTimeFormatter.ofPattern("(EEE, MMM d)", java.util.Locale.US)
+        val formatter =
+            java.time.format.DateTimeFormatter.ofPattern(
+                "(EEE, MMM d)",
+                java.util.Locale.US,
+            )
         date.format(formatter)
     } catch (_: Exception) {
         ""
     }
-}
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
@@ -34,8 +34,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.EventCOPRs
@@ -43,27 +43,36 @@ import com.thebluealliance.android.domain.model.EventInsights
 import com.thebluealliance.android.domain.model.EventOPRs
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
+import com.thebluealliance.android.util.openUrl
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.int
-import com.thebluealliance.android.util.openUrl
 
 sealed class StatType {
     object StandardOPRs : StatType()
+
     object QualInsights : StatType()
+
     object PlayoffInsights : StatType()
-    data class COPR(val statName: String) : StatType()
+
+    data class COPR(
+        val statName: String,
+    ) : StatType()
 }
 
 enum class OprSortColumn {
-    TEAM, OPR, DPR, CCWM
+    TEAM,
+    OPR,
+    DPR,
+    CCWM,
 }
 
 enum class CoprSortColumn {
-    TEAM, VALUE
+    TEAM,
+    VALUE,
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -95,19 +104,21 @@ fun EventInsightsTab(
     var coprSortColumn by remember { mutableStateOf(CoprSortColumn.VALUE) }
     var coprSortAscending by remember { mutableStateOf(false) }
     var showStatSelector by remember { mutableStateOf(false) }
-    val defaultStatType = when {
-        hasOprData -> StatType.StandardOPRs
-        hasInsightsData && insights.qual != null -> StatType.QualInsights
-        hasInsightsData && insights.playoff != null -> StatType.PlayoffInsights
-        hasCoprData -> StatType.COPR(coprs.coprs.keys.first())
-        else -> StatType.StandardOPRs
-    }
+    val defaultStatType =
+        when {
+            hasOprData -> StatType.StandardOPRs
+            hasInsightsData && insights.qual != null -> StatType.QualInsights
+            hasInsightsData && insights.playoff != null -> StatType.PlayoffInsights
+            hasCoprData -> StatType.COPR(coprs.coprs.keys.first())
+            else -> StatType.StandardOPRs
+        }
     var selectedStatType by remember { mutableStateOf(defaultStatType) }
 
     // Get available COPR stat names
-    val coprStatNames = remember(coprs) {
-        coprs?.coprs?.keys?.sorted() ?: emptyList()
-    }
+    val coprStatNames =
+        remember(coprs) {
+            coprs?.coprs?.keys?.sorted() ?: emptyList()
+        }
 
     if (showStatSelector) {
         StatSelectorDialog(
@@ -121,19 +132,20 @@ fun EventInsightsTab(
                     coprSortColumn = CoprSortColumn.VALUE
                     coprSortAscending = false
                 }
-            }
+            },
         )
     }
 
     val layoutDirection = LocalLayoutDirection.current
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(
-                top = innerPadding.calculateTopPadding(),
-                start = innerPadding.calculateStartPadding(layoutDirection),
-                end = innerPadding.calculateEndPadding(layoutDirection)
-            )
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(
+                    top = innerPadding.calculateTopPadding(),
+                    start = innerPadding.calculateStartPadding(layoutDirection),
+                    end = innerPadding.calculateEndPadding(layoutDirection),
+                ),
     ) {
         when (val statType = selectedStatType) {
             is StatType.StandardOPRs -> {
@@ -202,57 +214,60 @@ private fun StatSelectorDialog(
             LazyColumn {
                 item {
                     Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onSelect(StatType.StandardOPRs) }
-                            .padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelect(StatType.StandardOPRs) }
+                                .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = currentSelection is StatType.StandardOPRs,
-                            onClick = { onSelect(StatType.StandardOPRs) }
+                            onClick = { onSelect(StatType.StandardOPRs) },
                         )
                         Text(
                             text = "OPRs (OPR / DPR / CCWM)",
-                            modifier = Modifier.padding(start = 8.dp)
+                            modifier = Modifier.padding(start = 8.dp),
                         )
                     }
                 }
 
                 item {
                     Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onSelect(StatType.QualInsights) }
-                            .padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelect(StatType.QualInsights) }
+                                .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = currentSelection is StatType.QualInsights,
-                            onClick = { onSelect(StatType.QualInsights) }
+                            onClick = { onSelect(StatType.QualInsights) },
                         )
                         Text(
                             text = "Qual Insights",
-                            modifier = Modifier.padding(start = 8.dp)
+                            modifier = Modifier.padding(start = 8.dp),
                         )
                     }
                 }
 
                 item {
                     Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onSelect(StatType.PlayoffInsights) }
-                            .padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelect(StatType.PlayoffInsights) }
+                                .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(
                             selected = currentSelection is StatType.PlayoffInsights,
-                            onClick = { onSelect(StatType.PlayoffInsights) }
+                            onClick = { onSelect(StatType.PlayoffInsights) },
                         )
                         Text(
                             text = "Playoff Insights",
-                            modifier = Modifier.padding(start = 8.dp)
+                            modifier = Modifier.padding(start = 8.dp),
                         )
                     }
                 }
@@ -263,25 +278,28 @@ private fun StatSelectorDialog(
                         Text(
                             text = "Component OPRs",
                             style = MaterialTheme.typography.titleSmall,
-                            modifier = Modifier.padding(vertical = 8.dp)
+                            modifier = Modifier.padding(vertical = 8.dp),
                         )
                     }
 
                     items(availableCoprStats) { statName ->
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { onSelect(StatType.COPR(statName)) }
-                                .padding(vertical = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable { onSelect(StatType.COPR(statName)) }
+                                    .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
                         ) {
                             RadioButton(
-                                selected = currentSelection is StatType.COPR && currentSelection.statName == statName,
-                                onClick = { onSelect(StatType.COPR(statName)) }
+                                selected =
+                                    currentSelection is StatType.COPR &&
+                                        currentSelection.statName == statName,
+                                onClick = { onSelect(StatType.COPR(statName)) },
                             )
                             Text(
                                 text = statName,
-                                modifier = Modifier.padding(start = 8.dp)
+                                modifier = Modifier.padding(start = 8.dp),
                             )
                         }
                     }
@@ -305,31 +323,33 @@ private fun InsightsView(
     innerPadding: PaddingValues,
     onOpenOprLink: () -> Unit,
 ) {
-    val insightHeader = when (title) {
-        "Qual Insights" -> "Qual Insight"
-        "Playoff Insights" -> "Playoff Insight"
-        else -> "Insight"
-    }
+    val insightHeader =
+        when (title) {
+            "Qual Insights" -> "Qual Insight"
+            "Playoff Insights" -> "Playoff Insight"
+            else -> "Insight"
+        }
 
     if (insightsData == null) {
         Box(
             modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
+            contentAlignment = Alignment.Center,
         ) {
             Text("No $title data available")
         }
         return
     }
 
-    val insightsList = remember(insightsData) {
-        try {
-            val jsonElement = Json.parseToJsonElement(insightsData)
-            val jsonObject = jsonElement as? JsonObject ?: return@remember emptyList()
-            parseInsightsData(jsonObject)
-        } catch (_: Exception) {
-            emptyList()
+    val insightsList =
+        remember(insightsData) {
+            try {
+                val jsonElement = Json.parseToJsonElement(insightsData)
+                val jsonObject = jsonElement as? JsonObject ?: return@remember emptyList()
+                parseInsightsData(jsonObject)
+            } catch (_: Exception) {
+                emptyList()
+            }
         }
-    }
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -337,34 +357,35 @@ private fun InsightsView(
     ) {
         stickyHeader {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(Color(0xFF5C6BC0))
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFF5C6BC0))
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
                     text = insightHeader,
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     color = Color.White,
-                    modifier = Modifier.weight(1.5f)
+                    modifier = Modifier.weight(1.5f),
                 )
                 Text(
                     text = "Value",
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     color = Color.White,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f),
                 )
                 IconButton(
                     onClick = onShowStatSelector,
-                    modifier = Modifier.padding(0.dp)
+                    modifier = Modifier.padding(0.dp),
                 ) {
                     Icon(
                         imageVector = Icons.Default.MoreVert,
                         contentDescription = "Select stat type",
-                        tint = Color.White
+                        tint = Color.White,
                     )
                 }
             }
@@ -373,20 +394,21 @@ private fun InsightsView(
         items(insightsList) { insight ->
             Column {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
                         text = insight.name,
                         modifier = Modifier.weight(1.5f),
-                        style = MaterialTheme.typography.bodyLarge
+                        style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
                         text = insight.value,
                         modifier = Modifier.weight(1f),
-                        style = MaterialTheme.typography.bodyLarge
+                        style = MaterialTheme.typography.bodyLarge,
                     )
                     Box(modifier = Modifier.weight(0.4f))
                 }
@@ -399,15 +421,19 @@ private fun InsightsView(
                 text = "Learn more about OPR",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .clickable { onOpenOprLink() }
-                    .padding(16.dp),
+                modifier =
+                    Modifier
+                        .clickable { onOpenOprLink() }
+                        .padding(16.dp),
             )
         }
     }
 }
 
-data class InsightItem(val name: String, val value: String)
+data class InsightItem(
+    val name: String,
+    val value: String,
+)
 
 private fun parseInsightsData(jsonObject: JsonObject): List<InsightItem> {
     val items = mutableListOf<InsightItem>()
@@ -422,7 +448,12 @@ private fun parseInsightsData(jsonObject: JsonObject): List<InsightItem> {
                     val success = (value[0] as? JsonPrimitive)?.int ?: 0
                     val opportunities = (value[1] as? JsonPrimitive)?.int ?: 0
                     val percentage = (value[2] as? JsonPrimitive)?.doubleOrNull ?: 0.0
-                    items.add(InsightItem(formattedName, "$success / $opportunities (%.1f%%)".format(percentage)))
+                    items.add(
+                        InsightItem(
+                            formattedName,
+                            "$success / $opportunities (%.1f%%)".format(percentage),
+                        ),
+                    )
                 } else if (key == "high_score" && value.size >= 3) {
                     // Format as: score (match)
                     val score = (value[0] as? JsonPrimitive)?.int ?: 0
@@ -433,22 +464,40 @@ private fun parseInsightsData(jsonObject: JsonObject): List<InsightItem> {
                     val total = (value[0] as? JsonPrimitive)?.doubleOrNull ?: 0.0
                     val allianceAvg = (value[1] as? JsonPrimitive)?.doubleOrNull ?: 0.0
                     val teamAvg = (value[2] as? JsonPrimitive)?.doubleOrNull ?: 0.0
-                    val totalStr = if (total % 1.0 == 0.0) total.toInt().toString() else "%.2f".format(total)
-                    items.add(InsightItem(formattedName, "$totalStr total / ${"%.2f".format(allianceAvg)} alliance / ${"%.2f".format(teamAvg)} team"))
+                    val totalStr =
+                        if (total % 1.0 ==
+                            0.0
+                        ) {
+                            total.toInt().toString()
+                        } else {
+                            "%.2f".format(total)
+                        }
+                    items.add(
+                        InsightItem(
+                            formattedName,
+                            "$totalStr total / ${"%.2f".format(
+                                allianceAvg,
+                            )} alliance / ${"%.2f".format(teamAvg)} team",
+                        ),
+                    )
                 } else {
                     // Generic array formatting
                     items.add(InsightItem(formattedName, value.toString()))
                 }
             }
             is JsonPrimitive -> {
-                val formattedValue = when {
-                    value.isString -> value.content
-                    else -> {
-                        val num = value.doubleOrNull ?: 0.0
-                        if (num % 1.0 == 0.0) num.toInt().toString()
-                        else "%.2f".format(num)
+                val formattedValue =
+                    when {
+                        value.isString -> value.content
+                        else -> {
+                            val num = value.doubleOrNull ?: 0.0
+                            if (num % 1.0 == 0.0) {
+                                num.toInt().toString()
+                            } else {
+                                "%.2f".format(num)
+                            }
+                        }
                     }
-                }
                 items.add(InsightItem(formattedName, formattedValue))
             }
             else -> {
@@ -460,14 +509,13 @@ private fun parseInsightsData(jsonObject: JsonObject): List<InsightItem> {
     return items
 }
 
-private fun formatStatName(key: String): String {
-    return key
+private fun formatStatName(key: String): String =
+    key
         .replace("_", " ")
         .split(" ")
         .joinToString(" ") { word ->
             word.replaceFirstChar { it.uppercase() }
         }
-}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -480,23 +528,29 @@ private fun StandardOPRsView(
     innerPadding: PaddingValues,
     onOpenOprLink: () -> Unit,
 ) {
-    val teamKeys = oprs.oprs.keys.union(oprs.dprs.keys).union(oprs.ccwms.keys).toList()
+    val teamKeys =
+        oprs.oprs.keys
+            .union(oprs.dprs.keys)
+            .union(oprs.ccwms.keys)
+            .toList()
 
-    val sortedTeams = remember(oprs, sortColumn, sortAscending) {
-        teamKeys.sortedWith { a, b ->
-            val result = when (sortColumn) {
-                OprSortColumn.TEAM -> {
-                    val teamA = a.substring(3).toIntOrNull() ?: 0
-                    val teamB = b.substring(3).toIntOrNull() ?: 0
-                    teamA.compareTo(teamB)
-                }
-                OprSortColumn.OPR -> (oprs.oprs[a] ?: 0.0).compareTo(oprs.oprs[b] ?: 0.0)
-                OprSortColumn.DPR -> (oprs.dprs[a] ?: 0.0).compareTo(oprs.dprs[b] ?: 0.0)
-                OprSortColumn.CCWM -> (oprs.ccwms[a] ?: 0.0).compareTo(oprs.ccwms[b] ?: 0.0)
+    val sortedTeams =
+        remember(oprs, sortColumn, sortAscending) {
+            teamKeys.sortedWith { a, b ->
+                val result =
+                    when (sortColumn) {
+                        OprSortColumn.TEAM -> {
+                            val teamA = a.substring(3).toIntOrNull() ?: 0
+                            val teamB = b.substring(3).toIntOrNull() ?: 0
+                            teamA.compareTo(teamB)
+                        }
+                        OprSortColumn.OPR -> (oprs.oprs[a] ?: 0.0).compareTo(oprs.oprs[b] ?: 0.0)
+                        OprSortColumn.DPR -> (oprs.dprs[a] ?: 0.0).compareTo(oprs.dprs[b] ?: 0.0)
+                        OprSortColumn.CCWM -> (oprs.ccwms[a] ?: 0.0).compareTo(oprs.ccwms[b] ?: 0.0)
+                    }
+                if (sortAscending) result else -result
             }
-            if (sortAscending) result else -result
         }
-    }
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -504,11 +558,12 @@ private fun StandardOPRsView(
     ) {
         stickyHeader {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(Color(0xFF5C6BC0))
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFF5C6BC0))
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 OprHeaderItem(
                     text = "Team",
@@ -522,7 +577,7 @@ private fun StandardOPRsView(
                         } else {
                             onSortChange(OprSortColumn.TEAM, true)
                         }
-                    }
+                    },
                 )
                 OprHeaderItem(
                     text = "OPR",
@@ -536,7 +591,7 @@ private fun StandardOPRsView(
                         } else {
                             onSortChange(OprSortColumn.OPR, false)
                         }
-                    }
+                    },
                 )
                 OprHeaderItem(
                     text = "DPR",
@@ -550,7 +605,7 @@ private fun StandardOPRsView(
                         } else {
                             onSortChange(OprSortColumn.DPR, false)
                         }
-                    }
+                    },
                 )
                 OprHeaderItem(
                     text = "CCWM",
@@ -564,16 +619,16 @@ private fun StandardOPRsView(
                         } else {
                             onSortChange(OprSortColumn.CCWM, false)
                         }
-                    }
+                    },
                 )
                 IconButton(
                     onClick = onShowStatSelector,
-                    modifier = Modifier.padding(0.dp)
+                    modifier = Modifier.padding(0.dp),
                 ) {
                     Icon(
                         imageVector = Icons.Default.MoreVert,
                         contentDescription = "Select stat type",
-                        tint = Color.White
+                        tint = Color.White,
                     )
                 }
             }
@@ -582,30 +637,31 @@ private fun StandardOPRsView(
         items(sortedTeams) { teamKey ->
             Column {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
                         text = teamKey.substring(3),
                         modifier = Modifier.weight(1.2f),
-                        style = MaterialTheme.typography.bodyLarge
+                        style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
                         text = "%.2f".format(oprs.oprs[teamKey] ?: 0.0),
                         modifier = Modifier.weight(1f),
-                        style = MaterialTheme.typography.bodyLarge
+                        style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
                         text = "%.2f".format(oprs.dprs[teamKey] ?: 0.0),
                         modifier = Modifier.weight(1f),
-                        style = MaterialTheme.typography.bodyLarge
+                        style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
                         text = "%.2f".format(oprs.ccwms[teamKey] ?: 0.0),
                         modifier = Modifier.weight(1f),
-                        style = MaterialTheme.typography.bodyLarge
+                        style = MaterialTheme.typography.bodyLarge,
                     )
                     Box(modifier = Modifier.weight(0.4f))
                 }
@@ -618,9 +674,10 @@ private fun StandardOPRsView(
                 text = "Learn more about OPR",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .clickable { onOpenOprLink() }
-                    .padding(16.dp),
+                modifier =
+                    Modifier
+                        .clickable { onOpenOprLink() }
+                        .padding(16.dp),
             )
         }
     }
@@ -640,19 +697,21 @@ private fun COPRView(
 ) {
     val teamKeys = coprData.keys.toList()
 
-    val sortedTeams = remember(coprData, sortColumn, sortAscending) {
-        teamKeys.sortedWith { a, b ->
-            val result = when (sortColumn) {
-                CoprSortColumn.TEAM -> {
-                    val teamA = a.substring(3).toIntOrNull() ?: 0
-                    val teamB = b.substring(3).toIntOrNull() ?: 0
-                    teamA.compareTo(teamB)
-                }
-                CoprSortColumn.VALUE -> (coprData[a] ?: 0.0).compareTo(coprData[b] ?: 0.0)
+    val sortedTeams =
+        remember(coprData, sortColumn, sortAscending) {
+            teamKeys.sortedWith { a, b ->
+                val result =
+                    when (sortColumn) {
+                        CoprSortColumn.TEAM -> {
+                            val teamA = a.substring(3).toIntOrNull() ?: 0
+                            val teamB = b.substring(3).toIntOrNull() ?: 0
+                            teamA.compareTo(teamB)
+                        }
+                        CoprSortColumn.VALUE -> (coprData[a] ?: 0.0).compareTo(coprData[b] ?: 0.0)
+                    }
+                if (sortAscending) result else -result
             }
-            if (sortAscending) result else -result
         }
-    }
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -660,11 +719,12 @@ private fun COPRView(
     ) {
         stickyHeader {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(Color(0xFF5C6BC0))
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFF5C6BC0))
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 CoprHeaderItem(
                     text = "Team",
@@ -678,7 +738,7 @@ private fun COPRView(
                         } else {
                             onSortChange(CoprSortColumn.TEAM, true)
                         }
-                    }
+                    },
                 )
                 CoprHeaderItem(
                     text = statName,
@@ -692,16 +752,16 @@ private fun COPRView(
                         } else {
                             onSortChange(CoprSortColumn.VALUE, false)
                         }
-                    }
+                    },
                 )
                 IconButton(
                     onClick = onShowStatSelector,
-                    modifier = Modifier.padding(0.dp)
+                    modifier = Modifier.padding(0.dp),
                 ) {
                     Icon(
                         imageVector = Icons.Default.MoreVert,
                         contentDescription = "Select stat type",
-                        tint = Color.White
+                        tint = Color.White,
                     )
                 }
             }
@@ -710,20 +770,21 @@ private fun COPRView(
         items(sortedTeams) { teamKey ->
             Column {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
                         text = teamKey.substring(3),
                         modifier = Modifier.weight(1.2f),
-                        style = MaterialTheme.typography.bodyLarge
+                        style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
                         text = "%.2f".format(coprData[teamKey] ?: 0.0),
                         modifier = Modifier.weight(2f),
-                        style = MaterialTheme.typography.bodyLarge
+                        style = MaterialTheme.typography.bodyLarge,
                     )
                 }
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -735,9 +796,10 @@ private fun COPRView(
                 text = "Learn more about OPR",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .clickable { onOpenOprLink() }
-                    .padding(16.dp),
+                modifier =
+                    Modifier
+                        .clickable { onOpenOprLink() }
+                        .padding(16.dp),
             )
         }
     }
@@ -750,23 +812,25 @@ private fun OprHeaderItem(
     sortColumn: OprSortColumn,
     currentSort: OprSortColumn,
     ascending: Boolean,
-    onSortClick: () -> Unit
+    onSortClick: () -> Unit,
 ) {
     Row(
         modifier = modifier.clickable { onSortClick() },
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = text,
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
-            color = Color.White
+            color = Color.White,
         )
         if (currentSort == sortColumn) {
             Icon(
-                imageVector = if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
-                contentDescription = if (ascending) "Sorted Ascending" else "Sorted Descending",
-                tint = Color.White
+                imageVector =
+                    if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
+                contentDescription =
+                    if (ascending) "Sorted Ascending" else "Sorted Descending",
+                tint = Color.White,
             )
         }
     }
@@ -779,23 +843,25 @@ private fun CoprHeaderItem(
     sortColumn: CoprSortColumn,
     currentSort: CoprSortColumn,
     ascending: Boolean,
-    onSortClick: () -> Unit
+    onSortClick: () -> Unit,
 ) {
     Row(
         modifier = modifier.clickable { onSortClick() },
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = text,
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
-            color = Color.White
+            color = Color.White,
         )
         if (currentSort == sortColumn) {
             Icon(
-                imageVector = if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
-                contentDescription = if (ascending) "Sorted Ascending" else "Sorted Descending",
-                tint = Color.White
+                imageVector =
+                    if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
+                contentDescription =
+                    if (ascending) "Sorted Ascending" else "Sorted Descending",
+                tint = Color.White,
             )
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -42,7 +42,9 @@ import com.thebluealliance.android.ui.common.LoadingBox
 import java.util.Locale
 
 enum class RankingSortColumn {
-    TEAM, PRIMARY, SECONDARY
+    TEAM,
+    PRIMARY,
+    SECONDARY,
 }
 
 internal data class RankingSortState(
@@ -52,7 +54,8 @@ internal data class RankingSortState(
 
 internal fun rankingHeaderLabels(rankingSortOrders: List<RankingSortOrder>?): Pair<String, String> {
     val primaryLabel = rankingSortOrders?.getOrNull(0)?.name?.takeIf { it.isNotBlank() } ?: "RS"
-    val secondaryLabel = rankingSortOrders?.getOrNull(1)?.name?.takeIf { it.isNotBlank() } ?: "Sort 2"
+    val secondaryLabel =
+        rankingSortOrders?.getOrNull(1)?.name?.takeIf { it.isNotBlank() } ?: "Sort 2"
     return primaryLabel to secondaryLabel
 }
 
@@ -63,36 +66,39 @@ internal fun nextRankingSortState(
     if (current.column == selectedColumn) {
         return current.copy(ascending = !current.ascending)
     }
-    val ascending = when (selectedColumn) {
-        RankingSortColumn.TEAM -> true
-        RankingSortColumn.PRIMARY, RankingSortColumn.SECONDARY -> false
-    }
+    val ascending =
+        when (selectedColumn) {
+            RankingSortColumn.TEAM -> true
+            RankingSortColumn.PRIMARY, RankingSortColumn.SECONDARY -> false
+        }
     return RankingSortState(column = selectedColumn, ascending = ascending)
 }
 
 internal fun sortRankings(
     rankings: List<Ranking>,
     sortState: RankingSortState,
-): List<Ranking> = rankings.sortedWith { a, b ->
-    val result = when (sortState.column) {
-        RankingSortColumn.TEAM -> {
-            val teamA = a.teamKey.removePrefix("frc").toIntOrNull() ?: 0
-            val teamB = b.teamKey.removePrefix("frc").toIntOrNull() ?: 0
-            teamA.compareTo(teamB)
-        }
-        RankingSortColumn.PRIMARY -> {
-            val valA = a.sortOrders.getOrNull(0) ?: 0.0
-            val valB = b.sortOrders.getOrNull(0) ?: 0.0
-            valA.compareTo(valB)
-        }
-        RankingSortColumn.SECONDARY -> {
-            val valA = a.sortOrders.getOrNull(1) ?: 0.0
-            val valB = b.sortOrders.getOrNull(1) ?: 0.0
-            valA.compareTo(valB)
-        }
+): List<Ranking> =
+    rankings.sortedWith { a, b ->
+        val result =
+            when (sortState.column) {
+                RankingSortColumn.TEAM -> {
+                    val teamA = a.teamKey.removePrefix("frc").toIntOrNull() ?: 0
+                    val teamB = b.teamKey.removePrefix("frc").toIntOrNull() ?: 0
+                    teamA.compareTo(teamB)
+                }
+                RankingSortColumn.PRIMARY -> {
+                    val valA = a.sortOrders.getOrNull(0) ?: 0.0
+                    val valB = b.sortOrders.getOrNull(0) ?: 0.0
+                    valA.compareTo(valB)
+                }
+                RankingSortColumn.SECONDARY -> {
+                    val valA = a.sortOrders.getOrNull(1) ?: 0.0
+                    val valB = b.sortOrders.getOrNull(1) ?: 0.0
+                    valA.compareTo(valB)
+                }
+            }
+        if (sortState.ascending) result else -result
     }
-    if (sortState.ascending) result else -result
-}
 
 @Composable
 fun EventRankingsTab(
@@ -104,7 +110,7 @@ fun EventRankingsTab(
 ) {
     if (rankings == null) {
         LoadingBox(
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
         )
         return
     }
@@ -120,9 +126,10 @@ fun EventRankingsTab(
 
     var sortState by remember { mutableStateOf(RankingSortState()) }
 
-    val sortedRankings = remember(rankings, sortState) {
-        sortRankings(rankings, sortState)
-    }
+    val sortedRankings =
+        remember(rankings, sortState) {
+            sortRankings(rankings, sortState)
+        }
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -157,10 +164,11 @@ private fun RankingHeaderRow(
     onSortSelected: (RankingSortColumn) -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(Color(0xFF5C6BC0))
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(Color(0xFF5C6BC0))
+                .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -213,11 +221,11 @@ private fun RankingHeaderItem(
     sortColumn: RankingSortColumn,
     currentSort: RankingSortColumn,
     ascending: Boolean,
-    onSortClick: () -> Unit
+    onSortClick: () -> Unit,
 ) {
     Row(
         modifier = modifier.clickable { onSortClick() },
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = text,
@@ -229,9 +237,11 @@ private fun RankingHeaderItem(
         )
         if (currentSort == sortColumn) {
             Icon(
-                imageVector = if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
-                contentDescription = if (ascending) "Sorted Ascending" else "Sorted Descending",
-                tint = Color.White
+                imageVector =
+                    if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
+                contentDescription =
+                    if (ascending) "Sorted Ascending" else "Sorted Descending",
+                tint = Color.White,
             )
         }
     }
@@ -247,17 +257,18 @@ private fun RankingItem(
     var expanded by remember { mutableStateOf(false) }
     val rotationAngle by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
-        label = "chevron_rotation"
+        label = "chevron_rotation",
     )
 
     Column(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth(),
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { expanded = !expanded }
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { expanded = !expanded }
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -269,9 +280,10 @@ private fun RankingItem(
             Text(
                 text = ranking.teamKey.removePrefix("frc"),
                 style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .weight(0.22f)
-                    .clickable { onTeamClick(ranking.teamKey) },
+                modifier =
+                    Modifier
+                        .weight(0.22f)
+                        .clickable { onTeamClick(ranking.teamKey) },
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.primary,
             )
@@ -282,10 +294,11 @@ private fun RankingItem(
             )
 
             // Show first two sort order values (without labels, header has them)
-            val primarySortValue = ranking.sortOrders.getOrNull(0)?.let { value ->
-                val precision = sortOrders?.getOrNull(0)?.precision ?: 2
-                String.format(Locale.US, "%.${precision}f", value)
-            } ?: "--"
+            val primarySortValue =
+                ranking.sortOrders.getOrNull(0)?.let { value ->
+                    val precision = sortOrders?.getOrNull(0)?.precision ?: 2
+                    String.format(Locale.US, "%.${precision}f", value)
+                } ?: "--"
 
             Text(
                 text = primarySortValue,
@@ -294,10 +307,11 @@ private fun RankingItem(
                 modifier = Modifier.weight(0.18f),
             )
 
-            val secondarySortValue = ranking.sortOrders.getOrNull(1)?.let { value ->
-                val precision = sortOrders?.getOrNull(1)?.precision ?: 2
-                String.format(Locale.US, "%.${precision}f", value)
-            } ?: "--"
+            val secondarySortValue =
+                ranking.sortOrders.getOrNull(1)?.let { value ->
+                    val precision = sortOrders?.getOrNull(1)?.precision ?: 2
+                    String.format(Locale.US, "%.${precision}f", value)
+                } ?: "--"
 
             Text(
                 text = secondarySortValue,
@@ -309,19 +323,21 @@ private fun RankingItem(
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,
                 contentDescription = if (expanded) "Collapse" else "Expand",
-                modifier = Modifier
-                    .rotate(rotationAngle)
-                    .weight(0.12f),
+                modifier =
+                    Modifier
+                        .rotate(rotationAngle)
+                        .weight(0.12f),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
 
         AnimatedVisibility(visible = expanded) {
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .padding(start = 8.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .padding(start = 8.dp),
             ) {
                 // Show all other sort orders (tiebreakers)
                 if (sortOrders != null && ranking.sortOrders.size > 2) {
@@ -335,12 +351,18 @@ private fun RankingItem(
                     for (i in 2 until minOf(ranking.sortOrders.size, sortOrders.size)) {
                         val sortOrder = sortOrders[i]
                         val value = ranking.sortOrders[i]
-                        val formattedValue = String.format(Locale.US, "%.${sortOrder.precision}f", value)
+                        val formattedValue =
+                            String.format(
+                                Locale.US,
+                                "%.${sortOrder.precision}f",
+                                value,
+                            )
 
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 2.dp),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 2.dp),
                         ) {
                             Text(
                                 text = sortOrder.name,
@@ -372,9 +394,10 @@ private fun RankingItem(
                         val statName = info?.name ?: "Stat ${index + 1}"
                         val precision = info?.precision ?: 2
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 2.dp),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 2.dp),
                         ) {
                             Text(
                                 text = statName,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventTeamsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventTeamsTab.kt
@@ -21,14 +21,14 @@ fun EventTeamsTab(
 ) {
     if (teams == null) {
         LoadingBox(
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
         )
         return
     }
     if (teams.isEmpty()) {
         EmptyBox(
             modifier = Modifier.padding(innerPadding),
-            message = "No teams"
+            message = "No teams",
         )
         return
     }
@@ -46,4 +46,3 @@ fun EventTeamsTab(
         }
     }
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -97,7 +97,8 @@ fun MatchDetailScreen(
                     }
                     uiState.match?.let { match ->
                         IconButton(onClick = {
-                            val eventLabel = uiState.eventName?.let { "${uiState.year} $it - " } ?: ""
+                            val eventLabel =
+                                uiState.eventName?.let { "${uiState.year} $it - " } ?: ""
                             context.shareTbaUrl(
                                 title = "$eventLabel${match.getFullLabel(uiState.playoffType)}",
                                 url = "https://www.thebluealliance.com/match/${match.key}",
@@ -116,13 +117,15 @@ fun MatchDetailScreen(
         PullToRefreshBox(
             isRefreshing = isRefreshing,
             onRefresh = viewModel::refresh,
-            modifier = Modifier.fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
         ) {
             val match = uiState.match
             if (match == null) {
                 LoadingBox(
-                    modifier = Modifier.padding(innerPadding)
+                    modifier = Modifier.padding(innerPadding),
                 )
             } else {
                 LazyColumn(
@@ -161,9 +164,10 @@ fun MatchDetailScreen(
                     }
 
                     // Media
-                    val mediaItems = uiState.videos
-                        .filter { mediaUrl(it.type, it.key) != null }
-                        .map { MediaGridItem(type = it.type, foreignKey = it.key) }
+                    val mediaItems =
+                        uiState.videos
+                            .filter { mediaUrl(it.type, it.key) != null }
+                            .map { MediaGridItem(type = it.type, foreignKey = it.key) }
                     if (mediaItems.isNotEmpty()) {
                         item(key = "media_header") {
                             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
@@ -197,17 +201,26 @@ fun MatchDetailScreen(
 
                         val redBreakdown = breakdown["red"] ?: emptyMap()
                         val blueBreakdown = breakdown["blue"] ?: emptyMap()
-                        val orderedFields = getOrderedBreakdownFields(
-                            year = uiState.year,
-                            redBreakdown = redBreakdown,
-                            blueBreakdown = blueBreakdown,
-                        )
+                        val orderedFields =
+                            getOrderedBreakdownFields(
+                                year = uiState.year,
+                                redBreakdown = redBreakdown,
+                                blueBreakdown = blueBreakdown,
+                            )
 
                         items(orderedFields, key = { "breakdown_${it.first}" }) { (apiKey, label) ->
                             BreakdownRow(
                                 label = label,
-                                redValue = formatBreakdownValue(apiKey, redBreakdown[apiKey] ?: "-"),
-                                blueValue = formatBreakdownValue(apiKey, blueBreakdown[apiKey] ?: "-"),
+                                redValue =
+                                    formatBreakdownValue(
+                                        apiKey,
+                                        redBreakdown[apiKey] ?: "-",
+                                    ),
+                                blueValue =
+                                    formatBreakdownValue(
+                                        apiKey,
+                                        blueBreakdown[apiKey] ?: "-",
+                                    ),
                             )
                         }
                     }
@@ -226,9 +239,10 @@ private fun EventInfo(
 ) {
     if (eventName == null && formattedTime == null) return
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
         if (eventName != null && eventKey != null) {
             Text(
@@ -250,11 +264,29 @@ private fun EventInfo(
 }
 
 @Composable
-private fun RowScope.AllianceScoreSummaryCol(match: Match, rpBonuses: AllianceRpBonuses?,
-                                             advancementMsgs: MatchAdvancementMsgs?, alliance: String) {
-    val mainColor = if (alliance == "red") MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+private fun RowScope.AllianceScoreSummaryCol(
+    match: Match,
+    rpBonuses: AllianceRpBonuses?,
+    advancementMsgs: MatchAdvancementMsgs?,
+    alliance: String,
+) {
+    val mainColor =
+        if (alliance ==
+            "red"
+        ) {
+            MaterialTheme.colorScheme.error
+        } else {
+            MaterialTheme.colorScheme.primary
+        }
     val score = if (alliance == "red") match.redScore else match.blueScore
-    val playoffAlliance = if (alliance == "red") match.redPlayoffAlliance else match.bluePlayoffAlliance
+    val playoffAlliance =
+        if (alliance ==
+            "red"
+        ) {
+            match.redPlayoffAlliance
+        } else {
+            match.bluePlayoffAlliance
+        }
     val rpBonus = if (alliance == "red") rpBonuses?.red else rpBonuses?.blue
     val advancementMsg = if (alliance == "red") advancementMsgs?.red else advancementMsgs?.blue
 
@@ -265,12 +297,19 @@ private fun RowScope.AllianceScoreSummaryCol(match: Match, rpBonuses: AllianceRp
         Text(
             text = playoffAlliance?.displayTitle ?: alliance.replaceFirstChar { it.titlecase() },
             style = MaterialTheme.typography.titleSmall,
-            color = mainColor
+            color = mainColor,
         )
         Text(
             text = if (score < 0) "—" else score.toString(),
             style = MaterialTheme.typography.displaySmall,
-            fontWeight = if (match.winningAlliance == alliance) FontWeight.Bold else FontWeight.Normal,
+            fontWeight =
+                if (match.winningAlliance ==
+                    alliance
+                ) {
+                    FontWeight.Bold
+                } else {
+                    FontWeight.Normal
+                },
             color = mainColor,
         )
         rpBonus?.let {
@@ -278,22 +317,31 @@ private fun RowScope.AllianceScoreSummaryCol(match: Match, rpBonuses: AllianceRp
         }
         advancementMsg?.let {
             Box(
-                modifier = Modifier
-                    .heightIn(min = 36.dp)  // Reserve consistent space
-                    .padding(horizontal = 4.dp),
-                contentAlignment = Alignment.Center
+                modifier =
+                    Modifier
+                        .heightIn(min = 36.dp) // Reserve consistent space
+                        .padding(horizontal = 4.dp),
+                contentAlignment = Alignment.Center,
             ) {
                 Text(
                     text = it,
                     style = MaterialTheme.typography.labelSmall,
-                    fontWeight = if (match.winningAlliance == alliance) FontWeight.Bold else FontWeight.Normal,
+                    fontWeight =
+                        if (match.winningAlliance ==
+                            alliance
+                        ) {
+                            FontWeight.Bold
+                        } else {
+                            FontWeight.Normal
+                        },
                     color = MaterialTheme.colorScheme.secondary,
                     textAlign = TextAlign.Center,
                     maxLines = 2,
-                    lineHeight = 14.sp,  // Tighter line spacing
-                    modifier = Modifier
-                        .padding(horizontal = 4.dp)
-                        .padding(top = 4.dp)
+                    lineHeight = 14.sp, // Tighter line spacing
+                    modifier =
+                        Modifier
+                            .padding(horizontal = 4.dp)
+                            .padding(top = 4.dp),
                 )
             }
         }
@@ -301,16 +349,24 @@ private fun RowScope.AllianceScoreSummaryCol(match: Match, rpBonuses: AllianceRp
 }
 
 @Composable
-private fun ScoreSummary(match: Match, playoffType: PlayoffType) {
+private fun ScoreSummary(
+    match: Match,
+    playoffType: PlayoffType,
+) {
     val rpBonuses = remember(match.scoreBreakdown) { match.rpBonuses() }
-    val advancementMsgs = remember(
-        match.winningAlliance, match.compLevel, match.setNumber, playoffType
-    ) { match.getAdvancement(playoffType) }
+    val advancementMsgs =
+        remember(
+            match.winningAlliance,
+            match.compLevel,
+            match.setNumber,
+            playoffType,
+        ) { match.getAdvancement(playoffType) }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AllianceScoreSummaryCol(match, rpBonuses, advancementMsgs, "red")
@@ -330,9 +386,10 @@ private fun AllianceTeams(
     onTeamClick: (String) -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
         Column(
             modifier = Modifier.weight(1f),
@@ -343,9 +400,10 @@ private fun AllianceTeams(
                     text = key.removePrefix("frc"),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier
-                        .clickable { onTeamClick(key) }
-                        .padding(top = 2.dp),
+                    modifier =
+                        Modifier
+                            .clickable { onTeamClick(key) }
+                            .padding(top = 2.dp),
                 )
             }
         }
@@ -367,9 +425,10 @@ private fun AllianceTeams(
                     text = key.removePrefix("frc"),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .clickable { onTeamClick(key) }
-                        .padding(top = 2.dp),
+                    modifier =
+                        Modifier
+                            .clickable { onTeamClick(key) }
+                            .padding(top = 2.dp),
                 )
             }
         }
@@ -377,11 +436,16 @@ private fun AllianceTeams(
 }
 
 @Composable
-private fun BreakdownRow(label: String, redValue: String, blueValue: String) {
+private fun BreakdownRow(
+    label: String,
+    redValue: String,
+    blueValue: String,
+) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 2.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 2.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -408,7 +472,10 @@ private fun BreakdownRow(label: String, redValue: String, blueValue: String) {
 }
 
 @Composable
-private fun RpDots(bonuses: List<Boolean>, achievedColor: Color) {
+private fun RpDots(
+    bonuses: List<Boolean>,
+    achievedColor: Color,
+) {
     Row(
         modifier = Modifier.padding(top = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -433,13 +500,12 @@ private fun RpDots(bonuses: List<Boolean>, achievedColor: Color) {
     }
 }
 
-
-private fun camelCaseToLabel(key: String): String {
-    return key.replace(Regex("([A-Z])"), " $1")
+private fun camelCaseToLabel(key: String): String =
+    key
+        .replace(Regex("([A-Z])"), " $1")
         .replace("_", " ")
         .trim()
         .replaceFirstChar { it.uppercase() }
-}
 
 private fun getOrderedBreakdownFields(
     year: Int,
@@ -449,8 +515,10 @@ private fun getOrderedBreakdownFields(
     val yearFields = breakdownFieldsByYear[year]
     if (yearFields == null) {
         // Fallback: show all keys with camelCase-to-label conversion
-        val allKeys = (redBreakdown.keys + blueBreakdown.keys).distinct()
-            .filter { it != "totalPoints" }
+        val allKeys =
+            (redBreakdown.keys + blueBreakdown.keys)
+                .distinct()
+                .filter { it != "totalPoints" }
         return allKeys.map { it to camelCaseToLabel(it) }
     }
 
@@ -467,121 +535,126 @@ private fun getOrderedBreakdownFields(
     return result
 }
 
-private val breakdownFields2026 = listOf(
-    "autoTowerRobot1" to "Auto tower 1",
-    "autoTowerRobot2" to "Auto tower 2",
-    "autoTowerRobot3" to "Auto tower 3",
-    "autoTowerPoints" to "Auto tower",
-    "totalAutoPoints" to "Total auto",
-    "totalTeleopPoints" to "Total teleop",
-    "endGameTowerRobot1" to "Endgame 1",
-    "endGameTowerRobot2" to "Endgame 2",
-    "endGameTowerRobot3" to "Endgame 3",
-    "endGameTowerPoints" to "Endgame tower",
-    "totalTowerPoints" to "Total tower",
-    "energizedAchieved" to "Energized bonus",
-    "superchargedAchieved" to "Supercharged bonus",
-    "traversalAchieved" to "Traversal bonus",
-    "minorFoulCount" to "Minor fouls",
-    "majorFoulCount" to "Major fouls",
-    "g206Penalty" to "G206 penalty",
-    "foulPoints" to "Foul points",
-    "adjustPoints" to "Adjust",
-    "totalPoints" to "Total",
-    "rp" to "RP",
-)
+private val breakdownFields2026 =
+    listOf(
+        "autoTowerRobot1" to "Auto tower 1",
+        "autoTowerRobot2" to "Auto tower 2",
+        "autoTowerRobot3" to "Auto tower 3",
+        "autoTowerPoints" to "Auto tower",
+        "totalAutoPoints" to "Total auto",
+        "totalTeleopPoints" to "Total teleop",
+        "endGameTowerRobot1" to "Endgame 1",
+        "endGameTowerRobot2" to "Endgame 2",
+        "endGameTowerRobot3" to "Endgame 3",
+        "endGameTowerPoints" to "Endgame tower",
+        "totalTowerPoints" to "Total tower",
+        "energizedAchieved" to "Energized bonus",
+        "superchargedAchieved" to "Supercharged bonus",
+        "traversalAchieved" to "Traversal bonus",
+        "minorFoulCount" to "Minor fouls",
+        "majorFoulCount" to "Major fouls",
+        "g206Penalty" to "G206 penalty",
+        "foulPoints" to "Foul points",
+        "adjustPoints" to "Adjust",
+        "totalPoints" to "Total",
+        "rp" to "RP",
+    )
 
-private val breakdownFields2025 = listOf(
-    "autoLineRobot1" to "Auto leave 1",
-    "autoLineRobot2" to "Auto leave 2",
-    "autoLineRobot3" to "Auto leave 3",
-    "autoMobilityPoints" to "Auto mobility",
-    "autoCoralPoints" to "Auto coral",
-    "autoPoints" to "Total auto",
-    "teleopCoralPoints" to "Teleop coral",
-    "wallAlgaeCount" to "Processor algae",
-    "netAlgaeCount" to "Net algae",
-    "algaePoints" to "Algae points",
-    "endGameRobot1" to "Endgame 1",
-    "endGameRobot2" to "Endgame 2",
-    "endGameRobot3" to "Endgame 3",
-    "endGameBargePoints" to "Barge points",
-    "teleopPoints" to "Total teleop",
-    "coopertitionCriteriaMet" to "Coopertition",
-    "autoBonusAchieved" to "Auto bonus",
-    "coralBonusAchieved" to "Coral bonus",
-    "bargeBonusAchieved" to "Barge bonus",
-    "foulCount" to "Fouls",
-    "techFoulCount" to "Tech fouls",
-    "foulPoints" to "Foul points",
-    "adjustPoints" to "Adjust",
-    "totalPoints" to "Total",
-    "rp" to "RP",
-)
+private val breakdownFields2025 =
+    listOf(
+        "autoLineRobot1" to "Auto leave 1",
+        "autoLineRobot2" to "Auto leave 2",
+        "autoLineRobot3" to "Auto leave 3",
+        "autoMobilityPoints" to "Auto mobility",
+        "autoCoralPoints" to "Auto coral",
+        "autoPoints" to "Total auto",
+        "teleopCoralPoints" to "Teleop coral",
+        "wallAlgaeCount" to "Processor algae",
+        "netAlgaeCount" to "Net algae",
+        "algaePoints" to "Algae points",
+        "endGameRobot1" to "Endgame 1",
+        "endGameRobot2" to "Endgame 2",
+        "endGameRobot3" to "Endgame 3",
+        "endGameBargePoints" to "Barge points",
+        "teleopPoints" to "Total teleop",
+        "coopertitionCriteriaMet" to "Coopertition",
+        "autoBonusAchieved" to "Auto bonus",
+        "coralBonusAchieved" to "Coral bonus",
+        "bargeBonusAchieved" to "Barge bonus",
+        "foulCount" to "Fouls",
+        "techFoulCount" to "Tech fouls",
+        "foulPoints" to "Foul points",
+        "adjustPoints" to "Adjust",
+        "totalPoints" to "Total",
+        "rp" to "RP",
+    )
 
-private val breakdownFields2024 = listOf(
-    "autoLineRobot1" to "Auto leave 1",
-    "autoLineRobot2" to "Auto leave 2",
-    "autoLineRobot3" to "Auto leave 3",
-    "autoLeavePoints" to "Auto leave points",
-    "autoAmpNoteCount" to "Auto amp notes",
-    "autoSpeakerNoteCount" to "Auto speaker notes",
-    "autoTotalNotePoints" to "Auto note points",
-    "autoPoints" to "Total auto",
-    "teleopAmpNoteCount" to "Teleop amp notes",
-    "teleopSpeakerNoteCount" to "Teleop speaker notes",
-    "teleopSpeakerNoteAmplifiedCount" to "Amplified speaker",
-    "teleopTotalNotePoints" to "Teleop note points",
-    "endGameRobot1" to "Endgame 1",
-    "endGameRobot2" to "Endgame 2",
-    "endGameRobot3" to "Endgame 3",
-    "endGameHarmonyPoints" to "Harmony",
-    "endGameNoteInTrapPoints" to "Trap",
-    "endGameOnStagePoints" to "On stage",
-    "endGameParkPoints" to "Park",
-    "teleopPoints" to "Total teleop",
-    "coopertitionBonusAchieved" to "Coopertition",
-    "melodyBonusAchieved" to "Melody bonus",
-    "ensembleBonusAchieved" to "Ensemble bonus",
-    "foulCount" to "Fouls",
-    "techFoulCount" to "Tech fouls",
-    "foulPoints" to "Foul points",
-    "adjustPoints" to "Adjust",
-    "totalPoints" to "Total",
-    "rp" to "RP",
-)
+private val breakdownFields2024 =
+    listOf(
+        "autoLineRobot1" to "Auto leave 1",
+        "autoLineRobot2" to "Auto leave 2",
+        "autoLineRobot3" to "Auto leave 3",
+        "autoLeavePoints" to "Auto leave points",
+        "autoAmpNoteCount" to "Auto amp notes",
+        "autoSpeakerNoteCount" to "Auto speaker notes",
+        "autoTotalNotePoints" to "Auto note points",
+        "autoPoints" to "Total auto",
+        "teleopAmpNoteCount" to "Teleop amp notes",
+        "teleopSpeakerNoteCount" to "Teleop speaker notes",
+        "teleopSpeakerNoteAmplifiedCount" to "Amplified speaker",
+        "teleopTotalNotePoints" to "Teleop note points",
+        "endGameRobot1" to "Endgame 1",
+        "endGameRobot2" to "Endgame 2",
+        "endGameRobot3" to "Endgame 3",
+        "endGameHarmonyPoints" to "Harmony",
+        "endGameNoteInTrapPoints" to "Trap",
+        "endGameOnStagePoints" to "On stage",
+        "endGameParkPoints" to "Park",
+        "teleopPoints" to "Total teleop",
+        "coopertitionBonusAchieved" to "Coopertition",
+        "melodyBonusAchieved" to "Melody bonus",
+        "ensembleBonusAchieved" to "Ensemble bonus",
+        "foulCount" to "Fouls",
+        "techFoulCount" to "Tech fouls",
+        "foulPoints" to "Foul points",
+        "adjustPoints" to "Adjust",
+        "totalPoints" to "Total",
+        "rp" to "RP",
+    )
 
-private val breakdownFields2023 = listOf(
-    "autoLineRobot1" to "Auto line 1",
-    "autoLineRobot2" to "Auto line 2",
-    "autoLineRobot3" to "Auto line 3",
-    "autoMobilityPoints" to "Auto mobility",
-    "autoGamePieceCount" to "Auto game pieces",
-    "autoGamePiecePoints" to "Auto game piece points",
-    "autoChargeStationPoints" to "Auto charge station",
-    "autoPoints" to "Total auto",
-    "teleopGamePieceCount" to "Teleop game pieces",
-    "teleopGamePiecePoints" to "Teleop game piece points",
-    "endGameRobot1" to "Endgame 1",
-    "endGameRobot2" to "Endgame 2",
-    "endGameRobot3" to "Endgame 3",
-    "endGameChargeStationPoints" to "Endgame charge station",
-    "endGameParkPoints" to "Endgame park",
-    "teleopPoints" to "Total teleop",
-    "activationBonusAchieved" to "Activation bonus",
-    "sustainabilityBonusAchieved" to "Sustainability bonus",
-    "coopertitionCriteriaMet" to "Coopertition",
-    "foulCount" to "Fouls",
-    "techFoulCount" to "Tech fouls",
-    "foulPoints" to "Foul points",
-    "adjustPoints" to "Adjust",
-    "totalPoints" to "Total",
-    "rp" to "RP",
-)
+private val breakdownFields2023 =
+    listOf(
+        "autoLineRobot1" to "Auto line 1",
+        "autoLineRobot2" to "Auto line 2",
+        "autoLineRobot3" to "Auto line 3",
+        "autoMobilityPoints" to "Auto mobility",
+        "autoGamePieceCount" to "Auto game pieces",
+        "autoGamePiecePoints" to "Auto game piece points",
+        "autoChargeStationPoints" to "Auto charge station",
+        "autoPoints" to "Total auto",
+        "teleopGamePieceCount" to "Teleop game pieces",
+        "teleopGamePiecePoints" to "Teleop game piece points",
+        "endGameRobot1" to "Endgame 1",
+        "endGameRobot2" to "Endgame 2",
+        "endGameRobot3" to "Endgame 3",
+        "endGameChargeStationPoints" to "Endgame charge station",
+        "endGameParkPoints" to "Endgame park",
+        "teleopPoints" to "Total teleop",
+        "activationBonusAchieved" to "Activation bonus",
+        "sustainabilityBonusAchieved" to "Sustainability bonus",
+        "coopertitionCriteriaMet" to "Coopertition",
+        "foulCount" to "Fouls",
+        "techFoulCount" to "Tech fouls",
+        "foulPoints" to "Foul points",
+        "adjustPoints" to "Adjust",
+        "totalPoints" to "Total",
+        "rp" to "RP",
+    )
 
-private val breakdownFieldsByYear = mapOf(
-    2026 to breakdownFields2026,
-    2025 to breakdownFields2025,
-    2024 to breakdownFields2024,
-    2023 to breakdownFields2023,
-)
+private val breakdownFieldsByYear =
+    mapOf(
+        2026 to breakdownFields2026,
+        2025 to breakdownFields2025,
+        2024 to breakdownFields2024,
+        2023 to breakdownFields2023,
+    )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailViewModel.kt
@@ -30,113 +30,122 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @HiltViewModel(assistedFactory = MatchDetailViewModel.Factory::class)
-class MatchDetailViewModel @AssistedInject constructor(
-    @Assisted val navKey: Screen.MatchDetail,
-    private val matchRepository: MatchRepository,
-    private val eventRepository: EventRepository,
-) : ViewModel() {
+class MatchDetailViewModel
+    @AssistedInject
+    constructor(
+        @Assisted val navKey: Screen.MatchDetail,
+        private val matchRepository: MatchRepository,
+        private val eventRepository: EventRepository,
+    ) : ViewModel() {
+        private val matchKey: String = navKey.matchKey
+        private val eventKey: String = matchKey.substringBeforeLast("_")
+        private val year: Int = matchKey.substring(0, 4).toIntOrNull() ?: 0
 
-    private val matchKey: String = navKey.matchKey
-    private val eventKey: String = matchKey.substringBeforeLast("_")
-    private val year: Int = matchKey.substring(0, 4).toIntOrNull() ?: 0
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+        private val json = Json { ignoreUnknownKeys = true }
 
-    private val json = Json { ignoreUnknownKeys = true }
+        private val timeFormatter =
+            DateTimeFormatter.ofPattern(
+                "EEE, MMM d, yyyy 'at' h:mm a",
+                Locale.US,
+            )
 
-    private val timeFormatter = DateTimeFormatter.ofPattern(
-        "EEE, MMM d, yyyy 'at' h:mm a", Locale.US
-    )
+        val uiState: StateFlow<MatchDetailUiState> =
+            combine(
+                matchRepository.observeMatch(matchKey),
+                eventRepository.observeEvent(eventKey),
+                eventRepository.observeEventAlliances(eventKey),
+            ) { match, event, alliances ->
+                val breakdown = match?.scoreBreakdown?.let { parseBreakdown(it) }
+                val videos = match?.videos?.let { parseVideos(it) } ?: emptyList()
+                val timeToDisplay = match?.actualTime ?: match?.predictedTime ?: match?.time
+                val isEstimate =
+                    match?.actualTime == null &&
+                        match?.predictedTime != null &&
+                        match.time != null &&
+                        kotlin.math.abs(match.predictedTime - match.time) > 60
+                val formattedTime =
+                    formatMatchTime(timeToDisplay)?.let {
+                        if (isEstimate) "$it (est.)" else it
+                    }
+                MatchDetailUiState(
+                    match = match?.withPlayoffAlliances(alliances),
+                    scoreBreakdown = breakdown,
+                    eventName = event?.name,
+                    eventKey = event?.key,
+                    playoffType = event?.playoffType ?: PlayoffType.OTHER,
+                    formattedTime = formattedTime,
+                    videos = videos,
+                    year = year,
+                )
+            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), MatchDetailUiState())
 
-    val uiState: StateFlow<MatchDetailUiState> = combine(
-        matchRepository.observeMatch(matchKey),
-        eventRepository.observeEvent(eventKey),
-        eventRepository.observeEventAlliances(eventKey),
-    ) { match, event, alliances ->
-        val breakdown = match?.scoreBreakdown?.let { parseBreakdown(it) }
-        val videos = match?.videos?.let { parseVideos(it) } ?: emptyList()
-        val timeToDisplay = match?.actualTime ?: match?.predictedTime ?: match?.time
-        val isEstimate = match?.actualTime == null && match?.predictedTime != null &&
-            match.time != null && kotlin.math.abs(match.predictedTime - match.time) > 60
-        val formattedTime = formatMatchTime(timeToDisplay)?.let {
-            if (isEstimate) "$it (est.)" else it
+        init {
+            refresh()
+            viewModelScope.launch {
+                // Fetch event only if not already cached (e.g. deep-linked to match)
+                val cached = eventRepository.observeEvent(eventKey).first()
+                if (cached == null) {
+                    try {
+                        eventRepository.refreshEvent(eventKey)
+                    } catch (_: Exception) {
+                    }
+                }
+            }
         }
-        MatchDetailUiState(
-            match = match?.withPlayoffAlliances(alliances),
-            scoreBreakdown = breakdown,
-            eventName = event?.name,
-            eventKey = event?.key,
-            playoffType = event?.playoffType ?: PlayoffType.OTHER,
-            formattedTime = formattedTime,
-            videos = videos,
-            year = year,
-        )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), MatchDetailUiState())
 
-    init {
-        refresh()
-        viewModelScope.launch {
-            // Fetch event only if not already cached (e.g. deep-linked to match)
-            val cached = eventRepository.observeEvent(eventKey).first()
-            if (cached == null) {
+        fun refresh() {
+            viewModelScope.launch {
+                _isRefreshing.value = true
                 try {
-                    eventRepository.refreshEvent(eventKey)
-                } catch (_: Exception) {}
+                    matchRepository.refreshMatch(matchKey)
+                } catch (_: Exception) {
+                } finally {
+                    _isRefreshing.value = false
+                }
             }
         }
-    }
 
-    fun refresh() {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                matchRepository.refreshMatch(matchKey)
+        private fun formatMatchTime(epochSeconds: Long?): String? {
+            if (epochSeconds == null) return null
+            val instant = Instant.ofEpochSecond(epochSeconds)
+            return timeFormatter.format(instant.atZone(ZoneId.systemDefault()))
+        }
+
+        private fun parseVideos(jsonString: String): List<MatchVideo> {
+            return try {
+                val array = json.decodeFromString<JsonArray>(jsonString)
+                array.mapNotNull { element ->
+                    val obj = element as? JsonObject ?: return@mapNotNull null
+                    val type = obj["type"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                    val key = obj["key"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                    MatchVideo(type = type, key = key)
+                }
             } catch (_: Exception) {
-            } finally {
-                _isRefreshing.value = false
+                emptyList()
             }
         }
-    }
 
-    private fun formatMatchTime(epochSeconds: Long?): String? {
-        if (epochSeconds == null) return null
-        val instant = Instant.ofEpochSecond(epochSeconds)
-        return timeFormatter.format(instant.atZone(ZoneId.systemDefault()))
-    }
-
-    private fun parseVideos(jsonString: String): List<MatchVideo> {
-        return try {
-            val array = json.decodeFromString<JsonArray>(jsonString)
-            array.mapNotNull { element ->
-                val obj = element as? JsonObject ?: return@mapNotNull null
-                val type = obj["type"]?.jsonPrimitive?.content ?: return@mapNotNull null
-                val key = obj["key"]?.jsonPrimitive?.content ?: return@mapNotNull null
-                MatchVideo(type = type, key = key)
+        private fun parseBreakdown(jsonString: String): Map<String, Map<String, String>>? =
+            try {
+                val obj = json.decodeFromString<JsonObject>(jsonString)
+                val result = mutableMapOf<String, Map<String, String>>()
+                for (alliance in listOf("red", "blue")) {
+                    val allianceObj = obj[alliance] as? JsonObject ?: continue
+                    result[alliance] =
+                        allianceObj.entries
+                            .filter { (_, v) -> v is JsonPrimitive }
+                            .associate { (k, v) -> k to v.jsonPrimitive.content }
+                }
+                result.ifEmpty { null }
+            } catch (_: Exception) {
+                null
             }
-        } catch (_: Exception) {
-            emptyList()
+
+        @AssistedFactory
+        interface Factory {
+            fun create(navKey: Screen.MatchDetail): MatchDetailViewModel
         }
     }
-
-    private fun parseBreakdown(jsonString: String): Map<String, Map<String, String>>? {
-        return try {
-            val obj = json.decodeFromString<JsonObject>(jsonString)
-            val result = mutableMapOf<String, Map<String, String>>()
-            for (alliance in listOf("red", "blue")) {
-                val allianceObj = obj[alliance] as? JsonObject ?: continue
-                result[alliance] = allianceObj.entries
-                    .filter { (_, v) -> v is JsonPrimitive }
-                    .associate { (k, v) -> k to v.jsonPrimitive.content }
-            }
-            result.ifEmpty { null }
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(navKey: Screen.MatchDetail): MatchDetailViewModel
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/AboutScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/AboutScreen.kt
@@ -2,24 +2,24 @@ package com.thebluealliance.android.ui.more
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import com.thebluealliance.android.ui.components.TBATopAppBar
 
 @Composable
@@ -47,10 +47,11 @@ fun AboutScreen(
         },
     ) { innerPadding ->
         Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
         ) {
             LibrariesContainer(modifier = Modifier.fillMaxSize())
         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
@@ -5,18 +5,20 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -30,8 +32,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.BuildConfig
 import com.thebluealliance.android.ui.components.TBATopAppBar
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.ExperimentalMaterial3Api
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -58,16 +58,25 @@ fun MoreScreen(
         },
     ) { innerPadding ->
         Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
         ) {
             MoreItem(icon = Icons.Filled.Star, label = "myTBA", onClick = onNavigateToMyTBA)
             HorizontalDivider()
-            MoreItem(icon = Icons.Filled.EmojiEvents, label = "Regional Advancement", onClick = onNavigateToRegionalAdvancement)
+            MoreItem(
+                icon = Icons.Filled.EmojiEvents,
+                label = "Regional Advancement",
+                onClick = onNavigateToRegionalAdvancement,
+            )
             HorizontalDivider()
-            MoreItem(icon = Icons.Filled.Settings, label = "Settings", onClick = onNavigateToSettings)
+            MoreItem(
+                icon = Icons.Filled.Settings,
+                label = "Settings",
+                onClick = onNavigateToSettings,
+            )
             HorizontalDivider()
 
             Spacer(modifier = Modifier.weight(1f))
@@ -93,7 +102,9 @@ fun MoreScreen(
             }
 
             Text(
-                text = "v${BuildConfig.VERSION_NAME} (${BuildConfig.GIT_HASH})\nBuilt ${BuildConfig.BUILD_TIME}",
+                text =
+                    "v${BuildConfig.VERSION_NAME} (${BuildConfig.GIT_HASH})\n" +
+                        "Built ${BuildConfig.BUILD_TIME}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 4.dp),
@@ -103,12 +114,17 @@ fun MoreScreen(
 }
 
 @Composable
-private fun MoreItem(icon: ImageVector, label: String, onClick: () -> Unit) {
+private fun MoreItem(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(icon, contentDescription = null)

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/ThanksScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/ThanksScreen.kt
@@ -7,25 +7,29 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -37,11 +41,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil3.compose.AsyncImage
 import com.thebluealliance.android.data.remote.dto.GitHubContributorDto
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.util.openUrl
 
@@ -75,9 +74,10 @@ fun ThanksScreen(
         when (val state = uiState) {
             is ThanksUiState.Loading -> {
                 Box(
-                    modifier = Modifier
-                        .padding(innerPadding)
-                        .fillMaxSize(),
+                    modifier =
+                        Modifier
+                            .padding(innerPadding)
+                            .fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator()
@@ -85,11 +85,12 @@ fun ThanksScreen(
             }
             is ThanksUiState.Error -> {
                 Column(
-                    modifier = Modifier
-                        .padding(innerPadding)
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.background)
-                        .padding(16.dp),
+                    modifier =
+                        Modifier
+                            .padding(innerPadding)
+                            .fillMaxSize()
+                            .background(MaterialTheme.colorScheme.background)
+                            .padding(16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center,
                 ) {
@@ -106,9 +107,10 @@ fun ThanksScreen(
             }
             is ThanksUiState.Success -> {
                 LazyColumn(
-                    modifier = Modifier
-                        .padding(innerPadding)
-                        .fillMaxSize()
+                    modifier =
+                        Modifier
+                            .padding(innerPadding)
+                            .fillMaxSize(),
                 ) {
                     items(state.contributors) { contributor ->
                         ContributorRow(contributor)
@@ -123,12 +125,12 @@ fun ThanksScreen(
 private fun ContributorRow(contributor: GitHubContributorDto) {
     val context = LocalContext.current
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable {
-                context.openUrl(contributor.htmlUrl)
-            }
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable {
+                    context.openUrl(contributor.htmlUrl)
+                }.padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/ThanksViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/ThanksViewModel.kt
@@ -11,39 +11,47 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class ThanksViewModel @Inject constructor(
-    private val gitHubApi: GitHubApi,
-) : ViewModel() {
+class ThanksViewModel
+    @Inject
+    constructor(
+        private val gitHubApi: GitHubApi,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<ThanksUiState>(ThanksUiState.Loading)
+        val uiState: StateFlow<ThanksUiState> = _uiState
 
-    private val _uiState = MutableStateFlow<ThanksUiState>(ThanksUiState.Loading)
-    val uiState: StateFlow<ThanksUiState> = _uiState
+        init {
+            loadContributors()
+        }
 
-    init {
-        loadContributors()
-    }
+        fun retry() {
+            loadContributors()
+        }
 
-    fun retry() {
-        loadContributors()
-    }
-
-    private fun loadContributors() {
-        _uiState.value = ThanksUiState.Loading
-        viewModelScope.launch {
-            try {
-                val contributors = gitHubApi.getContributors(
-                    owner = "the-blue-alliance",
-                    repo = "the-blue-alliance-android",
-                )
-                _uiState.value = ThanksUiState.Success(contributors)
-            } catch (e: Exception) {
-                _uiState.value = ThanksUiState.Error(e.message ?: "Failed to load contributors")
+        private fun loadContributors() {
+            _uiState.value = ThanksUiState.Loading
+            viewModelScope.launch {
+                try {
+                    val contributors =
+                        gitHubApi.getContributors(
+                            owner = "the-blue-alliance",
+                            repo = "the-blue-alliance-android",
+                        )
+                    _uiState.value = ThanksUiState.Success(contributors)
+                } catch (e: Exception) {
+                    _uiState.value = ThanksUiState.Error(e.message ?: "Failed to load contributors")
+                }
             }
         }
     }
-}
 
 sealed interface ThanksUiState {
     data object Loading : ThanksUiState
-    data class Success(val contributors: List<GitHubContributorDto>) : ThanksUiState
-    data class Error(val message: String) : ThanksUiState
+
+    data class Success(
+        val contributors: List<GitHubContributorDto>,
+    ) : ThanksUiState
+
+    data class Error(
+        val message: String,
+    ) : ThanksUiState
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -7,13 +7,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -24,8 +24,10 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
@@ -64,14 +66,9 @@ import com.thebluealliance.android.R
 import com.thebluealliance.android.domain.model.Favorite
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.domain.model.Subscription
-import kotlinx.coroutines.launch
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.runtime.DisposableEffect
 import com.thebluealliance.android.ui.components.TBATopAppBar
-import com.thebluealliance.android.ui.theme.TBABlue
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 
 private val TABS = listOf("Favorites", "Notifications")
 
@@ -155,10 +152,11 @@ fun MyTBAScreen(
     ) { innerPadding ->
         if (!uiState.isSignedIn) {
             Box(
-                modifier = Modifier
-                    .padding(innerPadding)
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background),
+                modifier =
+                    Modifier
+                        .padding(innerPadding)
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background),
             ) {
                 SignInPrompt(onSignIn = onSignIn)
             }
@@ -166,25 +164,28 @@ fun MyTBAScreen(
         }
 
         Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
         ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 val personIcon = rememberVectorPainter(Icons.Default.Person)
                 AsyncImage(
                     model = uiState.userPhotoUrl,
                     contentDescription = "Profile photo",
-                    modifier = Modifier
-                        .size(40.dp)
-                        .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    modifier =
+                        Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
                     placeholder = personIcon,
                     error = personIcon,
                     fallback = personIcon,
@@ -237,14 +238,20 @@ fun MyTBAScreen(
                     TabRowDefaults.SecondaryIndicator(
                         modifier = Modifier.tabIndicatorOffset(pagerState.currentPage),
                         height = 3.dp,
-                        color = Color.White
+                        color = Color.White,
                     )
-                }
+                },
             ) {
                 TABS.forEachIndexed { index, title ->
                     Tab(
                         selected = pagerState.currentPage == index,
-                        onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(
+                                    index,
+                                )
+                            }
+                        },
                         text = {
                             Text(
                                 text = title,
@@ -266,21 +273,23 @@ fun MyTBAScreen(
                     modifier = Modifier.fillMaxSize(),
                 ) {
                     when (page) {
-                        MyTBATabs.FAVORITES -> FavoritesTab(
-                            favorites = uiState.favorites,
-                            onNavigateToTeam = onNavigateToTeam,
-                            onNavigateToEvent = onNavigateToEvent,
-                            listState = favoritesListState,
-                            canPinShortcuts = uiState.canPinShortcuts,
-                            onAddShortcut = viewModel::requestPinShortcut,
-                        )
+                        MyTBATabs.FAVORITES ->
+                            FavoritesTab(
+                                favorites = uiState.favorites,
+                                onNavigateToTeam = onNavigateToTeam,
+                                onNavigateToEvent = onNavigateToEvent,
+                                listState = favoritesListState,
+                                canPinShortcuts = uiState.canPinShortcuts,
+                                onAddShortcut = viewModel::requestPinShortcut,
+                            )
 
-                        MyTBATabs.NOTIFICATIONS -> NotificationsTab(
-                            uiState.subscriptions,
-                            onNavigateToTeam,
-                            onNavigateToEvent,
-                            notificationsListState
-                        )
+                        MyTBATabs.NOTIFICATIONS ->
+                            NotificationsTab(
+                                uiState.subscriptions,
+                                onNavigateToTeam,
+                                onNavigateToEvent,
+                                notificationsListState,
+                            )
                     }
                 }
             }
@@ -353,24 +362,26 @@ private fun FavoriteItem(
     showMenu: Boolean,
     onAddShortcut: () -> Unit,
 ) {
-    val typeLabel = when (favorite.modelType) {
-        ModelType.EVENT -> "Event"
-        ModelType.TEAM -> "Team"
-        ModelType.MATCH -> "Match"
-        else -> "Other"
-    }
+    val typeLabel =
+        when (favorite.modelType) {
+            ModelType.EVENT -> "Event"
+            ModelType.TEAM -> "Team"
+            ModelType.MATCH -> "Match"
+            else -> "Other"
+        }
     var menuExpanded by remember { mutableStateOf(false) }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(
-                start = 16.dp,
-                top = if (showMenu) 8.dp else 12.dp,
-                bottom = if (showMenu) 8.dp else 12.dp,
-                end = if (showMenu) 4.dp else 16.dp,
-            ),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(
+                    start = 16.dp,
+                    top = if (showMenu) 8.dp else 12.dp,
+                    bottom = if (showMenu) 8.dp else 12.dp,
+                    end = if (showMenu) 4.dp else 16.dp,
+                ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(
@@ -433,22 +444,23 @@ private fun NotificationsTab(
     }
     LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
         items(subscriptions, key = { "${it.modelType}_${it.modelKey}" }) { subscription ->
-            val typeLabel = when (subscription.modelType) {
-                ModelType.EVENT -> "Event"
-                ModelType.TEAM -> "Team"
-                ModelType.MATCH -> "Match"
-                else -> "Other"
-            }
+            val typeLabel =
+                when (subscription.modelType) {
+                    ModelType.EVENT -> "Event"
+                    ModelType.TEAM -> "Team"
+                    ModelType.MATCH -> "Match"
+                    else -> "Other"
+                }
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        when (subscription.modelType) {
-                            ModelType.TEAM -> onNavigateToTeam(subscription.modelKey)
-                            ModelType.EVENT -> onNavigateToEvent(subscription.modelKey)
-                        }
-                    }
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            when (subscription.modelType) {
+                                ModelType.TEAM -> onNavigateToTeam(subscription.modelKey)
+                                ModelType.EVENT -> onNavigateToEvent(subscription.modelKey)
+                            }
+                        }.padding(horizontal = 16.dp, vertical = 12.dp),
             ) {
                 Text(
                     text = subscription.modelKey,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
@@ -21,88 +21,120 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class MyTBAViewModel @Inject constructor(
-    private val authRepository: AuthRepository,
-    private val myTBARepository: MyTBARepository,
-    private val deviceRegistrationManager: DeviceRegistrationManager,
-    private val shortcutManager: TBAShortcutManager,
-) : ViewModel() {
+class MyTBAViewModel
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val myTBARepository: MyTBARepository,
+        private val deviceRegistrationManager: DeviceRegistrationManager,
+        private val shortcutManager: TBAShortcutManager,
+    ) : ViewModel() {
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+        val uiState: StateFlow<MyTBAUiState> =
+            combine(
+                authRepository.currentUser,
+                myTBARepository.observeFavorites(),
+                myTBARepository.observeSubscriptions(),
+            ) { user, favorites, subscriptions ->
+                MyTBAUiState(
+                    isSignedIn = user != null,
+                    userName = user?.displayName,
+                    userEmail = user?.email,
+                    userPhotoUrl = user?.photoUrl?.toString(),
+                    favorites = favorites,
+                    subscriptions = subscriptions,
+                    canPinShortcuts = shortcutManager.canPinShortcuts(),
+                )
+            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), MyTBAUiState())
 
-    val uiState: StateFlow<MyTBAUiState> = combine(
-        authRepository.currentUser,
-        myTBARepository.observeFavorites(),
-        myTBARepository.observeSubscriptions(),
-    ) { user, favorites, subscriptions ->
-        MyTBAUiState(
-            isSignedIn = user != null,
-            userName = user?.displayName,
-            userEmail = user?.email,
-            userPhotoUrl = user?.photoUrl?.toString(),
-            favorites = favorites,
-            subscriptions = subscriptions,
-            canPinShortcuts = shortcutManager.canPinShortcuts(),
-        )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), MyTBAUiState())
-
-    init {
-        // Auto-refresh when user signs in
-        viewModelScope.launch {
-            authRepository.currentUser
-                .map { it != null }
-                .distinctUntilChanged()
-                .collect { signedIn ->
-                    if (signedIn) {
-                        launch { try { deviceRegistrationManager.onSignIn() } catch (_: Exception) {} }
-                        refresh()
+        init {
+            // Auto-refresh when user signs in
+            viewModelScope.launch {
+                authRepository.currentUser
+                    .map { it != null }
+                    .distinctUntilChanged()
+                    .collect { signedIn ->
+                        if (signedIn) {
+                            launch {
+                                try {
+                                    deviceRegistrationManager.onSignIn()
+                                } catch (
+                                    _: Exception,
+                                ) {
+                                }
+                            }
+                            refresh()
+                        }
                     }
-                }
+            }
         }
-    }
 
-    fun requestPinShortcut(favorite: Favorite) {
-        viewModelScope.launch {
-            shortcutManager.requestPinShortcut(favorite)
+        fun requestPinShortcut(favorite: Favorite) {
+            viewModelScope.launch {
+                shortcutManager.requestPinShortcut(favorite)
+            }
         }
-    }
 
-    fun refresh() {
-        viewModelScope.launch {
-            if (!authRepository.isSignedIn()) return@launch
-            _isRefreshing.value = true
-            try {
-                coroutineScope {
-                    launch { try { myTBARepository.refreshFavorites() } catch (_: Exception) {} }
-                    launch { try { myTBARepository.refreshSubscriptions() } catch (_: Exception) {} }
+        fun refresh() {
+            viewModelScope.launch {
+                if (!authRepository.isSignedIn()) return@launch
+                _isRefreshing.value = true
+                try {
+                    coroutineScope {
+                        launch {
+                            try {
+                                myTBARepository.refreshFavorites()
+                            } catch (_: Exception) {
+                            }
+                        }
+                        launch {
+                            try {
+                                myTBARepository.refreshSubscriptions()
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                    }
+                } finally {
+                    _isRefreshing.value = false
                 }
-            } finally {
-                _isRefreshing.value = false
+            }
+        }
+
+        fun refreshTab(tab: Int) {
+            viewModelScope.launch {
+                if (!authRepository.isSignedIn()) return@launch
+                _isRefreshing.value = true
+                try {
+                    when (tab) {
+                        0 ->
+                            try {
+                                myTBARepository.refreshFavorites()
+                            } catch (_: Exception) {
+                            }
+                        1 ->
+                            try {
+                                myTBARepository.refreshSubscriptions()
+                            } catch (_: Exception) {
+                            }
+                    }
+                } finally {
+                    _isRefreshing.value = false
+                }
+            }
+        }
+
+        fun signOut() {
+            viewModelScope.launch {
+                try {
+                    deviceRegistrationManager.onSignOut()
+                } catch (_: Exception) {
+                }
+                authRepository.signOut()
+                myTBARepository.clearLocal()
             }
         }
     }
-
-    fun refreshTab(tab: Int) {
-        viewModelScope.launch {
-            if (!authRepository.isSignedIn()) return@launch
-            _isRefreshing.value = true
-            try {
-                when (tab) {
-                    0 -> try { myTBARepository.refreshFavorites() } catch (_: Exception) {}
-                    1 -> try { myTBARepository.refreshSubscriptions() } catch (_: Exception) {}
-                }
-            } finally {
-                _isRefreshing.value = false
-            }
-        }
-    }
-
-    fun signOut() {
-        viewModelScope.launch {
-            try { deviceRegistrationManager.onSignOut() } catch (_: Exception) {}
-            authRepository.signOut()
-            myTBARepository.clearLocal()
-        }
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
@@ -5,12 +5,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -78,7 +78,14 @@ fun RegionalAdvancementScreen(
                 title = {
                     TopBarYearPicker(
                         selectedYear = selectedYear,
-                        years = if (selectedYear > 0) (maxYear downTo 2025).toList() else emptyList(),
+                        years =
+                            if (selectedYear >
+                                0
+                            ) {
+                                (maxYear downTo 2025).toList()
+                            } else {
+                                emptyList()
+                            },
                         onYearSelected = viewModel::selectYear,
                         title = { Text("Regional Advancement") },
                     )
@@ -93,7 +100,11 @@ fun RegionalAdvancementScreen(
                         }
                     }
                 },
-                actions = { IconButton(onClick = onNavigateToSearch) { Icon(Icons.Default.Search, contentDescription = "Search") } },
+                actions = {
+                    IconButton(onClick = onNavigateToSearch) {
+                        Icon(Icons.Default.Search, contentDescription = "Search")
+                    }
+                },
             )
         },
     ) { innerPadding ->
@@ -110,19 +121,35 @@ fun RegionalAdvancementScreen(
                 }
                 is RegionalAdvancementUiState.Error -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text(text = state.message, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text(
+                            text = state.message,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
                     }
                 }
                 is RegionalAdvancementUiState.Success -> {
                     if (state.rankings.isEmpty()) {
                         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                            Text(text = "No regional advancement rankings for $selectedYear", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Text(
+                                text = "No regional advancement rankings for $selectedYear",
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
                         }
                     } else {
-                        LazyColumn(state = listState, modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+                        LazyColumn(
+                            state = listState,
+                            modifier =
+                                Modifier.fillMaxSize().background(
+                                    MaterialTheme.colorScheme.background,
+                                ),
+                        ) {
                             item(key = "header") { RankingsTableHeader() }
                             items(state.rankings, key = { "${it.year}_${it.teamKey}" }) { ranking ->
-                                RegionalRankingRow(ranking = ranking, onNavigateToTeam = onNavigateToTeam, onNavigateToEvent = onNavigateToEvent)
+                                RegionalRankingRow(
+                                    ranking = ranking,
+                                    onNavigateToTeam = onNavigateToTeam,
+                                    onNavigateToEvent = onNavigateToEvent,
+                                )
                             }
                         }
                     }
@@ -134,56 +161,204 @@ fun RegionalAdvancementScreen(
 
 @Composable
 private fun RankingsTableHeader() {
-    Column(modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surfaceContainer).padding(horizontal = 16.dp, vertical = 12.dp)) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(
+                    MaterialTheme.colorScheme.surfaceContainer,
+                ).padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            Text(text = "Rank", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.12f))
-            Text(text = "Team", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.18f))
-            Text(text = "Event 1", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.15f))
-            Text(text = "Event 2", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.15f))
-            Text(text = "Bonus", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.15f))
-            Text(text = "Total Points", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.18f))
-            Text(text = "Qualified", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.25f))
+            Text(
+                text = "Rank",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(0.12f),
+            )
+            Text(
+                text = "Team",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(0.18f),
+            )
+            Text(
+                text = "Event 1",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(0.15f),
+            )
+            Text(
+                text = "Event 2",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(0.15f),
+            )
+            Text(
+                text = "Bonus",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(0.15f),
+            )
+            Text(
+                text = "Total Points",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(0.18f),
+            )
+            Text(
+                text = "Qualified",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(0.25f),
+            )
         }
     }
 }
 
 @Composable
-private fun RegionalRankingRow(ranking: RegionalRanking, onNavigateToTeam: (String) -> Unit, onNavigateToEvent: (String) -> Unit) {
-    Column(modifier = Modifier.fillMaxWidth().clickable { onNavigateToTeam(ranking.teamKey) }.padding(horizontal = 16.dp, vertical = 8.dp)) {
+private fun RegionalRankingRow(
+    ranking: RegionalRanking,
+    onNavigateToTeam: (String) -> Unit,
+    onNavigateToEvent: (String) -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable {
+                    onNavigateToTeam(ranking.teamKey)
+                }.padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            Text(text = "${ranking.rank}", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.12f))
-            Text(text = ranking.teamKey.removePrefix("frc"), style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium, modifier = Modifier.weight(0.18f))
+            Text(
+                text = "${ranking.rank}",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(0.12f),
+            )
+            Text(
+                text = ranking.teamKey.removePrefix("frc"),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.weight(0.18f),
+            )
             val sortedEvents = ranking.eventPoints.sortedBy { it.eventKey }
             if (sortedEvents.isNotEmpty()) {
-                Text(text = "${sortedEvents[0].total.toInt()}", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(0.15f).clickable { onNavigateToEvent(sortedEvents[0].eventKey) })
+                Text(
+                    text = "${sortedEvents[0].total.toInt()}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier =
+                        Modifier
+                            .weight(
+                                0.15f,
+                            ).clickable {
+                                onNavigateToEvent(sortedEvents[0].eventKey)
+                            },
+                )
             } else {
-                Text(text = "--", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.weight(0.15f))
+                Text(
+                    text = "--",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(0.15f),
+                )
             }
             if (sortedEvents.size > 1) {
-                Text(text = "${sortedEvents[1].total.toInt()}", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(0.15f).clickable { onNavigateToEvent(sortedEvents[1].eventKey) })
+                Text(
+                    text = "${sortedEvents[1].total.toInt()}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier =
+                        Modifier
+                            .weight(
+                                0.15f,
+                            ).clickable {
+                                onNavigateToEvent(sortedEvents[1].eventKey)
+                            },
+                )
             } else {
-                Text(text = "--", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.weight(0.15f))
+                Text(
+                    text = "--",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(0.15f),
+                )
             }
             val totalBonus = (ranking.rookieBonus + ranking.singleEventBonus).toInt()
             if (totalBonus > 0) {
-                Text(text = "+$totalBonus", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(0.15f))
+                Text(
+                    text = "+$totalBonus",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(0.15f),
+                )
             } else {
-                Text(text = "--", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.weight(0.15f))
+                Text(
+                    text = "--",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(0.15f),
+                )
             }
-            Text(text = "${ranking.pointTotal.toInt()}", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.18f))
+            Text(
+                text = "${ranking.pointTotal.toInt()}",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(0.18f),
+            )
             AdvancementBadge(method = ranking.advancementMethod, modifier = Modifier.weight(0.25f))
         }
     }
 }
 
 @Composable
-private fun AdvancementBadge(method: String?, modifier: Modifier = Modifier) {
+private fun AdvancementBadge(
+    method: String?,
+    modifier: Modifier = Modifier,
+) {
     if (method.isNullOrBlank()) {
-        Text(text = "--", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = modifier)
+        Text(
+            text = "--",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = modifier,
+        )
     } else {
-        Box(modifier = modifier.background(color = when { method.contains("Regional Winner") -> MaterialTheme.colorScheme.primaryContainer; method.contains("Finalist") -> MaterialTheme.colorScheme.secondaryContainer; else -> MaterialTheme.colorScheme.tertiaryContainer }, shape = androidx.compose.foundation.shape.RoundedCornerShape(4.dp)).padding(horizontal = 8.dp, vertical = 4.dp)) {
-            Text(text = method, style = MaterialTheme.typography.labelSmall, fontSize = 10.sp, maxLines = 2, overflow = TextOverflow.Ellipsis, color = when { method.contains("Regional Winner") -> MaterialTheme.colorScheme.onPrimaryContainer; method.contains("Finalist") -> MaterialTheme.colorScheme.onSecondaryContainer; else -> MaterialTheme.colorScheme.onTertiaryContainer })
+        Box(
+            modifier =
+                modifier
+                    .background(
+                        color =
+                            when {
+                                method.contains(
+                                    "Regional Winner",
+                                ) -> MaterialTheme.colorScheme.primaryContainer
+                                method.contains(
+                                    "Finalist",
+                                ) -> MaterialTheme.colorScheme.secondaryContainer
+                                else -> MaterialTheme.colorScheme.tertiaryContainer
+                            },
+                        shape =
+                            androidx.compose.foundation.shape
+                                .RoundedCornerShape(4.dp),
+                    ).padding(horizontal = 8.dp, vertical = 4.dp),
+        ) {
+            Text(
+                text = method,
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 10.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                color =
+                    when {
+                        method.contains(
+                            "Regional Winner",
+                        ) -> MaterialTheme.colorScheme.onPrimaryContainer
+                        method.contains(
+                            "Finalist",
+                        ) -> MaterialTheme.colorScheme.onSecondaryContainer
+                        else -> MaterialTheme.colorScheme.onTertiaryContainer
+                    },
+            )
         }
     }
 }
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementUiState.kt
@@ -4,6 +4,12 @@ import com.thebluealliance.android.domain.model.RegionalRanking
 
 sealed interface RegionalAdvancementUiState {
     data object Loading : RegionalAdvancementUiState
-    data class Success(val rankings: List<RegionalRanking>) : RegionalAdvancementUiState
-    data class Error(val message: String) : RegionalAdvancementUiState
+
+    data class Success(
+        val rankings: List<RegionalRanking>,
+    ) : RegionalAdvancementUiState
+
+    data class Error(
+        val message: String,
+    ) : RegionalAdvancementUiState
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementViewModel.kt
@@ -13,64 +13,66 @@ import java.util.Calendar
 import javax.inject.Inject
 
 @HiltViewModel
-class RegionalAdvancementViewModel @Inject constructor(
-    private val repository: RegionalAdvancementRepository,
-    private val tbaApi: TbaApi,
-) : ViewModel() {
+class RegionalAdvancementViewModel
+    @Inject
+    constructor(
+        private val repository: RegionalAdvancementRepository,
+        private val tbaApi: TbaApi,
+    ) : ViewModel() {
+        private val fallbackYear = Calendar.getInstance().get(Calendar.YEAR)
 
-    private val fallbackYear = Calendar.getInstance().get(Calendar.YEAR)
+        private val _maxYear = MutableStateFlow(fallbackYear)
+        val maxYear: StateFlow<Int> = _maxYear.asStateFlow()
 
-    private val _maxYear = MutableStateFlow(fallbackYear)
-    val maxYear: StateFlow<Int> = _maxYear.asStateFlow()
+        private val _selectedYear = MutableStateFlow(fallbackYear)
+        val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
 
-    private val _selectedYear = MutableStateFlow(fallbackYear)
-    val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+        private val _uiState =
+            MutableStateFlow<RegionalAdvancementUiState>(RegionalAdvancementUiState.Loading)
+        val uiState: StateFlow<RegionalAdvancementUiState> = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow<RegionalAdvancementUiState>(RegionalAdvancementUiState.Loading)
-    val uiState: StateFlow<RegionalAdvancementUiState> = _uiState.asStateFlow()
+        init {
+            fetchMaxYear()
+            refreshRankings()
+        }
 
-    init {
-        fetchMaxYear()
-        refreshRankings()
-    }
-
-    private fun fetchMaxYear() {
-        viewModelScope.launch {
-            try {
-                val status = tbaApi.getStatus()
-                _maxYear.value = status.maxSeason
-                if (_selectedYear.value < status.maxSeason) {
-                    _selectedYear.value = status.maxSeason
+        private fun fetchMaxYear() {
+            viewModelScope.launch {
+                try {
+                    val status = tbaApi.getStatus()
+                    _maxYear.value = status.maxSeason
+                    if (_selectedYear.value < status.maxSeason) {
+                        _selectedYear.value = status.maxSeason
+                    }
+                } catch (_: Exception) {
+                    // Keep calendar year fallback if status request fails.
                 }
-            } catch (_: Exception) {
-                // Keep calendar year fallback if status request fails.
+            }
+        }
+
+        fun selectYear(year: Int) {
+            if (_selectedYear.value == year) return
+            _selectedYear.value = year
+            refreshRankings()
+        }
+
+        fun refreshRankings() {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    val rankings = repository.getRegionalRankings(_selectedYear.value)
+                    _uiState.value = RegionalAdvancementUiState.Success(rankings)
+                } catch (e: Exception) {
+                    _uiState.value =
+                        RegionalAdvancementUiState.Error(
+                            e.message ?: "Unable to load regional advancement rankings",
+                        )
+                } finally {
+                    _isRefreshing.value = false
+                }
             }
         }
     }
-
-    fun selectYear(year: Int) {
-        if (_selectedYear.value == year) return
-        _selectedYear.value = year
-        refreshRankings()
-    }
-
-    fun refreshRankings() {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                val rankings = repository.getRegionalRankings(_selectedYear.value)
-                _uiState.value = RegionalAdvancementUiState.Success(rankings)
-            } catch (e: Exception) {
-                _uiState.value = RegionalAdvancementUiState.Error(
-                    e.message ?: "Unable to load regional advancement rankings"
-                )
-            } finally {
-                _isRefreshing.value = false
-            }
-        }
-    }
-}
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/search/SearchScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
-import com.thebluealliance.android.ui.components.TBATopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -29,12 +28,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.ui.components.EventRow
 import com.thebluealliance.android.ui.components.SectionHeader
 import com.thebluealliance.android.ui.components.SectionHeaderInfo
+import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.TeamRow
 import kotlinx.coroutines.launch
 
@@ -59,30 +58,33 @@ fun SearchScreen(
         lazyListState.scrollToItem(0)
     }
 
-    val headerInfos = remember(uiState.teams.size, uiState.events.size) {
-        buildList {
-            var index = 0
-            if (uiState.teams.isNotEmpty()) {
-                add(SectionHeaderInfo("teams_header", "Teams", index))
-                index += 1 + uiState.teams.size
-            }
-            if (uiState.events.isNotEmpty()) {
-                add(SectionHeaderInfo("events_header", "Events", index))
+    val headerInfos =
+        remember(uiState.teams.size, uiState.events.size) {
+            buildList {
+                var index = 0
+                if (uiState.teams.isNotEmpty()) {
+                    add(SectionHeaderInfo("teams_header", "Teams", index))
+                    index += 1 + uiState.teams.size
+                }
+                if (uiState.events.isNotEmpty()) {
+                    add(SectionHeaderInfo("events_header", "Events", index))
+                }
             }
         }
-    }
 
-    val headerKeys = remember(headerInfos) {
-        headerInfos.map { it.key }.toSet()
-    }
+    val headerKeys =
+        remember(headerInfos) {
+            headerInfos.map { it.key }.toSet()
+        }
 
     val stuckHeaderKey by remember(headerKeys) {
         derivedStateOf {
-            val stuck = lazyListState.layoutInfo.visibleItemsInfo
-                .firstOrNull { item ->
-                    val key = item.key as? String
-                    key != null && key in headerKeys && item.offset <= 0
-                }?.key as? String
+            val stuck =
+                lazyListState.layoutInfo.visibleItemsInfo
+                    .firstOrNull { item ->
+                        val key = item.key as? String
+                        key != null && key in headerKeys && item.offset <= 0
+                    }?.key as? String
             stuck ?: headerInfos.firstOrNull()?.key
         }
     }
@@ -96,22 +98,28 @@ fun SearchScreen(
                         onValueChange = viewModel::onQueryChanged,
                         placeholder = { Text("Search teams & events") },
                         singleLine = true,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .focusRequester(focusRequester),
-                        colors = TextFieldDefaults.colors(
-                            focusedContainerColor = MaterialTheme.colorScheme.surface,
-                            unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-                            focusedTextColor = MaterialTheme.colorScheme.onSurface,
-                            unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
-                            focusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                            unfocusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                            cursorColor = MaterialTheme.colorScheme.primary,
-                            focusedIndicatorColor = MaterialTheme.colorScheme.primary,
-                            unfocusedIndicatorColor = MaterialTheme.colorScheme.outline,
-                            focusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                            unfocusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        ),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .focusRequester(focusRequester),
+                        colors =
+                            TextFieldDefaults.colors(
+                                focusedContainerColor = MaterialTheme.colorScheme.surface,
+                                unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                                focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                                focusedPlaceholderColor =
+                                    MaterialTheme.colorScheme.onSurfaceVariant,
+                                unfocusedPlaceholderColor =
+                                    MaterialTheme.colorScheme.onSurfaceVariant,
+                                cursorColor = MaterialTheme.colorScheme.primary,
+                                focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                                unfocusedIndicatorColor = MaterialTheme.colorScheme.outline,
+                                focusedTrailingIconColor =
+                                    MaterialTheme.colorScheme.onSurfaceVariant,
+                                unfocusedTrailingIconColor =
+                                    MaterialTheme.colorScheme.onSurfaceVariant,
+                            ),
                         trailingIcon = {
                             if (uiState.query.isNotEmpty()) {
                                 IconButton(onClick = { viewModel.onQueryChanged("") }) {
@@ -130,10 +138,11 @@ fun SearchScreen(
         },
     ) { innerPadding ->
         Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
         ) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
@@ -170,7 +179,11 @@ fun SearchScreen(
                         )
                     }
                     items(uiState.events, key = { "event_${it.key}" }) { event ->
-                        EventRow(event = event, onClick = { onNavigateToEvent(event.key) }, showYear = true)
+                        EventRow(
+                            event = event,
+                            onClick = { onNavigateToEvent(event.key) },
+                            showYear = true,
+                        )
                     }
                 }
             }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/search/SearchViewModel.kt
@@ -18,34 +18,44 @@ import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class, kotlinx.coroutines.FlowPreview::class)
 @HiltViewModel
-class SearchViewModel @Inject constructor(
-    private val teamRepository: TeamRepository,
-    private val eventRepository: EventRepository,
-) : ViewModel() {
+class SearchViewModel
+    @Inject
+    constructor(
+        private val teamRepository: TeamRepository,
+        private val eventRepository: EventRepository,
+    ) : ViewModel() {
+        private val query = MutableStateFlow("")
 
-    private val _query = MutableStateFlow("")
+        private val debouncedQuery = query.debounce(300)
 
-    private val debouncedQuery = _query.debounce(300)
+        private val teamsFlow =
+            debouncedQuery.flatMapLatest { query ->
+                if (query.length == 0) {
+                    flowOf(emptyList())
+                } else {
+                    teamRepository.searchTeams(query)
+                }
+            }
 
-    private val teamsFlow = debouncedQuery.flatMapLatest { query ->
-        if (query.length  == 0) flowOf(emptyList())
-        else teamRepository.searchTeams(query)
+        private val eventsFlow =
+            debouncedQuery.flatMapLatest { query ->
+                if (query.length == 0) {
+                    flowOf(emptyList())
+                } else {
+                    eventRepository.searchEvents(query)
+                }
+            }
+
+        val uiState: StateFlow<SearchUiState> =
+            combine(
+                query,
+                teamsFlow,
+                eventsFlow,
+            ) { query, teams, events ->
+                SearchUiState(query = query, teams = teams, events = events)
+            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SearchUiState())
+
+        fun onQueryChanged(newQuery: String) {
+            query.value = newQuery
+        }
     }
-
-    private val eventsFlow = debouncedQuery.flatMapLatest { query ->
-        if (query.length  == 0) flowOf(emptyList())
-        else eventRepository.searchEvents(query)
-    }
-
-    val uiState: StateFlow<SearchUiState> = combine(
-        _query,
-        teamsFlow,
-        eventsFlow,
-    ) { query, teams, events ->
-        SearchUiState(query = query, teams = teams, events = events)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SearchUiState())
-
-    fun onQueryChanged(query: String) {
-        _query.value = query
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/settings/SettingsScreen.kt
@@ -4,16 +4,21 @@ import android.app.NotificationManager
 import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
@@ -30,13 +35,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.BuildConfig
 import com.thebluealliance.android.messaging.NotificationBuilder
 import com.thebluealliance.android.messaging.NotificationChannelManager
-import com.thebluealliance.android.ui.theme.ThemeMode
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import com.thebluealliance.android.ui.components.TBATopAppBar
+import com.thebluealliance.android.ui.theme.ThemeMode
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -72,11 +72,12 @@ fun SettingsScreen(
         },
     ) { innerPadding ->
         Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-                .padding(16.dp),
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(16.dp),
         ) {
             Text(
                 text = "Appearance",
@@ -95,17 +96,18 @@ fun SettingsScreen(
                     SegmentedButton(
                         selected = themeMode == mode,
                         onClick = { viewModel.setThemeMode(mode) },
-                        shape = SegmentedButtonDefaults.itemShape(
-                            index = index,
-                            count = ThemeMode.entries.size,
-                        ),
+                        shape =
+                            SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = ThemeMode.entries.size,
+                            ),
                     ) {
                         Text(
                             when (mode) {
                                 ThemeMode.AUTO -> "Auto"
                                 ThemeMode.LIGHT -> "Light"
                                 ThemeMode.DARK -> "Dark"
-                            }
+                            },
                         )
                     }
                 }
@@ -122,27 +124,30 @@ fun SettingsScreen(
                 val context = LocalContext.current
                 Button(
                     onClick = { sendTestMatchScore(context) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
                 ) {
                     Text("Test: Match score notification")
                 }
 
                 Button(
                     onClick = { sendTestUpcomingMatch(context) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
                 ) {
                     Text("Test: Upcoming match notification")
                 }
 
                 Button(
                     onClick = { sendTestEventUpdate(context) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
                 ) {
                     Text("Test: Event update notification")
                 }
@@ -153,43 +158,48 @@ fun SettingsScreen(
 
 private fun sendTestMatchScore(context: Context) {
     val builder = NotificationBuilder(context)
-    val notification = builder.build(
-        channelId = NotificationChannelManager.CHANNEL_MATCH,
-        title = "BCVI Q42 Results",
-        body = "177, 254, 1114 beat 2056, 148, 67 scoring 152-138.",
-        eventKey = "2026bcvi",
-        matchKey = "2026bcvi_qm42",
-        teamKey = "frc177",
-        notificationType = "match_score",
-    )
+    val notification =
+        builder.build(
+            channelId = NotificationChannelManager.CHANNEL_MATCH,
+            title = "BCVI Q42 Results",
+            body = "177, 254, 1114 beat 2056, 148, 67 scoring 152-138.",
+            eventKey = "2026bcvi",
+            matchKey = "2026bcvi_qm42",
+            teamKey = "frc177",
+            notificationType = "match_score",
+        )
     val manager = context.getSystemService(NotificationManager::class.java)
     manager.notify(9001, notification)
 }
 
 private fun sendTestUpcomingMatch(context: Context) {
     val builder = NotificationBuilder(context)
-    val notification = builder.build(
-        channelId = NotificationChannelManager.CHANNEL_MATCH,
-        title = "BCVI Q43 Starting Soon",
-        body = "BC District Event, Quals 43: 177, 1519, 4909 will play 2791, 3467, 78.",
-        eventKey = "2026bcvi",
-        matchKey = "2026bcvi_qm43",
-        teamKey = "frc177",
-        notificationType = "upcoming_match",
-    )
+    val notification =
+        builder.build(
+            channelId = NotificationChannelManager.CHANNEL_MATCH,
+            title = "BCVI Q43 Starting Soon",
+            body = "BC District Event, Quals 43: 177, 1519, 4909 will play 2791, 3467, 78.",
+            eventKey = "2026bcvi",
+            matchKey = "2026bcvi_qm43",
+            teamKey = "frc177",
+            notificationType = "upcoming_match",
+        )
     val manager = context.getSystemService(NotificationManager::class.java)
     manager.notify(9002, notification)
 }
 
 private fun sendTestEventUpdate(context: Context) {
     val builder = NotificationBuilder(context)
-    val notification = builder.build(
-        channelId = NotificationChannelManager.CHANNEL_EVENT,
-        title = "BCVI Schedule Updated",
-        body = "The BC District Event match schedule has been updated. The next match starts at 14:30 ET.",
-        eventKey = "2026bcvi",
-        notificationType = "schedule_updated",
-    )
+    val notification =
+        builder.build(
+            channelId = NotificationChannelManager.CHANNEL_EVENT,
+            title = "BCVI Schedule Updated",
+            body =
+                "The BC District Event match schedule has been updated. " +
+                    "The next match starts at 14:30 ET.",
+            eventKey = "2026bcvi",
+            notificationType = "schedule_updated",
+        )
     val manager = context.getSystemService(NotificationManager::class.java)
     manager.notify(9003, notification)
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/settings/SettingsViewModel.kt
@@ -12,16 +12,18 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class SettingsViewModel @Inject constructor(
-    private val themePreferences: ThemePreferences,
-) : ViewModel() {
+class SettingsViewModel
+    @Inject
+    constructor(
+        private val themePreferences: ThemePreferences,
+    ) : ViewModel() {
+        val themeMode: StateFlow<ThemeMode> =
+            themePreferences.themeModeFlow
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ThemeMode.AUTO)
 
-    val themeMode: StateFlow<ThemeMode> = themePreferences.themeModeFlow
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ThemeMode.AUTO)
-
-    fun setThemeMode(mode: ThemeMode) {
-        viewModelScope.launch {
-            themePreferences.setThemeMode(mode)
+        fun setThemeMode(mode: ThemeMode) {
+            viewModelScope.launch {
+                themePreferences.setThemeMode(mode)
+            }
         }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -19,8 +19,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -34,8 +34,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -51,7 +51,6 @@ import com.thebluealliance.android.domain.model.Ranking
 import com.thebluealliance.android.domain.model.Team
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
-import com.thebluealliance.android.ui.events.detail.EventDetailTab
 import com.thebluealliance.android.ui.components.EventRow
 import com.thebluealliance.android.ui.components.MatchItem
 import com.thebluealliance.android.ui.components.MatchList
@@ -59,6 +58,7 @@ import com.thebluealliance.android.ui.components.MediaTab
 import com.thebluealliance.android.ui.components.TBATabRow
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.TeamRow
+import com.thebluealliance.android.ui.events.detail.EventDetailTab
 import com.thebluealliance.android.ui.events.detail.tabs.advancementBreakdownRows
 import com.thebluealliance.android.util.openUrl
 import kotlinx.coroutines.launch
@@ -116,7 +116,16 @@ fun TeamEventDetailScreen(
                                     text = event.shortName ?: event.name,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f).clickable { onNavigateToEvent(event.key, EventDetailTab.INFO) },
+                                    modifier =
+                                        Modifier
+                                            .weight(
+                                                1f,
+                                            ).clickable {
+                                                onNavigateToEvent(
+                                                    event.key,
+                                                    EventDetailTab.INFO,
+                                                )
+                                            },
                                     style = MaterialTheme.typography.titleLarge,
                                 )
                             }
@@ -132,7 +141,7 @@ fun TeamEventDetailScreen(
                         IconButton(onClick = onNavigateUp) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = "Back"
+                                contentDescription = "Back",
                             )
                         }
                     },
@@ -147,11 +156,24 @@ fun TeamEventDetailScreen(
                     TABS.forEachIndexed { index, title ->
                         Tab(
                             selected = pagerState.currentPage == index,
-                            onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
+                            onClick = {
+                                coroutineScope.launch {
+                                    pagerState.animateScrollToPage(
+                                        index,
+                                    )
+                                }
+                            },
                             text = {
                                 Text(
                                     text = title,
-                                    color = if (pagerState.currentPage == index) Color.White else Color.White.copy(alpha = 0.7f)
+                                    color =
+                                        if (pagerState.currentPage ==
+                                            index
+                                        ) {
+                                            Color.White
+                                        } else {
+                                            Color.White.copy(alpha = 0.7f)
+                                        },
                                 )
                             },
                         )
@@ -163,9 +185,11 @@ fun TeamEventDetailScreen(
         val bottomPadding = PaddingValues(bottom = innerPadding.calculateBottomPadding())
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier.fillMaxSize()
-                .padding(top = innerPadding.calculateTopPadding())
-                .background(MaterialTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(top = innerPadding.calculateTopPadding())
+                    .background(MaterialTheme.colorScheme.background),
         ) { page ->
             PullToRefreshBox(
                 isRefreshing = isRefreshing && uiState.matches != null && uiState.awards != null,
@@ -174,26 +198,29 @@ fun TeamEventDetailScreen(
             ) {
                 val evt = uiState.event
                 when (page) {
-                    TeamEventDetailTabs.SUMMARY -> SummaryTab(
-                        teamKey = viewModel.teamKey,
-                        eventKey = viewModel.eventKey,
-                        event = evt,
-                        team = uiState.team,
-                        ranking = uiState.ranking,
-                        alliances = uiState.alliances,
-                        awards = uiState.awards,
-                        matches = uiState.matches,
-                        pitLocation = uiState.pitLocation,
-                        cmpAdvancement = uiState.cmpAdvancement,
-                        onNavigateToEvent = onNavigateToEvent,
-                        onNavigateToTeam = onNavigateToTeam,
-                        onNavigateToMatch = onNavigateToMatch,
-                        innerPadding = bottomPadding,
-                    )
+                    TeamEventDetailTabs.SUMMARY ->
+                        SummaryTab(
+                            teamKey = viewModel.teamKey,
+                            eventKey = viewModel.eventKey,
+                            event = evt,
+                            team = uiState.team,
+                            ranking = uiState.ranking,
+                            alliances = uiState.alliances,
+                            awards = uiState.awards,
+                            matches = uiState.matches,
+                            pitLocation = uiState.pitLocation,
+                            cmpAdvancement = uiState.cmpAdvancement,
+                            onNavigateToEvent = onNavigateToEvent,
+                            onNavigateToTeam = onNavigateToTeam,
+                            onNavigateToMatch = onNavigateToMatch,
+                            innerPadding = bottomPadding,
+                        )
                     TeamEventDetailTabs.MATCHES -> {
                         val tm = uiState.team
                         val hasBoth = evt != null && tm != null
-                        val headerCount = (if (evt != null) 1 else 0) + (if (hasBoth) 1 else 0) + (if (tm != null) 1 else 0)
+                        val headerCount =
+                            (if (evt != null) 1 else 0) + (if (hasBoth) 1 else 0) +
+                                (if (tm != null) 1 else 0)
                         MatchList(
                             matches = uiState.matches,
                             playoffType = evt?.playoffType ?: PlayoffType.OTHER,
@@ -204,7 +231,12 @@ fun TeamEventDetailScreen(
                                     item(key = "header_event") {
                                         EventRow(
                                             event = evt,
-                                            onClick = { onNavigateToEvent(evt.key, EventDetailTab.INFO) },
+                                            onClick = {
+                                                onNavigateToEvent(
+                                                    evt.key,
+                                                    EventDetailTab.INFO,
+                                                )
+                                            },
                                             showYear = true,
                                             showChevron = true,
                                         )
@@ -226,17 +258,19 @@ fun TeamEventDetailScreen(
                             innerPadding = bottomPadding,
                         )
                     }
-                    TeamEventDetailTabs.MEDIA -> MediaTab(
-                        media = uiState.media,
-                        innerPadding = bottomPadding,
-                    )
-                    TeamEventDetailTabs.STATS -> StatsTab(
-                        teamKey = viewModel.teamKey,
-                        event = evt,
-                        oprs = uiState.oprs,
-                        advancementPoints = uiState.advancementPoints,
-                        innerPadding = bottomPadding,
-                    )
+                    TeamEventDetailTabs.MEDIA ->
+                        MediaTab(
+                            media = uiState.media,
+                            innerPadding = bottomPadding,
+                        )
+                    TeamEventDetailTabs.STATS ->
+                        StatsTab(
+                            teamKey = viewModel.teamKey,
+                            event = evt,
+                            oprs = uiState.oprs,
+                            advancementPoints = uiState.advancementPoints,
+                            innerPadding = bottomPadding,
+                        )
                     TeamEventDetailTabs.AWARDS -> {
                         val tm = uiState.team
                         AwardsTab(
@@ -300,16 +334,18 @@ private fun SummaryTab(
         }
 
         // Info header (ranking, alliance, pit location)
-        val teamAlliance = alliances?.firstOrNull { alliance ->
-            teamKey in alliance.picks || teamKey == alliance.backupIn
-        }
+        val teamAlliance =
+            alliances?.firstOrNull { alliance ->
+                teamKey in alliance.picks || teamKey == alliance.backupIn
+            }
         if (ranking != null || teamAlliance != null || pitLocation != null) {
             item(key = "summary_info_header") {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(Color(0xFF5C6BC0))
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .background(Color(0xFF5C6BC0))
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
                 ) {
                     Text(
                         text = "Info",
@@ -340,15 +376,23 @@ private fun SummaryTab(
                 item(key = "summary_alliance_divider") { HorizontalDivider() }
             }
             item(key = "summary_alliance") {
-                val role = when {
-                    teamKey == teamAlliance.backupIn -> "Backup"
-                    teamAlliance.picks.indexOf(teamKey) == 0 -> "Captain"
-                    else -> "Pick ${teamAlliance.picks.indexOf(teamKey)}"
-                }
+                val role =
+                    when {
+                        teamKey == teamAlliance.backupIn -> "Backup"
+                        teamAlliance.picks.indexOf(teamKey) == 0 -> "Captain"
+                        else -> "Pick ${teamAlliance.picks.indexOf(teamKey)}"
+                    }
                 InfoRow(
                     label = "Alliance ${teamAlliance.number}",
                     value = role,
-                    onClick = { event?.let { onNavigateToEvent(it.key, EventDetailTab.ALLIANCES) } },
+                    onClick = {
+                        event?.let {
+                            onNavigateToEvent(
+                                it.key,
+                                EventDetailTab.ALLIANCES,
+                            )
+                        }
+                    },
                 )
             }
             infoItemCount++
@@ -391,10 +435,11 @@ private fun SummaryTab(
         if (cmpAdvancement != null) {
             item(key = "summary_cmp_header") {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(Color(0xFF5C6BC0))
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .background(Color(0xFF5C6BC0))
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
                 ) {
                     Text(
                         text = "Championship Qualification",
@@ -416,9 +461,10 @@ private fun SummaryTab(
 
         // Last Match / Next Match
         if (matches != null) {
-            val sortedMatches = matches.sortedWith(
-                compareBy({ it.compLevel.order }, { it.setNumber }, { it.matchNumber })
-            )
+            val sortedMatches =
+                matches.sortedWith(
+                    compareBy({ it.compLevel.order }, { it.setNumber }, { it.matchNumber }),
+                )
             val lastPlayed = sortedMatches.lastOrNull { it.redScore >= 0 }
             val nextUnplayed = sortedMatches.firstOrNull { it.redScore < 0 }
             val playoffType = event?.playoffType ?: PlayoffType.OTHER
@@ -426,10 +472,11 @@ private fun SummaryTab(
             if (lastPlayed != null || nextUnplayed != null) {
                 item(key = "summary_match_header") {
                     Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .background(Color(0xFF5C6BC0))
-                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .background(Color(0xFF5C6BC0))
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
                     ) {
                         Text(
                             text = "Recent Matches",
@@ -468,14 +515,15 @@ private fun SummaryTab(
     }
 }
 
-private fun cmpAdvancementSummary(advancement: CmpAdvancement): String? = when (advancement) {
-    is CmpAdvancement.EventQualified -> {
-        val eventName = advancement.eventShortName ?: advancement.eventKey.ifBlank { null }
-        eventName?.let { "Qualified via $it" }
+private fun cmpAdvancementSummary(advancement: CmpAdvancement): String? =
+    when (advancement) {
+        is CmpAdvancement.EventQualified -> {
+            val eventName = advancement.eventShortName ?: advancement.eventKey.ifBlank { null }
+            eventName?.let { "Qualified via $it" }
+        }
+        is CmpAdvancement.PoolQualified -> "Qualified via Regional Pool (Week ${advancement.week})"
+        is CmpAdvancement.Qualified -> "Qualified"
     }
-    is CmpAdvancement.PoolQualified -> "Qualified via Regional Pool (Week ${advancement.week})"
-    is CmpAdvancement.Qualified -> "Qualified"
-}
 
 @Composable
 private fun SummarySection(
@@ -483,9 +531,10 @@ private fun SummarySection(
     content: @Composable () -> Unit,
 ) {
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         Text(
             text = label,
@@ -505,10 +554,11 @@ private fun InfoRow(
     onClick: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Row(modifier = Modifier.weight(1f)) {
@@ -558,16 +608,17 @@ private fun StatsTab(
     if (!hasOprData && !hasPointsData) {
         EmptyBox(
             modifier = Modifier.padding(innerPadding),
-            message = "No stats available"
+            message = "No stats available",
         )
         return
     }
     val context = LocalContext.current
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding)
-            .padding(16.dp),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         if (hasOprData) {
@@ -578,7 +629,12 @@ private fun StatsTab(
                 text = "Learn more about OPR",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.clickable { context.openUrl("https://www.thebluealliance.com/opr") },
+                modifier =
+                    Modifier.clickable {
+                        context.openUrl(
+                            "https://www.thebluealliance.com/opr",
+                        )
+                    },
             )
         }
 
@@ -618,7 +674,10 @@ private fun StatsTab(
 }
 
 @Composable
-private fun StatRow(label: String, value: Double) {
+private fun StatRow(
+    label: String,
+    value: Double,
+) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -646,7 +705,7 @@ private fun AwardsTab(
 ) {
     if (awards == null) {
         LoadingBox(
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
         )
         return
     }
@@ -688,9 +747,10 @@ private fun AwardsTab(
         }
         items(awards, key = { "${it.awardType}_${it.awardee.orEmpty()}" }) { award ->
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
             ) {
                 Text(
                     text = award.name,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailViewModel.kt
@@ -40,172 +40,362 @@ private data class TeamEventExtras(
 )
 
 @HiltViewModel(assistedFactory = TeamEventDetailViewModel.Factory::class)
-class TeamEventDetailViewModel @AssistedInject constructor(
-    @Assisted val navKey: Screen.TeamEventDetail,
-    private val teamRepository: TeamRepository,
-    private val eventRepository: EventRepository,
-    private val matchRepository: MatchRepository,
-) : ViewModel() {
+class TeamEventDetailViewModel
+    @AssistedInject
+    constructor(
+        @Assisted val navKey: Screen.TeamEventDetail,
+        private val teamRepository: TeamRepository,
+        private val eventRepository: EventRepository,
+        private val matchRepository: MatchRepository,
+    ) : ViewModel() {
+        val teamKey: String = navKey.teamKey
+        val eventKey: String = navKey.eventKey
+        private val year: Int = eventKey.substring(0, 4).toIntOrNull() ?: 0
 
-    val teamKey: String = navKey.teamKey
-    val eventKey: String = navKey.eventKey
-    private val year: Int = eventKey.substring(0, 4).toIntOrNull() ?: 0
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+        private val regionalCmpAdvancementByTeam =
+            MutableStateFlow<Map<String, CmpAdvancement>>(emptyMap())
 
-    private val _regionalCmpAdvancementByTeam = MutableStateFlow<Map<String, CmpAdvancement>>(emptyMap())
-
-    val uiState: StateFlow<TeamEventDetailUiState> = combine(
-        teamRepository.observeTeam(teamKey),
-        eventRepository.observeEvent(eventKey),
-        eventRepository.observeEventRankings(eventKey).map { rankings ->
-            rankings.firstOrNull { it.teamKey == teamKey }
-        },
-        matchRepository.observeEventMatches(eventKey).map { matches ->
-            matches.filter { m -> teamKey in m.redTeamKeys || teamKey in m.blueTeamKeys }
-        },
-        combine(
+        val uiState: StateFlow<TeamEventDetailUiState> =
             combine(
-                eventRepository.observeEventAwards(eventKey).map { awards ->
-                    awards.filter { it.teamKey == teamKey }
+                teamRepository.observeTeam(teamKey),
+                eventRepository.observeEvent(eventKey),
+                eventRepository.observeEventRankings(eventKey).map { rankings ->
+                    rankings.firstOrNull { it.teamKey == teamKey }
                 },
-                eventRepository.observeEventOPRs(eventKey),
-                eventRepository.observeEventAlliances(eventKey),
-                teamRepository.observeTeamMedia(teamKey, year),
-                teamRepository.observeTeamEventPitLocation(teamKey, eventKey),
-            ) { awards, oprs, alliances, media, pitLocation ->
-                TeamEventExtras(
-                    awards = awards,
-                    oprs = oprs,
-                    alliances = alliances,
-                    media = media,
-                    pitLocation = pitLocation,
-                    districtPointsByTeam = emptyMap(),
-                    regionalPointsByTeam = emptyMap(),
-                    regionalCmpAdvancementByTeam = emptyMap(),
-                )
-            },
-            combine(
-                eventRepository.observeEventDistrictPoints(eventKey).map { it.associateBy { points -> points.teamKey } },
-                eventRepository.observeEventRegionalPoints(eventKey).map { it.associateBy { points -> points.teamKey } },
-                _regionalCmpAdvancementByTeam,
-            ) { districtPoints, regionalPoints, cmpMap ->
-                Triple(districtPoints, regionalPoints, cmpMap)
-            },
-        ) { baseExtras, pointData ->
-            baseExtras.copy(
-                districtPointsByTeam = pointData.first,
-                regionalPointsByTeam = pointData.second,
-                regionalCmpAdvancementByTeam = pointData.third,
-            )
-        },
-    ) { team, event, ranking, matches, extras ->
-        val isDistrictEvent = event?.district != null
-        val advancementPoints = if (isDistrictEvent) {
-            extras.districtPointsByTeam[teamKey]
-        } else {
-            extras.regionalPointsByTeam[teamKey]
-        }
-        TeamEventDetailUiState(
-            team = team,
-            event = event,
-            ranking = ranking,
-            matches = matches.map { it.withPlayoffAlliances(extras.alliances) },
-            awards = extras.awards,
-            oprs = extras.oprs,
-            alliances = extras.alliances,
-            media = extras.media,
-            pitLocation = extras.pitLocation,
-            advancementPoints = advancementPoints,
-            cmpAdvancement = event?.let {
-                filterRegionalCmpQualificationForEvent(
-                    event = it,
-                    advancement = extras.regionalCmpAdvancementByTeam[teamKey],
-                )
-            },
-        )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), TeamEventDetailUiState())
-
-    init {
-        refreshAll()
-    }
-
-    fun refreshAll() {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                coroutineScope {
-                    launch { try { teamRepository.refreshTeam(teamKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEvent(eventKey) } catch (_: Exception) {} }
-                    launch { try { matchRepository.refreshEventMatches(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventRankings(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventAwards(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventOPRs(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventAlliances(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventDistrictPoints(eventKey) } catch (_: Exception) {} }
-                    launch { try { eventRepository.refreshEventRegionalPoints(eventKey) } catch (_: Exception) {} }
-                    launch {
-                        try {
-                            _regionalCmpAdvancementByTeam.value = eventRepository.fetchRegionalCmpAdvancementByTeam(year)
-                        } catch (_: Exception) {}
-                    }
-                    launch { try { teamRepository.refreshTeamMedia(teamKey, year) } catch (_: Exception) {} }
-                    launch { try { teamRepository.refreshTeamEventPitLocation(teamKey, eventKey) } catch (_: Exception) {} }
-                }
-            } finally {
-                _isRefreshing.value = false
-            }
-        }
-    }
-
-    fun refreshTab(tab: Int) {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                coroutineScope {
-                    when (tab) {
-                        0 -> { // Summary — needs most data for the overview
-                            launch { try { teamRepository.refreshTeam(teamKey) } catch (_: Exception) {} }
-                            launch { try { eventRepository.refreshEvent(eventKey) } catch (_: Exception) {} }
-                            launch { try { matchRepository.refreshEventMatches(eventKey) } catch (_: Exception) {} }
-                            launch { try { eventRepository.refreshEventRankings(eventKey) } catch (_: Exception) {} }
-                            launch { try { eventRepository.refreshEventAlliances(eventKey) } catch (_: Exception) {} }
-                            launch { try { eventRepository.refreshEventAwards(eventKey) } catch (_: Exception) {} }
-                            launch { try { eventRepository.refreshEventDistrictPoints(eventKey) } catch (_: Exception) {} }
-                            launch { try { eventRepository.refreshEventRegionalPoints(eventKey) } catch (_: Exception) {} }
-                            launch {
-                                try {
-                                    _regionalCmpAdvancementByTeam.value = eventRepository.fetchRegionalCmpAdvancementByTeam(year)
-                                } catch (_: Exception) {}
+                matchRepository.observeEventMatches(eventKey).map { matches ->
+                    matches.filter { m -> teamKey in m.redTeamKeys || teamKey in m.blueTeamKeys }
+                },
+                combine(
+                    combine(
+                        eventRepository.observeEventAwards(eventKey).map { awards ->
+                            awards.filter { it.teamKey == teamKey }
+                        },
+                        eventRepository.observeEventOPRs(eventKey),
+                        eventRepository.observeEventAlliances(eventKey),
+                        teamRepository.observeTeamMedia(teamKey, year),
+                        teamRepository.observeTeamEventPitLocation(teamKey, eventKey),
+                    ) { awards, oprs, alliances, media, pitLocation ->
+                        TeamEventExtras(
+                            awards = awards,
+                            oprs = oprs,
+                            alliances = alliances,
+                            media = media,
+                            pitLocation = pitLocation,
+                            districtPointsByTeam = emptyMap(),
+                            regionalPointsByTeam = emptyMap(),
+                            regionalCmpAdvancementByTeam = emptyMap(),
+                        )
+                    },
+                    combine(
+                        eventRepository.observeEventDistrictPoints(eventKey).map {
+                            it.associateBy { points ->
+                                points.teamKey
                             }
-                            launch { try { teamRepository.refreshTeamEventPitLocation(teamKey, eventKey) } catch (_: Exception) {} }
+                        },
+                        eventRepository.observeEventRegionalPoints(eventKey).map {
+                            it.associateBy { points ->
+                                points.teamKey
+                            }
+                        },
+                        regionalCmpAdvancementByTeam,
+                    ) { districtPoints, regionalPoints, cmpMap ->
+                        Triple(districtPoints, regionalPoints, cmpMap)
+                    },
+                ) { baseExtras, pointData ->
+                    baseExtras.copy(
+                        districtPointsByTeam = pointData.first,
+                        regionalPointsByTeam = pointData.second,
+                        regionalCmpAdvancementByTeam = pointData.third,
+                    )
+                },
+            ) { team, event, ranking, matches, extras ->
+                val isDistrictEvent = event?.district != null
+                val advancementPoints =
+                    if (isDistrictEvent) {
+                        extras.districtPointsByTeam[teamKey]
+                    } else {
+                        extras.regionalPointsByTeam[teamKey]
+                    }
+                TeamEventDetailUiState(
+                    team = team,
+                    event = event,
+                    ranking = ranking,
+                    matches = matches.map { it.withPlayoffAlliances(extras.alliances) },
+                    awards = extras.awards,
+                    oprs = extras.oprs,
+                    alliances = extras.alliances,
+                    media = extras.media,
+                    pitLocation = extras.pitLocation,
+                    advancementPoints = advancementPoints,
+                    cmpAdvancement =
+                        event?.let {
+                            filterRegionalCmpQualificationForEvent(
+                                event = it,
+                                advancement = extras.regionalCmpAdvancementByTeam[teamKey],
+                            )
+                        },
+                )
+            }.stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(5000),
+                TeamEventDetailUiState(),
+            )
+
+        init {
+            refreshAll()
+        }
+
+        fun refreshAll() {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    coroutineScope {
+                        launch {
+                            try {
+                                teamRepository.refreshTeam(teamKey)
+                            } catch (_: Exception) {
+                            }
                         }
-                        1 -> { // Matches
-                            launch { try { matchRepository.refreshEventMatches(eventKey) } catch (_: Exception) {} }
+                        launch {
+                            try {
+                                eventRepository.refreshEvent(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
                         }
-                        2 -> { // Media
-                            launch { try { teamRepository.refreshTeamMedia(teamKey, year) } catch (_: Exception) {} }
+                        launch {
+                            try {
+                                matchRepository.refreshEventMatches(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
                         }
-                        3 -> { // Stats
-                            launch { try { eventRepository.refreshEventOPRs(eventKey) } catch (_: Exception) {} }
+                        launch {
+                            try {
+                                eventRepository.refreshEventRankings(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
                         }
-                        4 -> { // Awards
-                            launch { try { eventRepository.refreshEventAwards(eventKey) } catch (_: Exception) {} }
+                        launch {
+                            try {
+                                eventRepository.refreshEventAwards(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventOPRs(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventAlliances(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventDistrictPoints(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                eventRepository.refreshEventRegionalPoints(eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                regionalCmpAdvancementByTeam.value =
+                                    eventRepository.fetchRegionalCmpAdvancementByTeam(year)
+                            } catch (_: Exception) {
+                            }
+                        }
+                        launch {
+                            try {
+                                teamRepository.refreshTeamMedia(teamKey, year)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
+                        }
+                        launch {
+                            try {
+                                teamRepository.refreshTeamEventPitLocation(teamKey, eventKey)
+                            } catch (
+                                _: Exception,
+                            ) {
+                            }
                         }
                     }
+                } finally {
+                    _isRefreshing.value = false
                 }
-            } finally {
-                _isRefreshing.value = false
             }
         }
-    }
 
-    @AssistedFactory
-    interface Factory {
-        fun create(navKey: Screen.TeamEventDetail): TeamEventDetailViewModel
+        fun refreshTab(tab: Int) {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    coroutineScope {
+                        when (tab) {
+                            0 -> { // Summary — needs most data for the overview
+                                launch {
+                                    try {
+                                        teamRepository.refreshTeam(teamKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        eventRepository.refreshEvent(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        matchRepository.refreshEventMatches(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventRankings(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventAlliances(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventAwards(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventDistrictPoints(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventRegionalPoints(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        regionalCmpAdvancementByTeam.value =
+                                            eventRepository.fetchRegionalCmpAdvancementByTeam(year)
+                                    } catch (_: Exception) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        teamRepository.refreshTeamEventPitLocation(
+                                            teamKey,
+                                            eventKey,
+                                        )
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            1 -> { // Matches
+                                launch {
+                                    try {
+                                        matchRepository.refreshEventMatches(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            2 -> { // Media
+                                launch {
+                                    try {
+                                        teamRepository.refreshTeamMedia(teamKey, year)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            3 -> { // Stats
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventOPRs(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            4 -> { // Awards
+                                launch {
+                                    try {
+                                        eventRepository.refreshEventAwards(eventKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } finally {
+                    _isRefreshing.value = false
+                }
+            }
+        }
+
+        @AssistedFactory
+        interface Factory {
+            fun create(navKey: Screen.TeamEventDetail): TeamEventDetailViewModel
+        }
     }
-}
 
 private fun filterRegionalCmpQualificationForEvent(
     event: Event,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -22,8 +22,8 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.NotificationsNone
@@ -135,7 +135,15 @@ fun TeamDetailScreen(
 
     if (showNotificationSheet) {
         NotificationPreferencesSheet(
-            displayName = uiState.team?.let { "Team ${it.number}" + (it.nickname?.let { n -> " - $n" } ?: "") } ?: "Team",
+            displayName =
+                uiState.team?.let {
+                    "Team ${it.number}" + (
+                        it.nickname?.let { n ->
+                            " - $n"
+                        } ?: ""
+                    )
+                }
+                    ?: "Team",
             modelType = ModelType.TEAM,
             isFavorite = isFavorite,
             currentNotifications = subscription?.notifications ?: emptyList(),
@@ -159,7 +167,14 @@ fun TeamDetailScreen(
                             onYearSelected = viewModel::selectYear,
                             title = {
                                 Text(
-                                    text = if (team != null) "${team.number} - ${team.nickname ?: ""}" else "Team",
+                                    text =
+                                        if (team !=
+                                            null
+                                        ) {
+                                            "${team.number} - ${team.nickname ?: ""}"
+                                        } else {
+                                            "Team"
+                                        },
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                 )
@@ -170,7 +185,7 @@ fun TeamDetailScreen(
                         IconButton(onClick = onNavigateUp) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = "Back"
+                                contentDescription = "Back",
                             )
                         }
                     },
@@ -184,14 +199,29 @@ fun TeamDetailScreen(
                         }) {
                             val hasSubscription = subscription?.notifications?.isNotEmpty() == true
                             Icon(
-                                imageVector = if (hasSubscription) Icons.Filled.Notifications else Icons.Outlined.NotificationsNone,
+                                imageVector =
+                                    if (hasSubscription) {
+                                        Icons.Filled.Notifications
+                                    } else {
+                                        Icons.Outlined.NotificationsNone
+                                    },
                                 contentDescription = "Notification preferences",
                             )
                         }
                         IconButton(onClick = viewModel::toggleFavorite) {
                             Icon(
-                                imageVector = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarBorder,
-                                contentDescription = if (isFavorite) "Remove from favorites" else "Add to favorites",
+                                imageVector =
+                                    if (isFavorite) {
+                                        Icons.Filled.Star
+                                    } else {
+                                        Icons.Outlined.StarBorder
+                                    },
+                                contentDescription =
+                                    if (isFavorite) {
+                                        "Remove from favorites"
+                                    } else {
+                                        "Add to favorites"
+                                    },
                             )
                         }
                         var menuExpanded by remember { mutableStateOf(false) }
@@ -209,14 +239,18 @@ fun TeamDetailScreen(
                                         leadingIcon = {
                                             Icon(
                                                 Icons.Filled.Share,
-                                                contentDescription = null
+                                                contentDescription = null,
                                             )
                                         },
                                         onClick = {
                                             menuExpanded = false
                                             context.shareTbaUrl(
-                                                title = "Team ${team.number} - ${team.nickname ?: ""}",
-                                                url = "https://www.thebluealliance.com/team/${team.number}",
+                                                title =
+                                                    "Team ${team.number} - " +
+                                                        (team.nickname ?: ""),
+                                                url =
+                                                    "https://www.thebluealliance.com/team/" +
+                                                        "${team.number}",
                                             )
                                         },
                                     )
@@ -226,7 +260,10 @@ fun TeamDetailScreen(
                                         text = { Text("Add to home screen") },
                                         leadingIcon = {
                                             Icon(
-                                                painter = painterResource(R.drawable.ic_add_to_home_screen),
+                                                painter =
+                                                    painterResource(
+                                                        R.drawable.ic_add_to_home_screen,
+                                                    ),
                                                 contentDescription = null,
                                             )
                                         },
@@ -245,11 +282,24 @@ fun TeamDetailScreen(
                     TABS.forEachIndexed { index, title ->
                         Tab(
                             selected = pagerState.currentPage == index,
-                            onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
+                            onClick = {
+                                coroutineScope.launch {
+                                    pagerState.animateScrollToPage(
+                                        index,
+                                    )
+                                }
+                            },
                             text = {
                                 Text(
                                     text = title,
-                                    color = if (pagerState.currentPage == index) Color.White else Color.White.copy(alpha = 0.7f)
+                                    color =
+                                        if (pagerState.currentPage ==
+                                            index
+                                        ) {
+                                            Color.White
+                                        } else {
+                                            Color.White.copy(alpha = 0.7f)
+                                        },
                                 )
                             },
                         )
@@ -261,8 +311,10 @@ fun TeamDetailScreen(
         val bottomPadding = PaddingValues(bottom = innerPadding.calculateBottomPadding())
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier.fillMaxSize()
-                .padding(top = innerPadding.calculateTopPadding()),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(top = innerPadding.calculateTopPadding()),
         ) { page ->
             PullToRefreshBox(
                 isRefreshing = isRefreshing && uiState.team != null,
@@ -270,25 +322,31 @@ fun TeamDetailScreen(
                 modifier = Modifier.fillMaxSize(),
             ) {
                 when (page) {
-                    TeamDetailTabs.INFO -> InfoTab(
-                        team = uiState.team,
-                        media = uiState.media,
-                        innerPadding = bottomPadding,
-                    )
-                    TeamDetailTabs.EVENTS -> EventsTab(
-                        events = uiState.events,
-                        selectedYear = selectedYear,
-                        onNavigateToEvent = { eventKey ->
-                            val teamKey = uiState.team?.key
-                            if (teamKey != null) onNavigateToTeamEvent(teamKey, eventKey)
-                            else onNavigateToEvent(eventKey)
-                        },
-                        innerPadding = bottomPadding,
-                    )
-                    TeamDetailTabs.MEDIA -> MediaTab(
-                        media = uiState.media,
-                        innerPadding = bottomPadding,
-                    )
+                    TeamDetailTabs.INFO ->
+                        InfoTab(
+                            team = uiState.team,
+                            media = uiState.media,
+                            innerPadding = bottomPadding,
+                        )
+                    TeamDetailTabs.EVENTS ->
+                        EventsTab(
+                            events = uiState.events,
+                            selectedYear = selectedYear,
+                            onNavigateToEvent = { eventKey ->
+                                val teamKey = uiState.team?.key
+                                if (teamKey != null) {
+                                    onNavigateToTeamEvent(teamKey, eventKey)
+                                } else {
+                                    onNavigateToEvent(eventKey)
+                                }
+                            },
+                            innerPadding = bottomPadding,
+                        )
+                    TeamDetailTabs.MEDIA ->
+                        MediaTab(
+                            media = uiState.media,
+                            innerPadding = bottomPadding,
+                        )
                 }
             }
         }
@@ -309,31 +367,35 @@ private fun InfoTab(
     }
     val avatar = media?.firstOrNull { it.isAvatar }
     LazyColumn(
-        modifier = Modifier.fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .padding(16.dp),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(16.dp),
         contentPadding = innerPadding,
     ) {
         item {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 if (avatar != null) {
-                    val bitmap = remember(avatar.base64Image) {
-                        try {
-                            val bytes = Base64.decode(avatar.base64Image, Base64.DEFAULT)
-                            BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-                        } catch (_: Exception) {
-                            null
+                    val bitmap =
+                        remember(avatar.base64Image) {
+                            try {
+                                val bytes = Base64.decode(avatar.base64Image, Base64.DEFAULT)
+                                BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                            } catch (_: Exception) {
+                                null
+                            }
                         }
-                    }
                     if (bitmap != null) {
                         var showRed by remember { mutableStateOf(false) }
                         val bgColor = if (showRed) FrcRed else FrcBlue
                         Box(
-                            modifier = Modifier
-                                .size(64.dp)
-                                .clip(RoundedCornerShape(8.dp))
-                                .background(bgColor)
-                                .clickable { showRed = !showRed },
+                            modifier =
+                                Modifier
+                                    .size(64.dp)
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .background(bgColor)
+                                    .clickable { showRed = !showRed },
                             contentAlignment = Alignment.Center,
                         ) {
                             Image(
@@ -407,7 +469,7 @@ private fun EventsTab(
     } else if (events.isEmpty()) {
         EmptyBox(
             modifier = Modifier.padding(innerPadding),
-            message = "No events for $selectedYear"
+            message = "No events for $selectedYear",
         )
     } else {
         LazyColumn(
@@ -423,4 +485,3 @@ private fun EventsTab(
 
 private val FrcBlue = Color(0xFF0066B3)
 private val FrcRed = Color(0xFFED1C24)
-

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailViewModel.kt
@@ -10,8 +10,8 @@ import com.thebluealliance.android.data.repository.TeamRepository
 import com.thebluealliance.android.domain.model.Favorite
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.domain.model.Subscription
-import com.thebluealliance.android.shortcuts.TBAShortcutManager
 import com.thebluealliance.android.navigation.Screen
+import com.thebluealliance.android.shortcuts.TBAShortcutManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -33,188 +33,250 @@ import java.util.Calendar
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel(assistedFactory = TeamDetailViewModel.Factory::class)
-class TeamDetailViewModel @AssistedInject constructor(
-    @Assisted val navKey: Screen.TeamDetail,
-    private val teamRepository: TeamRepository,
-    private val eventRepository: EventRepository,
-    private val myTBARepository: MyTBARepository,
-    private val authRepository: AuthRepository,
-    private val tbaApi: TbaApi,
-    private val shortcutManager: TBAShortcutManager,
-) : ViewModel() {
-
-    private val teamKey: String = navKey.teamKey.let { key ->
-        // Deep links from thebluealliance.com use /team/177 (number only),
-        // but the API/DB key format is "frc177".
-        if (key.all { it.isDigit() }) "frc$key" else key
-    }
-
-    private val _selectedYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
-    val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
-
-    private val _yearsParticipated = MutableStateFlow<List<Int>>(emptyList())
-    val yearsParticipated: StateFlow<List<Int>> = _yearsParticipated.asStateFlow()
-
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
-
-    val uiState: StateFlow<TeamDetailUiState> = combine(
-        teamRepository.observeTeam(teamKey),
-        _selectedYear.flatMapLatest { year ->
-            eventRepository.observeTeamEvents(teamKey, year)
-        },
-        _selectedYear.flatMapLatest { year ->
-            teamRepository.observeTeamMedia(teamKey, year)
-        },
-    ) { team, events, media ->
-        TeamDetailUiState(
-            team = team,
-            events = events,
-            media = media,
-        )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), TeamDetailUiState())
-
-    val isFavorite: StateFlow<Boolean> = myTBARepository.isFavorite(teamKey, ModelType.TEAM)
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
-
-    val subscription: StateFlow<Subscription?> = myTBARepository
-        .observeSubscription(teamKey, ModelType.TEAM)
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
-
-    private val _showSignInPrompt = MutableSharedFlow<Unit>()
-    val showSignInPrompt: SharedFlow<Unit> = _showSignInPrompt.asSharedFlow()
-
-    private val _userMessage = MutableSharedFlow<String>()
-    val userMessage: SharedFlow<String> = _userMessage.asSharedFlow()
-
-    init {
-        fetchYearsParticipated()
-        refreshAll()
-    }
-
-    private fun fetchYearsParticipated() {
-        viewModelScope.launch {
-            try {
-                val years = tbaApi.getTeamYearsParticipated(teamKey).sortedDescending()
-                _yearsParticipated.value = years
-                if (years.isNotEmpty()) {
-                    _selectedYear.value = years.first()
-                    refreshYearData()
-                }
-            } catch (_: Exception) {
-                // Fallback: generate year range from rookieYear if available
-                buildYearsFromRookieYear()
+class TeamDetailViewModel
+    @AssistedInject
+    constructor(
+        @Assisted val navKey: Screen.TeamDetail,
+        private val teamRepository: TeamRepository,
+        private val eventRepository: EventRepository,
+        private val myTBARepository: MyTBARepository,
+        private val authRepository: AuthRepository,
+        private val tbaApi: TbaApi,
+        private val shortcutManager: TBAShortcutManager,
+    ) : ViewModel() {
+        private val teamKey: String =
+            navKey.teamKey.let { key ->
+                // Deep links from thebluealliance.com use /team/177 (number only),
+                // but the API/DB key format is "frc177".
+                if (key.all { it.isDigit() }) "frc$key" else key
             }
-        }
-    }
 
-    private fun buildYearsFromRookieYear() {
-        viewModelScope.launch {
-            teamRepository.observeTeam(teamKey).collect { team ->
-                if (team != null && _yearsParticipated.value.isEmpty()) {
-                    val rookieYear = team.rookieYear ?: return@collect
-                    val maxYear = Calendar.getInstance().get(Calendar.YEAR)
-                    val years = (maxYear downTo rookieYear).toList()
+        private val _selectedYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
+        val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
+
+        private val _yearsParticipated = MutableStateFlow<List<Int>>(emptyList())
+        val yearsParticipated: StateFlow<List<Int>> = _yearsParticipated.asStateFlow()
+
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+        val uiState: StateFlow<TeamDetailUiState> =
+            combine(
+                teamRepository.observeTeam(teamKey),
+                _selectedYear.flatMapLatest { year ->
+                    eventRepository.observeTeamEvents(teamKey, year)
+                },
+                _selectedYear.flatMapLatest { year ->
+                    teamRepository.observeTeamMedia(teamKey, year)
+                },
+            ) { team, events, media ->
+                TeamDetailUiState(
+                    team = team,
+                    events = events,
+                    media = media,
+                )
+            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), TeamDetailUiState())
+
+        val isFavorite: StateFlow<Boolean> =
+            myTBARepository
+                .isFavorite(teamKey, ModelType.TEAM)
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+        val subscription: StateFlow<Subscription?> =
+            myTBARepository
+                .observeSubscription(teamKey, ModelType.TEAM)
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+        private val _showSignInPrompt = MutableSharedFlow<Unit>()
+        val showSignInPrompt: SharedFlow<Unit> = _showSignInPrompt.asSharedFlow()
+
+        private val _userMessage = MutableSharedFlow<String>()
+        val userMessage: SharedFlow<String> = _userMessage.asSharedFlow()
+
+        init {
+            fetchYearsParticipated()
+            refreshAll()
+        }
+
+        private fun fetchYearsParticipated() {
+            viewModelScope.launch {
+                try {
+                    val years = tbaApi.getTeamYearsParticipated(teamKey).sortedDescending()
                     _yearsParticipated.value = years
-                    _selectedYear.value = years.first()
-                    refreshYearData()
+                    if (years.isNotEmpty()) {
+                        _selectedYear.value = years.first()
+                        refreshYearData()
+                    }
+                } catch (_: Exception) {
+                    // Fallback: generate year range from rookieYear if available
+                    buildYearsFromRookieYear()
                 }
             }
         }
-    }
 
-    fun selectYear(year: Int) {
-        _selectedYear.value = year
-        viewModelScope.launch { refreshYearData() }
-    }
-
-    fun toggleFavorite() {
-        viewModelScope.launch {
-            if (!authRepository.isSignedIn()) {
-                _showSignInPrompt.emit(Unit)
-                return@launch
-            }
-            try {
-                if (isFavorite.value) {
-                    myTBARepository.removeFavorite(teamKey, ModelType.TEAM)
-                } else {
-                    myTBARepository.addFavorite(teamKey, ModelType.TEAM)
-                }
-            } catch (_: Exception) {}
-        }
-    }
-
-    fun updatePreferences(favorite: Boolean, notifications: List<String>) {
-        viewModelScope.launch {
-            try {
-                myTBARepository.updatePreferences(teamKey, ModelType.TEAM, favorite, notifications)
-            } catch (_: Exception) {
-                _userMessage.emit("Failed to save notification preferences")
-            }
-        }
-    }
-
-    val canPinShortcuts: Boolean = shortcutManager.canPinShortcuts()
-
-    fun requestPinShortcut() {
-        viewModelScope.launch {
-            shortcutManager.requestPinShortcut(
-                Favorite(modelKey = teamKey, modelType = ModelType.TEAM)
-            )
-        }
-    }
-
-    fun isSignedIn(): Boolean = authRepository.isSignedIn()
-
-    fun refreshAll() {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                coroutineScope {
-                    launch { try { teamRepository.refreshTeam(teamKey) } catch (_: Exception) {} }
-                    launch { refreshYearData() }
-                }
-            } finally {
-                _isRefreshing.value = false
-            }
-        }
-    }
-
-    fun refreshTab(tab: Int) {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                val year = _selectedYear.value
-                coroutineScope {
-                    when (tab) {
-                        0 -> { // Info
-                            launch { try { teamRepository.refreshTeam(teamKey) } catch (_: Exception) {} }
-                            launch { try { teamRepository.refreshTeamMedia(teamKey, year) } catch (_: Exception) {} }
-                        }
-                        1 -> { // Events
-                            launch { try { eventRepository.refreshTeamEvents(teamKey, year) } catch (_: Exception) {} }
-                        }
-                        2 -> { // Media
-                            launch { try { teamRepository.refreshTeamMedia(teamKey, year) } catch (_: Exception) {} }
-                        }
+        private fun buildYearsFromRookieYear() {
+            viewModelScope.launch {
+                teamRepository.observeTeam(teamKey).collect { team ->
+                    if (team != null && _yearsParticipated.value.isEmpty()) {
+                        val rookieYear = team.rookieYear ?: return@collect
+                        val maxYear = Calendar.getInstance().get(Calendar.YEAR)
+                        val years = (maxYear downTo rookieYear).toList()
+                        _yearsParticipated.value = years
+                        _selectedYear.value = years.first()
+                        refreshYearData()
                     }
                 }
-            } finally {
-                _isRefreshing.value = false
             }
         }
-    }
 
-    private suspend fun refreshYearData() {
-        val year = _selectedYear.value
-        coroutineScope {
-            launch { try { eventRepository.refreshTeamEvents(teamKey, year) } catch (_: Exception) {} }
-            launch { try { teamRepository.refreshTeamMedia(teamKey, year) } catch (_: Exception) {} }
+        fun selectYear(year: Int) {
+            _selectedYear.value = year
+            viewModelScope.launch { refreshYearData() }
+        }
+
+        fun toggleFavorite() {
+            viewModelScope.launch {
+                if (!authRepository.isSignedIn()) {
+                    _showSignInPrompt.emit(Unit)
+                    return@launch
+                }
+                try {
+                    if (isFavorite.value) {
+                        myTBARepository.removeFavorite(teamKey, ModelType.TEAM)
+                    } else {
+                        myTBARepository.addFavorite(teamKey, ModelType.TEAM)
+                    }
+                } catch (_: Exception) {
+                }
+            }
+        }
+
+        fun updatePreferences(
+            favorite: Boolean,
+            notifications: List<String>,
+        ) {
+            viewModelScope.launch {
+                try {
+                    myTBARepository.updatePreferences(
+                        teamKey,
+                        ModelType.TEAM,
+                        favorite,
+                        notifications,
+                    )
+                } catch (_: Exception) {
+                    _userMessage.emit("Failed to save notification preferences")
+                }
+            }
+        }
+
+        val canPinShortcuts: Boolean = shortcutManager.canPinShortcuts()
+
+        fun requestPinShortcut() {
+            viewModelScope.launch {
+                shortcutManager.requestPinShortcut(
+                    Favorite(modelKey = teamKey, modelType = ModelType.TEAM),
+                )
+            }
+        }
+
+        fun isSignedIn(): Boolean = authRepository.isSignedIn()
+
+        fun refreshAll() {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    coroutineScope {
+                        launch {
+                            try {
+                                teamRepository.refreshTeam(teamKey)
+                            } catch (_: Exception) {
+                            }
+                        }
+                        launch { refreshYearData() }
+                    }
+                } finally {
+                    _isRefreshing.value = false
+                }
+            }
+        }
+
+        fun refreshTab(tab: Int) {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    val year = _selectedYear.value
+                    coroutineScope {
+                        when (tab) {
+                            0 -> { // Info
+                                launch {
+                                    try {
+                                        teamRepository.refreshTeam(teamKey)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                                launch {
+                                    try {
+                                        teamRepository.refreshTeamMedia(teamKey, year)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            1 -> { // Events
+                                launch {
+                                    try {
+                                        eventRepository.refreshTeamEvents(teamKey, year)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                            2 -> { // Media
+                                launch {
+                                    try {
+                                        teamRepository.refreshTeamMedia(teamKey, year)
+                                    } catch (
+                                        _: Exception,
+                                    ) {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } finally {
+                    _isRefreshing.value = false
+                }
+            }
+        }
+
+        private suspend fun refreshYearData() {
+            val year = _selectedYear.value
+            coroutineScope {
+                launch {
+                    try {
+                        eventRepository.refreshTeamEvents(teamKey, year)
+                    } catch (
+                        _: Exception,
+                    ) {
+                    }
+                }
+                launch {
+                    try {
+                        teamRepository.refreshTeamMedia(teamKey, year)
+                    } catch (
+                        _: Exception,
+                    ) {
+                    }
+                }
+            }
+        }
+
+        @AssistedFactory
+        interface Factory {
+            fun create(navKey: Screen.TeamDetail): TeamDetailViewModel
         }
     }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(navKey: Screen.TeamDetail): TeamDetailViewModel
-    }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsScreen.kt
@@ -2,17 +2,21 @@ package com.thebluealliance.android.ui.teams
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -25,18 +29,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.ui.components.FastScrollbar
 import com.thebluealliance.android.ui.components.SectionHeader
 import com.thebluealliance.android.ui.components.SectionHeaderInfo
-import com.thebluealliance.android.ui.components.TeamRow
 import com.thebluealliance.android.ui.components.TBATopAppBar
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import com.thebluealliance.android.ui.components.TeamRow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
@@ -69,16 +68,17 @@ fun TeamsScreen(
                         Icon(Icons.Default.Search, contentDescription = "Search")
                     }
                 },
-                showLamp = true
+                showLamp = true,
             )
         },
     ) { innerPadding ->
         PullToRefreshBox(
             isRefreshing = isRefreshing && uiState !is TeamsUiState.Loading,
             onRefresh = viewModel::refreshTeams,
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize(),
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize(),
         ) {
             when (val state = uiState) {
                 is TeamsUiState.Loading -> {
@@ -95,38 +95,54 @@ fun TeamsScreen(
                             }
                         }
                     } else {
-                        val favoriteTeams = if (state.favoriteTeamKeys.isNotEmpty()) {
-                            state.teams.filter { it.key in state.favoriteTeamKeys }
-                        } else {
-                            emptyList()
-                        }
+                        val favoriteTeams =
+                            if (state.favoriteTeamKeys.isNotEmpty()) {
+                                state.teams.filter { it.key in state.favoriteTeamKeys }
+                            } else {
+                                emptyList()
+                            }
 
                         val hasFavorites = favoriteTeams.isNotEmpty()
 
-                        val headerInfos = remember(hasFavorites, favoriteTeams.size, state.teams.size) {
-                            if (!hasFavorites) {
-                                emptyList()
-                            } else {
-                                buildList {
-                                    var index = 0
-                                    add(SectionHeaderInfo("favorites_header", "Favorites", index))
-                                    index += 1 + favoriteTeams.size
-                                    add(SectionHeaderInfo("all_teams_header", "All teams", index))
+                        val headerInfos =
+                            remember(hasFavorites, favoriteTeams.size, state.teams.size) {
+                                if (!hasFavorites) {
+                                    emptyList()
+                                } else {
+                                    buildList {
+                                        var index = 0
+                                        add(
+                                            SectionHeaderInfo(
+                                                "favorites_header",
+                                                "Favorites",
+                                                index,
+                                            ),
+                                        )
+                                        index += 1 + favoriteTeams.size
+                                        add(
+                                            SectionHeaderInfo(
+                                                "all_teams_header",
+                                                "All teams",
+                                                index,
+                                            ),
+                                        )
+                                    }
                                 }
                             }
-                        }
 
-                        val headerKeys = remember(headerInfos) {
-                            headerInfos.map { it.key }.toSet()
-                        }
+                        val headerKeys =
+                            remember(headerInfos) {
+                                headerInfos.map { it.key }.toSet()
+                            }
 
                         val stuckHeaderKey by remember(headerKeys) {
                             derivedStateOf {
-                                val stuck = listState.layoutInfo.visibleItemsInfo
-                                    .firstOrNull { item ->
-                                        val key = item.key as? String
-                                        key != null && key in headerKeys && item.offset <= 0
-                                    }?.key as? String
+                                val stuck =
+                                    listState.layoutInfo.visibleItemsInfo
+                                        .firstOrNull { item ->
+                                            val key = item.key as? String
+                                            key != null && key in headerKeys && item.offset <= 0
+                                        }?.key as? String
                                 stuck ?: headerInfos.firstOrNull()?.key
                             }
                         }
@@ -134,9 +150,10 @@ fun TeamsScreen(
                         FastScrollbar(listState = listState) {
                             LazyColumn(
                                 state = listState,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .background(MaterialTheme.colorScheme.background)
+                                modifier =
+                                    Modifier
+                                        .fillMaxSize()
+                                        .background(MaterialTheme.colorScheme.background),
                             ) {
                                 if (hasFavorites) {
                                     stickyHeader(key = "favorites_header") {
@@ -152,7 +169,10 @@ fun TeamsScreen(
                                         )
                                     }
                                     items(favoriteTeams, key = { "fav_${it.key}" }) { team ->
-                                        TeamRow(team = team, onClick = { onNavigateToTeam(team.key) })
+                                        TeamRow(
+                                            team = team,
+                                            onClick = { onNavigateToTeam(team.key) },
+                                        )
                                     }
                                     stickyHeader(key = "all_teams_header") {
                                         SectionHeader(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsUiState.kt
@@ -4,6 +4,7 @@ import com.thebluealliance.android.domain.model.Team
 
 sealed interface TeamsUiState {
     data object Loading : TeamsUiState
+
     data class Success(
         val teams: List<Team>,
         val favoriteTeamKeys: Set<String> = emptySet(),

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsViewModel.kt
@@ -17,48 +17,60 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class TeamsViewModel @Inject constructor(
-    private val teamRepository: TeamRepository,
-    private val myTBARepository: MyTBARepository,
-    private val authRepository: AuthRepository,
-) : ViewModel() {
+class TeamsViewModel
+    @Inject
+    constructor(
+        private val teamRepository: TeamRepository,
+        private val myTBARepository: MyTBARepository,
+        private val authRepository: AuthRepository,
+    ) : ViewModel() {
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+        val uiState: StateFlow<TeamsUiState> =
+            combine(
+                teamRepository.observeAllTeams(),
+                myTBARepository.observeFavorites(),
+            ) { teams, favorites ->
+                val favoriteTeamKeys =
+                    favorites
+                        .filter { it.modelType == ModelType.TEAM }
+                        .map { it.modelKey }
+                        .toSet()
+                TeamsUiState.Success(teams = teams, favoriteTeamKeys = favoriteTeamKeys)
+            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), TeamsUiState.Loading)
 
-    val uiState: StateFlow<TeamsUiState> = combine(
-        teamRepository.observeAllTeams(),
-        myTBARepository.observeFavorites(),
-    ) { teams, favorites ->
-        val favoriteTeamKeys = favorites
-            .filter { it.modelType == ModelType.TEAM }
-            .map { it.modelKey }
-            .toSet()
-        TeamsUiState.Success(teams = teams, favoriteTeamKeys = favoriteTeamKeys)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), TeamsUiState.Loading)
-
-    init {
-        refreshTeams()
-        refreshFavorites()
-    }
-
-    private fun refreshFavorites() {
-        viewModelScope.launch {
-            if (!authRepository.isSignedIn()) return@launch
-            try { myTBARepository.refreshFavorites() } catch (_: Exception) {}
+        init {
+            refreshTeams()
+            refreshFavorites()
         }
-    }
 
-    fun refreshTeams() {
-        viewModelScope.launch {
-            _isRefreshing.value = true
-            try {
-                (0..19).map { page ->
-                    launch { try { teamRepository.refreshTeamsPage(page) } catch (_: Exception) {} }
-                }.forEach { it.join() }
-            } finally {
-                _isRefreshing.value = false
+        private fun refreshFavorites() {
+            viewModelScope.launch {
+                if (!authRepository.isSignedIn()) return@launch
+                try {
+                    myTBARepository.refreshFavorites()
+                } catch (_: Exception) {
+                }
+            }
+        }
+
+        fun refreshTeams() {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    (0..19)
+                        .map { page ->
+                            launch {
+                                try {
+                                    teamRepository.refreshTeamsPage(page)
+                                } catch (_: Exception) {
+                                }
+                            }
+                        }.forEach { it.join() }
+                } finally {
+                    _isRefreshing.value = false
+                }
             }
         }
     }
-}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/theme/Theme.kt
@@ -12,28 +12,30 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 // Indigo tonal scale — TBA brand palette
-val TBABlue = Color(0xFF3F51B5)           // Indigo 500 — canonical TBA brand color
-val TBAIndigo400 = Color(0xFF5C6BC0)      // Indigo 400 — section headers
-private val TBABlueDark = Color(0xFF303F9F)    // Indigo 700 — dark-mode container
-private val TBABlueLight = Color(0xFF9FA8DA)   // Indigo 200 — dark-mode primary
-private val TBAPastelBlue = Color(0xFFC5CAE9)  // Indigo 100 — light-mode primaryContainer
-private val TBAIndigo900 = Color(0xFF1A237E)   // Indigo 900 — onPrimaryContainer
+val TBABlue = Color(0xFF3F51B5) // Indigo 500 — canonical TBA brand color
+val TBAIndigo400 = Color(0xFF5C6BC0) // Indigo 400 — section headers
+private val TBABlueDark = Color(0xFF303F9F) // Indigo 700 — dark-mode container
+private val TBABlueLight = Color(0xFF9FA8DA) // Indigo 200 — dark-mode primary
+private val TBAPastelBlue = Color(0xFFC5CAE9) // Indigo 100 — light-mode primaryContainer
+private val TBAIndigo900 = Color(0xFF1A237E) // Indigo 900 — onPrimaryContainer
 
-private val LightColorScheme = lightColorScheme(
-    primary = TBABlue,
-    onPrimary = Color.White,
-    primaryContainer = TBAPastelBlue,
-    onPrimaryContainer = TBAIndigo900,
-    surfaceTint = TBABlue,
-)
+private val LightColorScheme =
+    lightColorScheme(
+        primary = TBABlue,
+        onPrimary = Color.White,
+        primaryContainer = TBAPastelBlue,
+        onPrimaryContainer = TBAIndigo900,
+        surfaceTint = TBABlue,
+    )
 
-private val DarkColorScheme = darkColorScheme(
-    primary = TBABlueLight,
-    onPrimary = Color(0xFF00174D),
-    primaryContainer = TBABlueDark,
-    onPrimaryContainer = TBAPastelBlue,
-    surfaceTint = TBABlueLight,
-)
+private val DarkColorScheme =
+    darkColorScheme(
+        primary = TBABlueLight,
+        onPrimary = Color(0xFF00174D),
+        primaryContainer = TBABlueDark,
+        onPrimaryContainer = TBAPastelBlue,
+        surfaceTint = TBABlueLight,
+    )
 
 @Composable
 fun TBATheme(
@@ -41,14 +43,15 @@ fun TBATheme(
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit,
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+    val colorScheme =
+        when {
+            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            }
+            darkTheme -> DarkColorScheme
+            else -> LightColorScheme
         }
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
 
     MaterialTheme(
         colorScheme = colorScheme,

--- a/app/src/main/kotlin/com/thebluealliance/android/util/BitmapExtension.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/util/BitmapExtension.kt
@@ -16,9 +16,10 @@ import androidx.core.graphics.createBitmap
 fun Bitmap.addRoundedCorners(radius: Float): Bitmap {
     val output = createBitmap(width, height)
     val canvas = Canvas(output)
-    val paint = Paint().apply {
-        isAntiAlias = true
-    }
+    val paint =
+        Paint().apply {
+            isAntiAlias = true
+        }
     val rect = Rect(0, 0, width, height)
     val rectF = RectF(rect)
 

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidget.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidget.kt
@@ -21,8 +21,6 @@ import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.PreviewSizeMode
 import androidx.glance.appwidget.SizeMode
-import androidx.glance.preview.ExperimentalGlancePreviewApi
-import androidx.glance.preview.Preview
 import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
@@ -38,6 +36,8 @@ import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
 import androidx.glance.layout.width
+import androidx.glance.preview.ExperimentalGlancePreviewApi
+import androidx.glance.preview.Preview
 import androidx.glance.state.GlanceStateDefinition
 import androidx.glance.state.PreferencesGlanceStateDefinition
 import androidx.glance.text.FontWeight
@@ -60,27 +60,30 @@ import com.thebluealliance.android.R
  * - FULL (4x2):     Full layout with last match + next match + footer
  */
 class TeamTrackingWidget : GlanceAppWidget() {
-
     override val stateDefinition: GlanceStateDefinition<*> = PreferencesGlanceStateDefinition
 
     companion object {
-        private val TINY = DpSize(60.dp, 60.dp)       // 1x1
-        private val MINIMAL = DpSize(110.dp, 60.dp)   // 2x1
-        private val SQUARE = DpSize(110.dp, 110.dp)   // 2x2
-        private val COMPACT = DpSize(250.dp, 60.dp)   // 4x1
-        private val FULL = DpSize(250.dp, 110.dp)     // 4x2
-
+        private val TINY = DpSize(60.dp, 60.dp) // 1x1
+        private val MINIMAL = DpSize(110.dp, 60.dp) // 2x1
+        private val SQUARE = DpSize(110.dp, 110.dp) // 2x2
+        private val COMPACT = DpSize(250.dp, 60.dp) // 4x1
+        private val FULL = DpSize(250.dp, 110.dp) // 4x2
     }
 
-    override val sizeMode = SizeMode.Responsive(
-        setOf(TINY, MINIMAL, SQUARE, COMPACT, FULL)
-    )
+    override val sizeMode =
+        SizeMode.Responsive(
+            setOf(TINY, MINIMAL, SQUARE, COMPACT, FULL),
+        )
 
-    override val previewSizeMode: PreviewSizeMode = SizeMode.Responsive(
-        setOf(TINY, MINIMAL, SQUARE, COMPACT, FULL)
-    )
+    override val previewSizeMode: PreviewSizeMode =
+        SizeMode.Responsive(
+            setOf(TINY, MINIMAL, SQUARE, COMPACT, FULL),
+        )
 
-    override suspend fun provideGlance(context: Context, id: GlanceId) {
+    override suspend fun provideGlance(
+        context: Context,
+        id: GlanceId,
+    ) {
         provideContent {
             GlanceTheme {
                 val prefs = currentState<androidx.datastore.preferences.core.Preferences>()
@@ -90,7 +93,10 @@ class TeamTrackingWidget : GlanceAppWidget() {
         }
     }
 
-    override suspend fun providePreview(context: Context, widgetCategory: Int) {
+    override suspend fun providePreview(
+        context: Context,
+        widgetCategory: Int,
+    ) {
         provideContent {
             GlanceTheme {
                 WidgetContent(WidgetData.sampleData())
@@ -99,24 +105,29 @@ class TeamTrackingWidget : GlanceAppWidget() {
     }
 
     @Composable
-    private fun WidgetContent(data: WidgetData, forcedSize: String? = null) {
+    private fun WidgetContent(
+        data: WidgetData,
+        forcedSize: String? = null,
+    ) {
         val size = LocalSize.current
 
         // Debug override: force a specific size tier regardless of actual widget size
-        val tier = when (forcedSize) {
-            "4x2" -> "full"
-            "4x1" -> "compact"
-            "2x2" -> "square"
-            "2x1" -> "minimal"
-            "1x1" -> "tiny"
-            else -> when {
-                size.width >= 250.dp && size.height >= 110.dp -> "full"
-                size.width >= 250.dp -> "compact"
-                size.width >= 110.dp && size.height >= 110.dp -> "square"
-                size.width >= 110.dp -> "minimal"
-                else -> "tiny"
+        val tier =
+            when (forcedSize) {
+                "4x2" -> "full"
+                "4x1" -> "compact"
+                "2x2" -> "square"
+                "2x1" -> "minimal"
+                "1x1" -> "tiny"
+                else ->
+                    when {
+                        size.width >= 250.dp && size.height >= 110.dp -> "full"
+                        size.width >= 250.dp -> "compact"
+                        size.width >= 110.dp && size.height >= 110.dp -> "square"
+                        size.width >= 110.dp -> "minimal"
+                        else -> "tiny"
+                    }
             }
-        }
 
         when (tier) {
             "full" -> FullLayout(data)
@@ -155,7 +166,8 @@ class TeamTrackingWidget : GlanceAppWidget() {
             nextRedTeams = prefs[TeamTrackingWidgetKeys.NEXT_MATCH_RED_TEAMS],
             nextBlueTeams = prefs[TeamTrackingWidgetKeys.NEXT_MATCH_BLUE_TEAMS],
             nextMatchTime = prefs[TeamTrackingWidgetKeys.NEXT_MATCH_TIME],
-            nextTimeIsEstimate = prefs[TeamTrackingWidgetKeys.NEXT_MATCH_TIME_IS_ESTIMATE] == "true",
+            nextTimeIsEstimate =
+                prefs[TeamTrackingWidgetKeys.NEXT_MATCH_TIME_IS_ESTIMATE] == "true",
         )
     }
 
@@ -188,113 +200,139 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 try {
                     val bytes = Base64.decode(it, Base64.DEFAULT)
                     BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-                } catch (_: Exception) { null }
+                } catch (_: Exception) {
+                    null
+                }
             }
         }
 
         val teamLabel: String
-            get() = if (teamNumber.isNotEmpty()) {
-                if (teamNickname.isNotEmpty()) "$teamNumber \u2014 $teamNickname" else "Team $teamNumber"
-            } else {
-                "Team Tracker"
-            }
+            get() =
+                if (teamNumber.isNotEmpty()) {
+                    if (teamNickname.isNotEmpty()) {
+                        "$teamNumber \u2014 $teamNickname"
+                    } else {
+                        "Team $teamNumber"
+                    }
+                } else {
+                    "Team Tracker"
+                }
 
         /** Last match brief summary for when there's no next match. */
         val lastMatchBrief: String?
             get() {
-                if (lastMatchLabel == null || lastRedScore == null || lastBlueScore == null) return null
-                return "Last: $lastMatchLabel ${lastRedScore}-${lastBlueScore}"
+                if (lastMatchLabel == null ||
+                    lastRedScore == null ||
+                    lastBlueScore == null
+                ) {
+                    return null
+                }
+                return "Last: $lastMatchLabel $lastRedScore-$lastBlueScore"
             }
 
         /** Subtitle line: "record at event", "record", "event", or "Upcoming events". */
         val subtitle: String
-            get() = when {
-                record.isNotEmpty() && eventName.isNotEmpty() -> "$record at $eventName"
-                record.isNotEmpty() -> record
-                eventName.isNotEmpty() && eventName != "No event" -> eventName
-                upcomingEvents != null -> "Upcoming events"
-                else -> ""
-            }
+            get() =
+                when {
+                    record.isNotEmpty() && eventName.isNotEmpty() -> "$record at $eventName"
+                    record.isNotEmpty() -> record
+                    eventName.isNotEmpty() && eventName != "No event" -> eventName
+                    upcomingEvents != null -> "Upcoming events"
+                    else -> ""
+                }
 
         /** Fallback text when no match data. */
         val fallbackInfo: String
-            get() = when {
-                record.isNotEmpty() -> record
-                eventName.isNotEmpty() && eventName != "No event" -> eventName
-                else -> ""
-            }
+            get() =
+                when {
+                    record.isNotEmpty() -> record
+                    eventName.isNotEmpty() && eventName != "No event" -> eventName
+                    else -> ""
+                }
 
         val hasNextMatch: Boolean
             get() = nextMatchLabel != null && nextRedTeams != null && nextBlueTeams != null
 
         val hasLastMatch: Boolean
-            get() = lastMatchLabel != null && lastRedTeams != null && lastBlueTeams != null
-                    && lastRedScore != null && lastBlueScore != null
+            get() =
+                lastMatchLabel != null &&
+                    lastRedTeams != null &&
+                    lastBlueTeams != null &&
+                    lastRedScore != null &&
+                    lastBlueScore != null
 
         val upcomingEventsList: List<UpcomingEvent>
-            get() = upcomingEvents?.split("\n")?.mapNotNull { line ->
-                val parts = line.split("\t")
-                if (parts.size >= 3) UpcomingEvent(parts[0], parts[1], parts[2]) else null
-            } ?: emptyList()
+            get() =
+                upcomingEvents?.split("\n")?.mapNotNull { line ->
+                    val parts = line.split("\t")
+                    if (parts.size >= 3) UpcomingEvent(parts[0], parts[1], parts[2]) else null
+                } ?: emptyList()
 
         companion object {
             /** Sample data for widget previews — at-event state with matches. */
-            fun sampleData() = WidgetData(
-                teamNumber = "177",
-                teamKey = "frc177",
-                teamNickname = "Bobcat Robotics",
-                avatarBase64 = null,
-                nextAlliance = "blue",
-                eventName = "NE District Event",
-                record = "5-2-0",
-                upcomingEvents = null,
-                lastUpdated = "just now",
-                lastMatchLabel = "Q12",
-                lastRedTeams = "195, 1519, 4909",
-                lastBlueTeams = "177, 1153, 2067",
-                lastRedScore = "52",
-                lastBlueScore = "71",
-                lastWinningAlliance = "blue",
-                lastRedRp = "false, false",
-                lastBlueRp = "true, true",
-                nextMatchLabel = "Q18",
-                nextRedTeams = "177, 3467, 5112",
-                nextBlueTeams = "1073, 2791, 3958",
-                nextMatchTime = "2:30 PM",
-                nextTimeIsEstimate = true,
-            )
+            fun sampleData() =
+                WidgetData(
+                    teamNumber = "177",
+                    teamKey = "frc177",
+                    teamNickname = "Bobcat Robotics",
+                    avatarBase64 = null,
+                    nextAlliance = "blue",
+                    eventName = "NE District Event",
+                    record = "5-2-0",
+                    upcomingEvents = null,
+                    lastUpdated = "just now",
+                    lastMatchLabel = "Q12",
+                    lastRedTeams = "195, 1519, 4909",
+                    lastBlueTeams = "177, 1153, 2067",
+                    lastRedScore = "52",
+                    lastBlueScore = "71",
+                    lastWinningAlliance = "blue",
+                    lastRedRp = "false, false",
+                    lastBlueRp = "true, true",
+                    nextMatchLabel = "Q18",
+                    nextRedTeams = "177, 3467, 5112",
+                    nextBlueTeams = "1073, 2791, 3958",
+                    nextMatchTime = "2:30 PM",
+                    nextTimeIsEstimate = true,
+                )
 
             /** Sample data for widget previews — off-season with upcoming events. */
-            fun sampleUpcomingData() = WidgetData(
-                teamNumber = "177",
-                teamKey = "frc177",
-                teamNickname = "Bobcat Robotics",
-                avatarBase64 = null,
-                nextAlliance = "",
-                eventName = "No event",
-                record = "",
-                upcomingEvents = "NE District WPI\tWorcester, MA\tMar 7\n" +
-                        "NE District UNH\tDurham, NH\tMar 28\n" +
-                        "NE FIRST Championship\tSpringfield, MA\tApr 16",
-                lastUpdated = "just now",
-                lastMatchLabel = null,
-                lastRedTeams = null,
-                lastBlueTeams = null,
-                lastRedScore = null,
-                lastBlueScore = null,
-                lastWinningAlliance = null,
-                lastRedRp = null,
-                lastBlueRp = null,
-                nextMatchLabel = null,
-                nextRedTeams = null,
-                nextBlueTeams = null,
-                nextMatchTime = null,
-                nextTimeIsEstimate = false,
-            )
+            fun sampleUpcomingData() =
+                WidgetData(
+                    teamNumber = "177",
+                    teamKey = "frc177",
+                    teamNickname = "Bobcat Robotics",
+                    avatarBase64 = null,
+                    nextAlliance = "",
+                    eventName = "No event",
+                    record = "",
+                    upcomingEvents =
+                        "NE District WPI\tWorcester, MA\tMar 7\n" +
+                            "NE District UNH\tDurham, NH\tMar 28\n" +
+                            "NE FIRST Championship\tSpringfield, MA\tApr 16",
+                    lastUpdated = "just now",
+                    lastMatchLabel = null,
+                    lastRedTeams = null,
+                    lastBlueTeams = null,
+                    lastRedScore = null,
+                    lastBlueScore = null,
+                    lastWinningAlliance = null,
+                    lastRedRp = null,
+                    lastBlueRp = null,
+                    nextMatchLabel = null,
+                    nextRedTeams = null,
+                    nextBlueTeams = null,
+                    nextMatchTime = null,
+                    nextTimeIsEstimate = false,
+                )
         }
     }
 
-    private data class UpcomingEvent(val name: String, val city: String, val date: String)
+    private data class UpcomingEvent(
+        val name: String,
+        val city: String,
+        val date: String,
+    )
 
     // ─── TINY layout (1x1) ─────────────────────────────────────────────────────
     // Solid alliance color background with team number + next match time.
@@ -302,24 +340,25 @@ class TeamTrackingWidget : GlanceAppWidget() {
 
     @Composable
     private fun TinyLayout(data: WidgetData) {
-
         Column(
-            modifier = GlanceModifier
-                .fillMaxSize()
-                .background(GlanceTheme.colors.widgetBackground)
-                .padding(12.dp)
-                .clickable(actionRunCallback<TeamTrackingWidgetOpenAction>()),
+            modifier =
+                GlanceModifier
+                    .fillMaxSize()
+                    .background(GlanceTheme.colors.widgetBackground)
+                    .padding(12.dp)
+                    .clickable(actionRunCallback<TeamTrackingWidgetOpenAction>()),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             if (data.teamNumber.isNotEmpty()) {
                 // Team number pinned to top
                 Text(
                     text = data.teamNumber,
-                    style = TextStyle(
-                        color = GlanceTheme.colors.onSurface,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Bold,
-                    ),
+                    style =
+                        TextStyle(
+                            color = GlanceTheme.colors.onSurface,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold,
+                        ),
                     maxLines = 1,
                 )
                 if (data.nextMatchLabel != null) {
@@ -327,20 +366,26 @@ class TeamTrackingWidget : GlanceAppWidget() {
                     Spacer(modifier = GlanceModifier.defaultWeight())
                     Text(
                         text = data.nextMatchLabel,
-                        style = TextStyle(
-                            color = GlanceTheme.colors.onSurface,
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.Medium,
-                        ),
+                        style =
+                            TextStyle(
+                                color = GlanceTheme.colors.onSurface,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Medium,
+                            ),
                         maxLines = 1,
                     )
                     if (data.nextMatchTime != null) {
                         Text(
-                            text = formatTimeWithEstimate(data.nextMatchTime, data.nextTimeIsEstimate),
-                            style = TextStyle(
-                                color = GlanceTheme.colors.onSurfaceVariant,
-                                fontSize = 10.sp,
-                            ),
+                            text =
+                                formatTimeWithEstimate(
+                                    data.nextMatchTime,
+                                    data.nextTimeIsEstimate,
+                                ),
+                            style =
+                                TextStyle(
+                                    color = GlanceTheme.colors.onSurfaceVariant,
+                                    fontSize = 10.sp,
+                                ),
                             maxLines = 1,
                         )
                     }
@@ -348,14 +393,18 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 } else if (data.avatarBitmap != null) {
                     // No match data — show avatar filling available space
                     Spacer(modifier = GlanceModifier.defaultWeight())
-                    val avatarBg = when (data.nextAlliance) {
-                        "red" -> ColorProvider(R.color.widget_red)
-                        "blue" -> ColorProvider(R.color.widget_blue)
-                        else -> ColorProvider(R.color.widget_blue)
-                    }
+                    val avatarBg =
+                        when (data.nextAlliance) {
+                            "red" -> ColorProvider(R.color.widget_red)
+                            "blue" -> ColorProvider(R.color.widget_blue)
+                            else -> ColorProvider(R.color.widget_blue)
+                        }
                     Box(
-                        modifier = GlanceModifier.size(40.dp).cornerRadius(4.dp)
-                            .background(avatarBg),
+                        modifier =
+                            GlanceModifier
+                                .size(40.dp)
+                                .cornerRadius(4.dp)
+                                .background(avatarBg),
                         contentAlignment = Alignment.Center,
                     ) {
                         Image(
@@ -391,19 +440,21 @@ class TeamTrackingWidget : GlanceAppWidget() {
         val blueColor = ColorProvider(R.color.widget_blue_text)
 
         Column(
-            modifier = GlanceModifier
-                .fillMaxSize()
-                .background(GlanceTheme.colors.widgetBackground)
-                .padding(12.dp)
-                .clickable(actionRunCallback<TeamTrackingWidgetOpenAction>()),
+            modifier =
+                GlanceModifier
+                    .fillMaxSize()
+                    .background(GlanceTheme.colors.widgetBackground)
+                    .padding(12.dp)
+                    .clickable(actionRunCallback<TeamTrackingWidgetOpenAction>()),
         ) {
             if (data.teamNumber.isEmpty()) {
                 Text(
                     text = "Tap to set up",
-                    style = TextStyle(
-                        color = GlanceTheme.colors.onSurfaceVariant,
-                        fontSize = 12.sp,
-                    ),
+                    style =
+                        TextStyle(
+                            color = GlanceTheme.colors.onSurfaceVariant,
+                            fontSize = 12.sp,
+                        ),
                 )
             } else {
                 Row(
@@ -413,11 +464,12 @@ class TeamTrackingWidget : GlanceAppWidget() {
                     TeamAvatar(data, boxSize = 20.dp, imageSize = 16.dp, cornerRadius = 3.dp)
                     Text(
                         text = data.teamLabel,
-                        style = TextStyle(
-                            color = GlanceTheme.colors.onSurface,
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Bold,
-                        ),
+                        style =
+                            TextStyle(
+                                color = GlanceTheme.colors.onSurface,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold,
+                            ),
                         maxLines = 1,
                     )
                 }
@@ -431,26 +483,42 @@ class TeamTrackingWidget : GlanceAppWidget() {
                     ) {
                         Text(
                             text = data.nextMatchLabel!!,
-                            style = TextStyle(
-                                color = GlanceTheme.colors.onSurface,
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.Medium,
-                            ),
+                            style =
+                                TextStyle(
+                                    color = GlanceTheme.colors.onSurface,
+                                    fontSize = 12.sp,
+                                    fontWeight = FontWeight.Medium,
+                                ),
                         )
                         if (data.nextMatchTime != null) {
                             Spacer(modifier = GlanceModifier.defaultWeight())
                             Text(
-                                text = formatTimeWithEstimate(data.nextMatchTime, data.nextTimeIsEstimate),
-                                style = TextStyle(
-                                    color = GlanceTheme.colors.onSurfaceVariant,
-                                    fontSize = 12.sp,
-                                ),
+                                text =
+                                    formatTimeWithEstimate(
+                                        data.nextMatchTime,
+                                        data.nextTimeIsEstimate,
+                                    ),
+                                style =
+                                    TextStyle(
+                                        color = GlanceTheme.colors.onSurfaceVariant,
+                                        fontSize = 12.sp,
+                                    ),
                             )
                         }
                     }
                     // Alliance team rows in color
-                    TeamNumbersRow(data.nextRedTeams!!, data.teamKey.removePrefix("frc"), redColor, false)
-                    TeamNumbersRow(data.nextBlueTeams!!, data.teamKey.removePrefix("frc"), blueColor, false)
+                    TeamNumbersRow(
+                        data.nextRedTeams!!,
+                        data.teamKey.removePrefix("frc"),
+                        redColor,
+                        false,
+                    )
+                    TeamNumbersRow(
+                        data.nextBlueTeams!!,
+                        data.teamKey.removePrefix("frc"),
+                        blueColor,
+                        false,
+                    )
                     Spacer(modifier = GlanceModifier.defaultWeight())
                 } else {
                     Spacer(modifier = GlanceModifier.defaultWeight())
@@ -458,10 +526,11 @@ class TeamTrackingWidget : GlanceAppWidget() {
                     if (fallback != null) {
                         Text(
                             text = fallback,
-                            style = TextStyle(
-                                color = GlanceTheme.colors.onSurfaceVariant,
-                                fontSize = 11.sp,
-                            ),
+                            style =
+                                TextStyle(
+                                    color = GlanceTheme.colors.onSurfaceVariant,
+                                    fontSize = 11.sp,
+                                ),
                             maxLines = 1,
                         )
                     } else {
@@ -471,10 +540,11 @@ class TeamTrackingWidget : GlanceAppWidget() {
                         } else if (data.fallbackInfo.isNotEmpty()) {
                             Text(
                                 text = data.fallbackInfo,
-                                style = TextStyle(
-                                    color = GlanceTheme.colors.onSurfaceVariant,
-                                    fontSize = 11.sp,
-                                ),
+                                style =
+                                    TextStyle(
+                                        color = GlanceTheme.colors.onSurfaceVariant,
+                                        fontSize = 11.sp,
+                                    ),
                                 maxLines = 1,
                             )
                         }
@@ -493,11 +563,12 @@ class TeamTrackingWidget : GlanceAppWidget() {
         val blueColor = ColorProvider(R.color.widget_blue_text)
 
         Column(
-            modifier = GlanceModifier
-                .fillMaxSize()
-                .background(GlanceTheme.colors.widgetBackground)
-                .padding(12.dp)
-                .clickable(actionRunCallback<TeamTrackingWidgetOpenAction>()),
+            modifier =
+                GlanceModifier
+                    .fillMaxSize()
+                    .background(GlanceTheme.colors.widgetBackground)
+                    .padding(12.dp)
+                    .clickable(actionRunCallback<TeamTrackingWidgetOpenAction>()),
         ) {
             // Header: avatar + team label
             Row(
@@ -508,20 +579,22 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 Column(modifier = GlanceModifier.defaultWeight()) {
                     Text(
                         text = if (data.teamNumber.isNotEmpty()) data.teamLabel else "TBA",
-                        style = TextStyle(
-                            color = GlanceTheme.colors.onSurface,
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Bold,
-                        ),
+                        style =
+                            TextStyle(
+                                color = GlanceTheme.colors.onSurface,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold,
+                            ),
                         maxLines = 1,
                     )
                     if (data.teamNumber.isNotEmpty() && data.subtitle.isNotEmpty()) {
                         Text(
                             text = data.subtitle,
-                            style = TextStyle(
-                                color = GlanceTheme.colors.onSurfaceVariant,
-                                fontSize = 11.sp,
-                            ),
+                            style =
+                                TextStyle(
+                                    color = GlanceTheme.colors.onSurfaceVariant,
+                                    fontSize = 11.sp,
+                                ),
                             maxLines = 1,
                         )
                     }
@@ -532,10 +605,11 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 Spacer(modifier = GlanceModifier.defaultWeight())
                 Text(
                     text = "Tap to set up",
-                    style = TextStyle(
-                        color = GlanceTheme.colors.onSurfaceVariant,
-                        fontSize = 12.sp,
-                    ),
+                    style =
+                        TextStyle(
+                            color = GlanceTheme.colors.onSurfaceVariant,
+                            fontSize = 12.sp,
+                        ),
                 )
                 return@Column
             }
@@ -550,28 +624,41 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 ) {
                     Text(
                         text = data.nextMatchLabel!!,
-                        style = TextStyle(
-                            color = GlanceTheme.colors.onSurface,
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.Medium,
-                        ),
+                        style =
+                            TextStyle(
+                                color = GlanceTheme.colors.onSurface,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Medium,
+                            ),
                     )
                     if (data.nextMatchTime != null) {
                         Spacer(modifier = GlanceModifier.defaultWeight())
                         Text(
-                            text = formatTimeWithEstimate(
-                                data.nextMatchTime,
-                                data.nextTimeIsEstimate,
-                            ),
-                            style = TextStyle(
-                                color = GlanceTheme.colors.onSurfaceVariant,
-                                fontSize = 12.sp,
-                            ),
+                            text =
+                                formatTimeWithEstimate(
+                                    data.nextMatchTime,
+                                    data.nextTimeIsEstimate,
+                                ),
+                            style =
+                                TextStyle(
+                                    color = GlanceTheme.colors.onSurfaceVariant,
+                                    fontSize = 12.sp,
+                                ),
                         )
                     }
                 }
-                TeamNumbersRow(data.nextRedTeams!!, data.teamKey.removePrefix("frc"), redColor, false)
-                TeamNumbersRow(data.nextBlueTeams!!, data.teamKey.removePrefix("frc"), blueColor, false)
+                TeamNumbersRow(
+                    data.nextRedTeams!!,
+                    data.teamKey.removePrefix("frc"),
+                    redColor,
+                    false,
+                )
+                TeamNumbersRow(
+                    data.nextBlueTeams!!,
+                    data.teamKey.removePrefix("frc"),
+                    blueColor,
+                    false,
+                )
             } else if (data.hasLastMatch) {
                 MatchSectionLabel("Last match")
                 Row(
@@ -580,20 +667,22 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 ) {
                     Text(
                         text = data.lastMatchLabel!!,
-                        style = TextStyle(
-                            color = GlanceTheme.colors.onSurface,
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.Medium,
-                        ),
+                        style =
+                            TextStyle(
+                                color = GlanceTheme.colors.onSurface,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Medium,
+                            ),
                     )
                     Spacer(modifier = GlanceModifier.defaultWeight())
                     Text(
                         text = "${data.lastRedScore}-${data.lastBlueScore}",
-                        style = TextStyle(
-                            color = GlanceTheme.colors.onSurface,
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.Bold,
-                        ),
+                        style =
+                            TextStyle(
+                                color = GlanceTheme.colors.onSurface,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Bold,
+                            ),
                     )
                 }
             } else if (data.upcomingEvents != null) {
@@ -618,13 +707,13 @@ class TeamTrackingWidget : GlanceAppWidget() {
 
     @Composable
     private fun CompactHorizontalLayout(data: WidgetData) {
-
         Column(
-            modifier = GlanceModifier
-                .fillMaxSize()
-                .background(GlanceTheme.colors.widgetBackground)
-                .padding(12.dp)
-                .clickable(actionRunCallback<TeamTrackingWidgetOpenAction>()),
+            modifier =
+                GlanceModifier
+                    .fillMaxSize()
+                    .background(GlanceTheme.colors.widgetBackground)
+                    .padding(12.dp)
+                    .clickable(actionRunCallback<TeamTrackingWidgetOpenAction>()),
         ) {
             WidgetHeader(data)
 
@@ -632,10 +721,11 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 Spacer(modifier = GlanceModifier.defaultWeight())
                 Text(
                     text = "Tap to set up",
-                    style = TextStyle(
-                        color = GlanceTheme.colors.onSurfaceVariant,
-                        fontSize = 12.sp,
-                    ),
+                    style =
+                        TextStyle(
+                            color = GlanceTheme.colors.onSurfaceVariant,
+                            fontSize = 12.sp,
+                        ),
                 )
                 return@Column
             }
@@ -683,13 +773,13 @@ class TeamTrackingWidget : GlanceAppWidget() {
 
     @Composable
     private fun FullLayout(data: WidgetData) {
-
         Column(
-            modifier = GlanceModifier
-                .fillMaxSize()
-                .background(GlanceTheme.colors.widgetBackground)
-                .padding(12.dp)
-                .clickable(actionRunCallback<TeamTrackingWidgetOpenAction>()),
+            modifier =
+                GlanceModifier
+                    .fillMaxSize()
+                    .background(GlanceTheme.colors.widgetBackground)
+                    .padding(12.dp)
+                    .clickable(actionRunCallback<TeamTrackingWidgetOpenAction>()),
         ) {
             WidgetHeader(data)
 
@@ -755,10 +845,11 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 if (data.teamNumber.isEmpty()) {
                     Text(
                         text = "Tap to set up",
-                        style = TextStyle(
-                            color = GlanceTheme.colors.onSurfaceVariant,
-                            fontSize = 12.sp,
-                        ),
+                        style =
+                            TextStyle(
+                                color = GlanceTheme.colors.onSurfaceVariant,
+                                fontSize = 12.sp,
+                            ),
                     )
                 }
                 Spacer(modifier = GlanceModifier.defaultWeight())
@@ -776,14 +867,16 @@ class TeamTrackingWidget : GlanceAppWidget() {
         if (lastUpdated.isNotEmpty()) {
             Text(
                 text = "\u21BB Updated $lastUpdated",
-                style = TextStyle(
-                    color = GlanceTheme.colors.primary,
-                    fontSize = 11.sp,
-                ),
-                modifier = GlanceModifier
-                    .fillMaxWidth()
-                    .padding(top = 4.dp)
-                    .clickable(actionRunCallback<TeamTrackingWidgetRefreshAction>()),
+                style =
+                    TextStyle(
+                        color = GlanceTheme.colors.primary,
+                        fontSize = 11.sp,
+                    ),
+                modifier =
+                    GlanceModifier
+                        .fillMaxWidth()
+                        .padding(top = 4.dp)
+                        .clickable(actionRunCallback<TeamTrackingWidgetRefreshAction>()),
             )
         }
     }
@@ -799,37 +892,41 @@ class TeamTrackingWidget : GlanceAppWidget() {
             Column(modifier = GlanceModifier.defaultWeight()) {
                 Text(
                     text = data.teamLabel,
-                    style = TextStyle(
-                        color = GlanceTheme.colors.onSurface,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Bold,
-                    ),
+                    style =
+                        TextStyle(
+                            color = GlanceTheme.colors.onSurface,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Bold,
+                        ),
                     maxLines = 1,
                 )
                 if (data.subtitle.isNotEmpty()) {
                     Text(
                         text = data.subtitle,
-                        style = TextStyle(
-                            color = GlanceTheme.colors.onSurfaceVariant,
-                            fontSize = 11.sp,
-                        ),
+                        style =
+                            TextStyle(
+                                color = GlanceTheme.colors.onSurfaceVariant,
+                                fontSize = 11.sp,
+                            ),
                         maxLines = 1,
                     )
                 }
             }
             Box(
-                modifier = GlanceModifier
-                    .size(28.dp)
-                    .clickable(actionRunCallback<TeamTrackingWidgetSettingsAction>()),
+                modifier =
+                    GlanceModifier
+                        .size(28.dp)
+                        .clickable(actionRunCallback<TeamTrackingWidgetSettingsAction>()),
                 contentAlignment = Alignment.TopEnd,
             ) {
                 Image(
                     provider = ImageProvider(R.drawable.ic_settings),
                     contentDescription = "Change team",
                     modifier = GlanceModifier.size(16.dp),
-                    colorFilter = ColorFilter.tint(
-                        ColorProvider(R.color.widget_settings_icon)
-                    ),
+                    colorFilter =
+                        ColorFilter.tint(
+                            ColorProvider(R.color.widget_settings_icon),
+                        ),
                 )
             }
         }
@@ -839,25 +936,35 @@ class TeamTrackingWidget : GlanceAppWidget() {
     private fun MatchSectionLabel(label: String) {
         Text(
             text = label,
-            style = TextStyle(
-                color = GlanceTheme.colors.onSurfaceVariant,
-                fontSize = 10.sp,
-            ),
+            style =
+                TextStyle(
+                    color = GlanceTheme.colors.onSurfaceVariant,
+                    fontSize = 10.sp,
+                ),
         )
     }
 
     /** Renders the team avatar with alliance-colored background and trailing spacer. */
     @Composable
-    private fun TeamAvatar(data: WidgetData, boxSize: Dp, imageSize: Dp, cornerRadius: Dp) {
+    private fun TeamAvatar(
+        data: WidgetData,
+        boxSize: Dp,
+        imageSize: Dp,
+        cornerRadius: Dp,
+    ) {
         if (data.avatarBitmap != null) {
-            val avatarBg = when (data.nextAlliance) {
-                "red" -> ColorProvider(R.color.widget_red)
-                "blue" -> ColorProvider(R.color.widget_blue)
-                else -> ColorProvider(R.color.widget_blue)
-            }
+            val avatarBg =
+                when (data.nextAlliance) {
+                    "red" -> ColorProvider(R.color.widget_red)
+                    "blue" -> ColorProvider(R.color.widget_blue)
+                    else -> ColorProvider(R.color.widget_blue)
+                }
             Box(
-                modifier = GlanceModifier.size(boxSize).cornerRadius(cornerRadius)
-                    .background(avatarBg),
+                modifier =
+                    GlanceModifier
+                        .size(boxSize)
+                        .cornerRadius(cornerRadius)
+                        .background(avatarBg),
                 contentAlignment = Alignment.Center,
             ) {
                 Image(
@@ -902,11 +1009,12 @@ class TeamTrackingWidget : GlanceAppWidget() {
             // Match label (widened to 44dp for longer labels like QF1-1)
             Text(
                 text = label,
-                style = TextStyle(
-                    color = GlanceTheme.colors.onSurface,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Medium,
-                ),
+                style =
+                    TextStyle(
+                        color = GlanceTheme.colors.onSurface,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium,
+                    ),
                 modifier = GlanceModifier.width(44.dp),
             )
 
@@ -932,29 +1040,46 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 Column(horizontalAlignment = Alignment.End) {
                     Text(
                         text = redScore!!,
-                        style = TextStyle(
-                            color = redColor,
-                            fontSize = 12.sp,
-                            fontWeight = if (winningAlliance == "red") FontWeight.Bold else FontWeight.Normal,
-                        ),
+                        style =
+                            TextStyle(
+                                color = redColor,
+                                fontSize = 12.sp,
+                                fontWeight =
+                                    if (winningAlliance ==
+                                        "red"
+                                    ) {
+                                        FontWeight.Bold
+                                    } else {
+                                        FontWeight.Normal
+                                    },
+                            ),
                     )
                     Text(
                         text = blueScore!!,
-                        style = TextStyle(
-                            color = blueColor,
-                            fontSize = 12.sp,
-                            fontWeight = if (winningAlliance == "blue") FontWeight.Bold else FontWeight.Normal,
-                        ),
+                        style =
+                            TextStyle(
+                                color = blueColor,
+                                fontSize = 12.sp,
+                                fontWeight =
+                                    if (winningAlliance ==
+                                        "blue"
+                                    ) {
+                                        FontWeight.Bold
+                                    } else {
+                                        FontWeight.Normal
+                                    },
+                            ),
                     )
                 }
             } else if (time != null) {
                 // Use "~" prefix for estimates instead of "(est.)" on a separate line
                 Text(
                     text = formatTimeWithEstimate(time, timeIsEstimate),
-                    style = TextStyle(
-                        color = GlanceTheme.colors.onSurfaceVariant,
-                        fontSize = 12.sp,
-                    ),
+                    style =
+                        TextStyle(
+                            color = GlanceTheme.colors.onSurfaceVariant,
+                            fontSize = 12.sp,
+                        ),
                 )
             }
         }
@@ -979,12 +1104,14 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 val isTracked = team == highlightTeam
                 Text(
                     text = team,
-                    style = TextStyle(
-                        color = color,
-                        fontSize = 12.sp,
-                        fontWeight = if (isWinner) FontWeight.Bold else FontWeight.Normal,
-                        textDecoration = if (isTracked) TextDecoration.Underline else TextDecoration.None,
-                    ),
+                    style =
+                        TextStyle(
+                            color = color,
+                            fontSize = 12.sp,
+                            fontWeight = if (isWinner) FontWeight.Bold else FontWeight.Normal,
+                            textDecoration =
+                                if (isTracked) TextDecoration.Underline else TextDecoration.None,
+                        ),
                 )
             }
         }
@@ -992,33 +1119,42 @@ class TeamTrackingWidget : GlanceAppWidget() {
 
     /** Compact upcoming event row for 2x1 and 4x1: event name + date, no city. */
     @Composable
-    private fun UpcomingEventRowCompact(name: String, date: String) {
+    private fun UpcomingEventRowCompact(
+        name: String,
+        date: String,
+    ) {
         Row(
             modifier = GlanceModifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 text = name,
-                style = TextStyle(
-                    color = GlanceTheme.colors.onSurface,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Medium,
-                ),
+                style =
+                    TextStyle(
+                        color = GlanceTheme.colors.onSurface,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium,
+                    ),
                 modifier = GlanceModifier.defaultWeight(),
                 maxLines = 1,
             )
             Text(
                 text = date,
-                style = TextStyle(
-                    color = GlanceTheme.colors.onSurfaceVariant,
-                    fontSize = 12.sp,
-                ),
+                style =
+                    TextStyle(
+                        color = GlanceTheme.colors.onSurfaceVariant,
+                        fontSize = 12.sp,
+                    ),
             )
         }
     }
 
     @Composable
-    private fun UpcomingEventRow(name: String, city: String, date: String) {
+    private fun UpcomingEventRow(
+        name: String,
+        city: String,
+        date: String,
+    ) {
         Row(
             modifier = GlanceModifier.fillMaxWidth().padding(vertical = 2.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -1026,30 +1162,33 @@ class TeamTrackingWidget : GlanceAppWidget() {
             Column(modifier = GlanceModifier.defaultWeight()) {
                 Text(
                     text = name,
-                    style = TextStyle(
-                        color = GlanceTheme.colors.onSurface,
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Medium,
-                    ),
+                    style =
+                        TextStyle(
+                            color = GlanceTheme.colors.onSurface,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Medium,
+                        ),
                     maxLines = 1,
                 )
                 if (city.isNotEmpty()) {
                     Text(
                         text = city,
-                        style = TextStyle(
-                            color = GlanceTheme.colors.onSurfaceVariant,
-                            fontSize = 11.sp,
-                        ),
+                        style =
+                            TextStyle(
+                                color = GlanceTheme.colors.onSurfaceVariant,
+                                fontSize = 11.sp,
+                            ),
                         maxLines = 1,
                     )
                 }
             }
             Text(
                 text = date,
-                style = TextStyle(
-                    color = GlanceTheme.colors.onSurfaceVariant,
-                    fontSize = 12.sp,
-                ),
+                style =
+                    TextStyle(
+                        color = GlanceTheme.colors.onSurfaceVariant,
+                        fontSize = 12.sp,
+                    ),
             )
         }
     }
@@ -1066,10 +1205,11 @@ class TeamTrackingWidget : GlanceAppWidget() {
             bonuses.forEach { achieved ->
                 Text(
                     text = if (achieved) "\u25CF" else "\u25CB",
-                    style = TextStyle(
-                        color = if (achieved) achievedColor else inactiveColor,
-                        fontSize = 8.sp,
-                    ),
+                    style =
+                        TextStyle(
+                            color = if (achieved) achievedColor else inactiveColor,
+                            fontSize = 8.sp,
+                        ),
                     modifier = GlanceModifier.padding(horizontal = 1.dp),
                 )
             }
@@ -1080,58 +1220,136 @@ class TeamTrackingWidget : GlanceAppWidget() {
     // Grouped by size tier. Typical = Pixel-like launcher, Minimum = breakpoint edge.
 
     // Tiny (1×1)
-    @Preview(widthDp = 80, heightDp = 100) @Composable
-    fun TinyPreview() { GlanceTheme { WidgetContent(WidgetData.sampleData()) } }
-    @Preview(widthDp = 60, heightDp = 60) @Composable
-    fun TinyMinimumPreview() { GlanceTheme { WidgetContent(WidgetData.sampleData()) } }
-    @Preview(widthDp = 80, heightDp = 100) @Composable
-    fun TinyUpcomingPreview() { GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) } }
-    @Preview(widthDp = 60, heightDp = 60) @Composable
-    fun TinyUpcomingMinimumPreview() { GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) } }
+    @Preview(widthDp = 80, heightDp = 100)
+    @Composable
+    fun TinyPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleData()) }
+    }
+
+    @Preview(widthDp = 60, heightDp = 60)
+    @Composable
+    fun TinyMinimumPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleData()) }
+    }
+
+    @Preview(widthDp = 80, heightDp = 100)
+    @Composable
+    fun TinyUpcomingPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) }
+    }
+
+    @Preview(widthDp = 60, heightDp = 60)
+    @Composable
+    fun TinyUpcomingMinimumPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) }
+    }
 
     // Minimal (2×1)
-    @Preview(widthDp = 170, heightDp = 100) @Composable
-    fun MinimalPreview() { GlanceTheme { WidgetContent(WidgetData.sampleData()) } }
-    @Preview(widthDp = 110, heightDp = 60) @Composable
-    fun MinimalMinimumPreview() { GlanceTheme { WidgetContent(WidgetData.sampleData()) } }
-    @Preview(widthDp = 170, heightDp = 100) @Composable
-    fun MinimalUpcomingPreview() { GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) } }
-    @Preview(widthDp = 110, heightDp = 60) @Composable
-    fun MinimalUpcomingMinimumPreview() { GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) } }
+    @Preview(widthDp = 170, heightDp = 100)
+    @Composable
+    fun MinimalPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleData()) }
+    }
+
+    @Preview(widthDp = 110, heightDp = 60)
+    @Composable
+    fun MinimalMinimumPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleData()) }
+    }
+
+    @Preview(widthDp = 170, heightDp = 100)
+    @Composable
+    fun MinimalUpcomingPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) }
+    }
+
+    @Preview(widthDp = 110, heightDp = 60)
+    @Composable
+    fun MinimalUpcomingMinimumPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) }
+    }
 
     // Square (2×2)
-    @Preview(widthDp = 170, heightDp = 210) @Composable
-    fun SquarePreview() { GlanceTheme { WidgetContent(WidgetData.sampleData()) } }
-    @Preview(widthDp = 110, heightDp = 110) @Composable
-    fun SquareMinimumPreview() { GlanceTheme { WidgetContent(WidgetData.sampleData()) } }
-    @Preview(widthDp = 170, heightDp = 210) @Composable
-    fun SquareUpcomingPreview() { GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) } }
-    @Preview(widthDp = 110, heightDp = 110) @Composable
-    fun SquareUpcomingMinimumPreview() { GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) } }
+    @Preview(widthDp = 170, heightDp = 210)
+    @Composable
+    fun SquarePreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleData()) }
+    }
+
+    @Preview(widthDp = 110, heightDp = 110)
+    @Composable
+    fun SquareMinimumPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleData()) }
+    }
+
+    @Preview(widthDp = 170, heightDp = 210)
+    @Composable
+    fun SquareUpcomingPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) }
+    }
+
+    @Preview(widthDp = 110, heightDp = 110)
+    @Composable
+    fun SquareUpcomingMinimumPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) }
+    }
 
     // Compact (4×1)
-    @Preview(widthDp = 350, heightDp = 100) @Composable
-    fun CompactPreview() { GlanceTheme { WidgetContent(WidgetData.sampleData()) } }
-    @Preview(widthDp = 250, heightDp = 60) @Composable
-    fun CompactMinimumPreview() { GlanceTheme { WidgetContent(WidgetData.sampleData()) } }
-    @Preview(widthDp = 350, heightDp = 100) @Composable
-    fun CompactUpcomingPreview() { GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) } }
-    @Preview(widthDp = 250, heightDp = 60) @Composable
-    fun CompactUpcomingMinimumPreview() { GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) } }
+    @Preview(widthDp = 350, heightDp = 100)
+    @Composable
+    fun CompactPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleData()) }
+    }
+
+    @Preview(widthDp = 250, heightDp = 60)
+    @Composable
+    fun CompactMinimumPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleData()) }
+    }
+
+    @Preview(widthDp = 350, heightDp = 100)
+    @Composable
+    fun CompactUpcomingPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) }
+    }
+
+    @Preview(widthDp = 250, heightDp = 60)
+    @Composable
+    fun CompactUpcomingMinimumPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) }
+    }
 
     // Full (4×2)
-    @Preview(widthDp = 350, heightDp = 210) @Composable
-    fun FullPreview() { GlanceTheme { WidgetContent(WidgetData.sampleData()) } }
-    @Preview(widthDp = 250, heightDp = 110) @Composable
-    fun FullMinimumPreview() { GlanceTheme { WidgetContent(WidgetData.sampleData()) } }
-    @Preview(widthDp = 350, heightDp = 210) @Composable
-    fun FullUpcomingPreview() { GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) } }
-    @Preview(widthDp = 250, heightDp = 110) @Composable
-    fun FullUpcomingMinimumPreview() { GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) } }
+    @Preview(widthDp = 350, heightDp = 210)
+    @Composable
+    fun FullPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleData()) }
+    }
+
+    @Preview(widthDp = 250, heightDp = 110)
+    @Composable
+    fun FullMinimumPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleData()) }
+    }
+
+    @Preview(widthDp = 350, heightDp = 210)
+    @Composable
+    fun FullUpcomingPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) }
+    }
+
+    @Preview(widthDp = 250, heightDp = 110)
+    @Composable
+    fun FullUpcomingMinimumPreview() {
+        GlanceTheme { WidgetContent(WidgetData.sampleUpcomingData()) }
+    }
 }
 
 /** Formats a time string with "~" prefix for estimates. */
-private fun formatTimeWithEstimate(time: String, isEstimate: Boolean): String {
+private fun formatTimeWithEstimate(
+    time: String,
+    isEstimate: Boolean,
+): String {
     if (time.isEmpty()) return ""
     return if (isEstimate) "~$time" else time
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetConfigActivity.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetConfigActivity.kt
@@ -18,15 +18,13 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.ui.res.painterResource
-import com.thebluealliance.android.R
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.TextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -43,25 +42,26 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.state.getAppWidgetState
 import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.lifecycle.lifecycleScope
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
-import com.thebluealliance.android.ui.theme.TBATheme
+import com.thebluealliance.android.R
 import com.thebluealliance.android.ui.theme.TBABlue
-import androidx.lifecycle.lifecycleScope
+import com.thebluealliance.android.ui.theme.TBATheme
 import kotlinx.coroutines.launch
 
 class TeamTrackingWidgetConfigActivity : ComponentActivity() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         // If the user backs out, cancel widget placement
         setResult(Activity.RESULT_CANCELED)
 
-        val appWidgetId = intent?.extras?.getInt(
-            AppWidgetManager.EXTRA_APPWIDGET_ID,
-            AppWidgetManager.INVALID_APPWIDGET_ID,
-        ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+        val appWidgetId =
+            intent?.extras?.getInt(
+                AppWidgetManager.EXTRA_APPWIDGET_ID,
+                AppWidgetManager.INVALID_APPWIDGET_ID,
+            ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
 
         if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
             finish()
@@ -84,10 +84,16 @@ class TeamTrackingWidgetConfigActivity : ComponentActivity() {
                         Column {
                             // Blue header bar
                             Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .background(TBABlue)
-                                    .padding(start = 16.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .background(TBABlue)
+                                        .padding(
+                                            start = 16.dp,
+                                            end = 4.dp,
+                                            top = 4.dp,
+                                            bottom = 4.dp,
+                                        ),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
                                 Icon(
@@ -123,13 +129,17 @@ class TeamTrackingWidgetConfigActivity : ComponentActivity() {
 
                                 LaunchedEffect(Unit) {
                                     try {
-                                        val manager = GlanceAppWidgetManager(this@TeamTrackingWidgetConfigActivity)
+                                        val manager =
+                                            GlanceAppWidgetManager(
+                                                this@TeamTrackingWidgetConfigActivity,
+                                            )
                                         val glanceId = manager.getGlanceIdBy(appWidgetId)
-                                        val state = getAppWidgetState(
-                                            this@TeamTrackingWidgetConfigActivity,
-                                            PreferencesGlanceStateDefinition,
-                                            glanceId,
-                                        )
+                                        val state =
+                                            getAppWidgetState(
+                                                this@TeamTrackingWidgetConfigActivity,
+                                                PreferencesGlanceStateDefinition,
+                                                glanceId,
+                                            )
                                         state[TeamTrackingWidgetKeys.TEAM_NUMBER]?.let {
                                             teamNumber = it
                                         }
@@ -143,17 +153,19 @@ class TeamTrackingWidgetConfigActivity : ComponentActivity() {
                                     onValueChange = { teamNumber = it.filter { c -> c.isDigit() } },
                                     label = { Text("Team Number") },
                                     placeholder = { Text("e.g. 9180") },
-                                    keyboardOptions = KeyboardOptions(
-                                        keyboardType = KeyboardType.Number,
-                                        imeAction = ImeAction.Done,
-                                    ),
-                                    keyboardActions = KeyboardActions(
-                                        onDone = {
-                                            if (teamNumber.isNotBlank()) {
-                                                confirmWidget(appWidgetId, teamNumber)
-                                            }
-                                        }
-                                    ),
+                                    keyboardOptions =
+                                        KeyboardOptions(
+                                            keyboardType = KeyboardType.Number,
+                                            imeAction = ImeAction.Done,
+                                        ),
+                                    keyboardActions =
+                                        KeyboardActions(
+                                            onDone = {
+                                                if (teamNumber.isNotBlank()) {
+                                                    confirmWidget(appWidgetId, teamNumber)
+                                                }
+                                            },
+                                        ),
                                     singleLine = true,
                                     modifier = Modifier.fillMaxWidth(),
                                 )
@@ -175,7 +187,10 @@ class TeamTrackingWidgetConfigActivity : ComponentActivity() {
         }
     }
 
-    private fun confirmWidget(appWidgetId: Int, teamNumber: String) {
+    private fun confirmWidget(
+        appWidgetId: Int,
+        teamNumber: String,
+    ) {
         lifecycleScope.launch {
             val manager = GlanceAppWidgetManager(this@TeamTrackingWidgetConfigActivity)
             val glanceId = manager.getGlanceIdBy(appWidgetId)
@@ -190,7 +205,8 @@ class TeamTrackingWidgetConfigActivity : ComponentActivity() {
 
             // Trigger data fetch
             TeamTrackingWorker.enqueuePeriodicRefresh(this@TeamTrackingWidgetConfigActivity)
-            WorkManager.getInstance(this@TeamTrackingWidgetConfigActivity)
+            WorkManager
+                .getInstance(this@TeamTrackingWidgetConfigActivity)
                 .enqueue(OneTimeWorkRequestBuilder<TeamTrackingWorker>().build())
 
             val result = Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetKeys.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetKeys.kt
@@ -36,13 +36,23 @@ object TeamTrackingWidgetKeys {
     // Debug: force a specific size tier (e.g. "1x1", "2x1", "2x2", "4x1", "4x2")
     val DEBUG_FORCED_SIZE = stringPreferencesKey("debug_forced_size")
 
-    val ALL_LAST_MATCH_KEYS = listOf(
-        LAST_MATCH_LABEL, LAST_MATCH_RED_TEAMS, LAST_MATCH_BLUE_TEAMS,
-        LAST_MATCH_RED_SCORE, LAST_MATCH_BLUE_SCORE, LAST_MATCH_WINNING_ALLIANCE,
-        LAST_MATCH_RED_RP, LAST_MATCH_BLUE_RP,
-    )
-    val ALL_NEXT_MATCH_KEYS = listOf(
-        NEXT_MATCH_LABEL, NEXT_MATCH_RED_TEAMS, NEXT_MATCH_BLUE_TEAMS,
-        NEXT_MATCH_TIME, NEXT_MATCH_TIME_IS_ESTIMATE,
-    )
+    val ALL_LAST_MATCH_KEYS =
+        listOf(
+            LAST_MATCH_LABEL,
+            LAST_MATCH_RED_TEAMS,
+            LAST_MATCH_BLUE_TEAMS,
+            LAST_MATCH_RED_SCORE,
+            LAST_MATCH_BLUE_SCORE,
+            LAST_MATCH_WINNING_ALLIANCE,
+            LAST_MATCH_RED_RP,
+            LAST_MATCH_BLUE_RP,
+        )
+    val ALL_NEXT_MATCH_KEYS =
+        listOf(
+            NEXT_MATCH_LABEL,
+            NEXT_MATCH_RED_TEAMS,
+            NEXT_MATCH_BLUE_TEAMS,
+            NEXT_MATCH_TIME,
+            NEXT_MATCH_TIME_IS_ESTIMATE,
+        )
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetOpenAction.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetOpenAction.kt
@@ -30,24 +30,26 @@ class TeamTrackingWidgetOpenAction : ActionCallback {
             // No team configured — open config. Must always call startActivity;
             // returning without one crashes the Glance action trampoline.
             val appWidgetId = GlanceAppWidgetManager(context).getAppWidgetId(glanceId)
-            val intent = Intent(context, TeamTrackingWidgetConfigActivity::class.java).apply {
-                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            }
+            val intent =
+                Intent(context, TeamTrackingWidgetConfigActivity::class.java).apply {
+                    putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                }
             context.startActivity(intent)
             return
         }
 
         val eventKey = state[TeamTrackingWidgetKeys.EVENT_KEY]
-        val intent = Intent(context, MainActivity::class.java).apply {
-            putExtra(NotificationBuilder.EXTRA_TEAM_KEY, teamKey)
-            if (eventKey != null) {
-                putExtra(NotificationBuilder.EXTRA_EVENT_KEY, eventKey)
-            } else {
-                putExtra(EXTRA_INITIAL_TAB, Screen.TeamDetail.TAB_EVENTS)
+        val intent =
+            Intent(context, MainActivity::class.java).apply {
+                putExtra(NotificationBuilder.EXTRA_TEAM_KEY, teamKey)
+                if (eventKey != null) {
+                    putExtra(NotificationBuilder.EXTRA_EVENT_KEY, eventKey)
+                } else {
+                    putExtra(EXTRA_INITIAL_TAB, Screen.TeamDetail.TAB_EVENTS)
+                }
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             }
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        }
         context.startActivity(intent)
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetSettingsAction.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetSettingsAction.kt
@@ -17,10 +17,11 @@ class TeamTrackingWidgetSettingsAction : ActionCallback {
         val manager = GlanceAppWidgetManager(context)
         val appWidgetId = manager.getAppWidgetId(glanceId)
 
-        val intent = Intent(context, TeamTrackingWidgetConfigActivity::class.java).apply {
-            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-        }
+        val intent =
+            Intent(context, TeamTrackingWidgetConfigActivity::class.java).apply {
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
         context.startActivity(intent)
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWorker.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWorker.kt
@@ -3,7 +3,6 @@ package com.thebluealliance.android.widget
 import android.content.Context
 import android.util.Log
 import androidx.datastore.preferences.core.MutablePreferences
-import androidx.datastore.preferences.core.Preferences
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.state.getAppWidgetState
 import androidx.glance.appwidget.state.updateAppWidgetState
@@ -20,11 +19,11 @@ import com.thebluealliance.android.data.repository.EventRepository
 import com.thebluealliance.android.data.repository.MatchRepository
 import com.thebluealliance.android.data.repository.TeamRepository
 import com.thebluealliance.android.domain.getShortLabel
-import com.thebluealliance.android.domain.rpBonuses
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.Match
 import com.thebluealliance.android.domain.model.Media
 import com.thebluealliance.android.domain.model.PlayoffType
+import com.thebluealliance.android.domain.rpBonuses
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.firstOrNull
@@ -36,308 +35,383 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 @HiltWorker
-class TeamTrackingWorker @AssistedInject constructor(
-    @Assisted appContext: Context,
-    @Assisted workerParams: WorkerParameters,
-    private val matchRepository: MatchRepository,
-    private val eventRepository: EventRepository,
-    private val teamRepository: TeamRepository,
-) : CoroutineWorker(appContext, workerParams) {
+class TeamTrackingWorker
+    @AssistedInject
+    constructor(
+        @Assisted appContext: Context,
+        @Assisted workerParams: WorkerParameters,
+        private val matchRepository: MatchRepository,
+        private val eventRepository: EventRepository,
+        private val teamRepository: TeamRepository,
+    ) : CoroutineWorker(appContext, workerParams) {
+        companion object {
+            private const val TAG = "TeamTrackingWorker"
+            private const val WORK_NAME = "team_tracking_widget_refresh"
+            private const val FAST_WORK_NAME = "team_tracking_widget_fast_refresh"
 
-    companion object {
-        private const val TAG = "TeamTrackingWorker"
-        private const val WORK_NAME = "team_tracking_widget_refresh"
-        private const val FAST_WORK_NAME = "team_tracking_widget_fast_refresh"
+            fun cancelPeriodicRefresh(context: Context) {
+                val wm = WorkManager.getInstance(context)
+                wm.cancelUniqueWork(WORK_NAME)
+                wm.cancelUniqueWork(FAST_WORK_NAME)
+            }
 
-        fun cancelPeriodicRefresh(context: Context) {
-            val wm = WorkManager.getInstance(context)
-            wm.cancelUniqueWork(WORK_NAME)
-            wm.cancelUniqueWork(FAST_WORK_NAME)
+            fun enqueuePeriodicRefresh(context: Context) {
+                val request =
+                    PeriodicWorkRequestBuilder<TeamTrackingWorker>(
+                        6,
+                        TimeUnit.HOURS,
+                    ).build()
+                WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                    WORK_NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    request,
+                )
+            }
+
+            private fun enqueueFastRefresh(context: Context) {
+                val request =
+                    OneTimeWorkRequestBuilder<TeamTrackingWorker>()
+                        .setInitialDelay(15, TimeUnit.MINUTES)
+                        .build()
+                WorkManager.getInstance(context).enqueueUniqueWork(
+                    FAST_WORK_NAME,
+                    ExistingWorkPolicy.REPLACE,
+                    request,
+                )
+            }
+
+            private val timeFormat = DateTimeFormatter.ofPattern("h:mm a", Locale.US)
+            private val timeWithDayFormat = DateTimeFormatter.ofPattern("EEE h:mm a", Locale.US)
         }
 
-        fun enqueuePeriodicRefresh(context: Context) {
-            val request = PeriodicWorkRequestBuilder<TeamTrackingWorker>(
-                6, TimeUnit.HOURS,
-            ).build()
-            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                WORK_NAME,
-                ExistingPeriodicWorkPolicy.KEEP,
-                request,
-            )
-        }
+        override suspend fun doWork(): Result =
+            try {
+                val manager = GlanceAppWidgetManager(applicationContext)
+                val glanceIds = manager.getGlanceIds(TeamTrackingWidget::class.java)
+                var anyActiveEvent = false
 
-        private fun enqueueFastRefresh(context: Context) {
-            val request = OneTimeWorkRequestBuilder<TeamTrackingWorker>()
-                .setInitialDelay(15, TimeUnit.MINUTES)
-                .build()
-            WorkManager.getInstance(context).enqueueUniqueWork(
-                FAST_WORK_NAME,
-                ExistingWorkPolicy.REPLACE,
-                request,
-            )
-        }
+                for (glanceId in glanceIds) {
+                    try {
+                        val state =
+                            getAppWidgetState(
+                                applicationContext,
+                                PreferencesGlanceStateDefinition,
+                                glanceId,
+                            )
+                        val teamKey = state[TeamTrackingWidgetKeys.TEAM_KEY] ?: continue
+                        val teamNumber = teamKey.removePrefix("frc")
 
-        private val timeFormat = DateTimeFormatter.ofPattern("h:mm a", Locale.US)
-        private val timeWithDayFormat = DateTimeFormatter.ofPattern("EEE h:mm a", Locale.US)
-    }
-
-    override suspend fun doWork(): Result {
-        return try {
-            val manager = GlanceAppWidgetManager(applicationContext)
-            val glanceIds = manager.getGlanceIds(TeamTrackingWidget::class.java)
-            var anyActiveEvent = false
-
-            for (glanceId in glanceIds) {
-                try {
-                    val state = getAppWidgetState(applicationContext, PreferencesGlanceStateDefinition, glanceId)
-                    val teamKey = state[TeamTrackingWidgetKeys.TEAM_KEY] ?: continue
-                    val teamNumber = teamKey.removePrefix("frc")
-
-                    val hasActiveEvent = updateWidgetForTeam(teamKey, teamNumber, glanceId)
-                    if (hasActiveEvent) anyActiveEvent = true
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to update widget $glanceId", e)
+                        val hasActiveEvent = updateWidgetForTeam(teamKey, teamNumber, glanceId)
+                        if (hasActiveEvent) anyActiveEvent = true
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to update widget $glanceId", e)
+                    }
                 }
+
+                // When any widget has an active event, schedule a fast follow-up refresh.
+                // Otherwise the 6-hour periodic baseline is sufficient.
+                if (anyActiveEvent) {
+                    enqueueFastRefresh(applicationContext)
+                }
+
+                Result.success()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to update widgets", e)
+                Result.retry()
             }
 
-            // When any widget has an active event, schedule a fast follow-up refresh.
-            // Otherwise the 6-hour periodic baseline is sufficient.
-            if (anyActiveEvent) {
-                enqueueFastRefresh(applicationContext)
+        /** Returns true if the widget has an active event (needs fast refresh). */
+        private suspend fun updateWidgetForTeam(
+            teamKey: String,
+            teamNumber: String,
+            glanceId: androidx.glance.GlanceId,
+        ): Boolean {
+            // Fetch team info and avatar
+            val year = LocalDate.now().year
+            try {
+                teamRepository.refreshTeam(teamKey)
+            } catch (
+                e: Exception,
+            ) {
+                Log.w(TAG, "Failed to refresh team $teamKey", e)
+            }
+            try {
+                teamRepository.refreshTeamMedia(teamKey, year)
+            } catch (
+                e: Exception,
+            ) {
+                Log.w(TAG, "Failed to refresh team media $teamKey/$year", e)
+            }
+            val team = teamRepository.observeTeam(teamKey).firstOrNull()
+            val teamNickname = team?.nickname ?: ""
+            val avatar =
+                teamRepository
+                    .observeTeamMedia(teamKey, year)
+                    .firstOrNull()
+                    ?.firstOrNull { it.isAvatar }
+                    ?: teamRepository
+                        .observeTeamMedia(teamKey, year - 1)
+                        .firstOrNull()
+                        ?.firstOrNull { it.isAvatar }
+
+            // Find the team's current event
+            try {
+                eventRepository.refreshTeamEvents(teamKey, year)
+            } catch (
+                e: Exception,
+            ) {
+                Log.w(TAG, "Failed to refresh team events $teamKey/$year", e)
+            }
+            val events =
+                eventRepository.observeTeamEvents(teamKey, year).firstOrNull()
+                    ?: emptyList()
+            val currentEvent = findCurrentEvent(events, teamKey)
+
+            val now =
+                Instant
+                    .now()
+                    .atZone(ZoneId.systemDefault())
+                    .format(timeFormat)
+
+            if (currentEvent == null) {
+                val today = LocalDate.now()
+                val upcomingEvents =
+                    events
+                        .filter { event ->
+                            val start =
+                                event.startDate?.let { LocalDate.parse(it) } ?: return@filter false
+                            !start.isBefore(today)
+                        }.sortedBy { it.startDate }
+                        .take(3)
+
+                val upcomingEventsData =
+                    upcomingEvents.joinToString("\n") { event ->
+                        val name = event.shortName ?: event.name
+                        val city = listOfNotNull(event.city, event.state).joinToString(", ")
+                        val date =
+                            event.startDate?.let {
+                                LocalDate
+                                    .parse(
+                                        it,
+                                    ).format(DateTimeFormatter.ofPattern("MMM d", Locale.US))
+                            } ?: ""
+                        "$name\t$city\t$date"
+                    }
+
+                updateAppWidgetState(applicationContext, glanceId) { prefs ->
+                    prefs.updateTeamInfo(teamNumber, teamKey, teamNickname, avatar, now)
+                    prefs.remove(TeamTrackingWidgetKeys.EVENT_KEY)
+                    prefs[TeamTrackingWidgetKeys.EVENT_NAME] = ""
+                    prefs[TeamTrackingWidgetKeys.RECORD] = ""
+                    prefs[TeamTrackingWidgetKeys.NEXT_ALLIANCE] = ""
+                    if (upcomingEventsData.isNotEmpty()) {
+                        prefs[TeamTrackingWidgetKeys.UPCOMING_EVENTS] = upcomingEventsData
+                    } else {
+                        prefs.remove(TeamTrackingWidgetKeys.UPCOMING_EVENTS)
+                    }
+                    TeamTrackingWidgetKeys.ALL_LAST_MATCH_KEYS.forEach { prefs.remove(it) }
+                    TeamTrackingWidgetKeys.ALL_NEXT_MATCH_KEYS.forEach { prefs.remove(it) }
+                }
+                TeamTrackingWidget().update(applicationContext, glanceId)
+                Log.d(TAG, "Widget updated for $teamKey — no current event")
+                return false
             }
 
-            Result.success()
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to update widgets", e)
-            Result.retry()
-        }
-    }
+            val eventKey = currentEvent.key
 
-    /** Returns true if the widget has an active event (needs fast refresh). */
-    private suspend fun updateWidgetForTeam(
-        teamKey: String,
-        teamNumber: String,
-        glanceId: androidx.glance.GlanceId,
-    ): Boolean {
-        // Fetch team info and avatar
-        val year = LocalDate.now().year
-        try { teamRepository.refreshTeam(teamKey) } catch (e: Exception) { Log.w(TAG, "Failed to refresh team $teamKey", e) }
-        try { teamRepository.refreshTeamMedia(teamKey, year) } catch (e: Exception) { Log.w(TAG, "Failed to refresh team media $teamKey/$year", e) }
-        val team = teamRepository.observeTeam(teamKey).firstOrNull()
-        val teamNickname = team?.nickname ?: ""
-        val avatar = teamRepository.observeTeamMedia(teamKey, year).firstOrNull()
-            ?.firstOrNull { it.isAvatar }
-            ?: teamRepository.observeTeamMedia(teamKey, year - 1).firstOrNull()
-                ?.firstOrNull { it.isAvatar }
-
-        // Find the team's current event
-        try { eventRepository.refreshTeamEvents(teamKey, year) } catch (e: Exception) { Log.w(TAG, "Failed to refresh team events $teamKey/$year", e) }
-        val events = eventRepository.observeTeamEvents(teamKey, year).firstOrNull()
-            ?: emptyList()
-        val currentEvent = findCurrentEvent(events, teamKey)
-
-        val now = Instant.now()
-            .atZone(ZoneId.systemDefault())
-            .format(timeFormat)
-
-        if (currentEvent == null) {
-            val today = LocalDate.now()
-            val upcomingEvents = events.filter { event ->
-                val start = event.startDate?.let { LocalDate.parse(it) } ?: return@filter false
-                !start.isBefore(today)
-            }.sortedBy { it.startDate }.take(3)
-
-            val upcomingEventsData = upcomingEvents.joinToString("\n") { event ->
-                val name = event.shortName ?: event.name
-                val city = listOfNotNull(event.city, event.state).joinToString(", ")
-                val date = event.startDate?.let {
-                    LocalDate.parse(it).format(DateTimeFormatter.ofPattern("MMM d", Locale.US))
-                } ?: ""
-                "$name\t$city\t$date"
+            // Refresh match data from API
+            try {
+                matchRepository.refreshEventMatches(eventKey)
+            } catch (
+                e: Exception,
+            ) {
+                Log.w(TAG, "Failed to refresh event matches $eventKey", e)
             }
+
+            val event = eventRepository.observeEvent(eventKey).firstOrNull()
+            val eventName = event?.shortName ?: event?.name ?: eventKey
+            val playoffType = event?.playoffType ?: PlayoffType.BRACKET_8_TEAM
+
+            val matches =
+                matchRepository.observeEventMatches(eventKey).firstOrNull()
+                    ?: emptyList()
+
+            // Filter to matches involving this team
+            val teamMatches =
+                matches
+                    .filter { match ->
+                        teamKey in match.redTeamKeys || teamKey in match.blueTeamKeys
+                    }.sortedWith(
+                        compareBy({ it.compLevel.order }, { it.setNumber }, { it.matchNumber }),
+                    )
+
+            val record = computeRecord(teamMatches, teamKey)
+
+            val playedMatches = teamMatches.filter { it.redScore >= 0 }
+            val unplayedMatches = teamMatches.filter { it.redScore < 0 }
+            val lastMatch = playedMatches.lastOrNull()
+            val nextMatch = unplayedMatches.firstOrNull()
 
             updateAppWidgetState(applicationContext, glanceId) { prefs ->
                 prefs.updateTeamInfo(teamNumber, teamKey, teamNickname, avatar, now)
-                prefs.remove(TeamTrackingWidgetKeys.EVENT_KEY)
-                prefs[TeamTrackingWidgetKeys.EVENT_NAME] = ""
-                prefs[TeamTrackingWidgetKeys.RECORD] = ""
-                prefs[TeamTrackingWidgetKeys.NEXT_ALLIANCE] = ""
-                if (upcomingEventsData.isNotEmpty()) {
-                    prefs[TeamTrackingWidgetKeys.UPCOMING_EVENTS] = upcomingEventsData
+                prefs[TeamTrackingWidgetKeys.EVENT_KEY] = eventKey
+                prefs[TeamTrackingWidgetKeys.EVENT_NAME] = eventName
+                prefs[TeamTrackingWidgetKeys.RECORD] = record
+                val nextAlliance =
+                    when {
+                        nextMatch != null && teamKey in nextMatch.redTeamKeys -> "red"
+                        nextMatch != null && teamKey in nextMatch.blueTeamKeys -> "blue"
+                        else -> ""
+                    }
+                prefs[TeamTrackingWidgetKeys.NEXT_ALLIANCE] = nextAlliance
+                prefs.remove(TeamTrackingWidgetKeys.UPCOMING_EVENTS)
+
+                if (lastMatch != null) {
+                    prefs[TeamTrackingWidgetKeys.LAST_MATCH_LABEL] =
+                        lastMatch.getShortLabel(playoffType)
+                    prefs[TeamTrackingWidgetKeys.LAST_MATCH_RED_TEAMS] =
+                        lastMatch.redTeamKeys.joinToString(",") { it.removePrefix("frc") }
+                    prefs[TeamTrackingWidgetKeys.LAST_MATCH_BLUE_TEAMS] =
+                        lastMatch.blueTeamKeys.joinToString(",") { it.removePrefix("frc") }
+                    prefs[TeamTrackingWidgetKeys.LAST_MATCH_RED_SCORE] =
+                        lastMatch.redScore.toString()
+                    prefs[TeamTrackingWidgetKeys.LAST_MATCH_BLUE_SCORE] =
+                        lastMatch.blueScore.toString()
+                    prefs[TeamTrackingWidgetKeys.LAST_MATCH_WINNING_ALLIANCE] =
+                        lastMatch.winningAlliance ?: ""
+                    val rp = lastMatch.rpBonuses()
+                    if (rp != null) {
+                        prefs[TeamTrackingWidgetKeys.LAST_MATCH_RED_RP] = rp.red.joinToString(",")
+                        prefs[TeamTrackingWidgetKeys.LAST_MATCH_BLUE_RP] = rp.blue.joinToString(",")
+                    } else {
+                        prefs.remove(TeamTrackingWidgetKeys.LAST_MATCH_RED_RP)
+                        prefs.remove(TeamTrackingWidgetKeys.LAST_MATCH_BLUE_RP)
+                    }
                 } else {
-                    prefs.remove(TeamTrackingWidgetKeys.UPCOMING_EVENTS)
+                    TeamTrackingWidgetKeys.ALL_LAST_MATCH_KEYS.forEach { prefs.remove(it) }
                 }
-                TeamTrackingWidgetKeys.ALL_LAST_MATCH_KEYS.forEach { prefs.remove(it) }
-                TeamTrackingWidgetKeys.ALL_NEXT_MATCH_KEYS.forEach { prefs.remove(it) }
+
+                if (nextMatch != null) {
+                    prefs[TeamTrackingWidgetKeys.NEXT_MATCH_LABEL] =
+                        nextMatch.getShortLabel(playoffType)
+                    prefs[TeamTrackingWidgetKeys.NEXT_MATCH_RED_TEAMS] =
+                        nextMatch.redTeamKeys.joinToString(",") { it.removePrefix("frc") }
+                    prefs[TeamTrackingWidgetKeys.NEXT_MATCH_BLUE_TEAMS] =
+                        nextMatch.blueTeamKeys.joinToString(",") { it.removePrefix("frc") }
+                    prefs[TeamTrackingWidgetKeys.NEXT_MATCH_TIME] = formatMatchTime(nextMatch)
+                    prefs[TeamTrackingWidgetKeys.NEXT_MATCH_TIME_IS_ESTIMATE] =
+                        isUsingPredictedTime(nextMatch).toString()
+                } else {
+                    TeamTrackingWidgetKeys.ALL_NEXT_MATCH_KEYS.forEach { prefs.remove(it) }
+                }
             }
             TeamTrackingWidget().update(applicationContext, glanceId)
-            Log.d(TAG, "Widget updated for $teamKey — no current event")
-            return false
+            Log.d(TAG, "Widget updated for $teamKey at $eventKey")
+            return true
         }
 
-        val eventKey = currentEvent.key
-
-        // Refresh match data from API
-        try { matchRepository.refreshEventMatches(eventKey) } catch (e: Exception) { Log.w(TAG, "Failed to refresh event matches $eventKey", e) }
-
-        val event = eventRepository.observeEvent(eventKey).firstOrNull()
-        val eventName = event?.shortName ?: event?.name ?: eventKey
-        val playoffType = event?.playoffType ?: PlayoffType.BRACKET_8_TEAM
-
-        val matches = matchRepository.observeEventMatches(eventKey).firstOrNull()
-            ?: emptyList()
-
-        // Filter to matches involving this team
-        val teamMatches = matches.filter { match ->
-            teamKey in match.redTeamKeys || teamKey in match.blueTeamKeys
-        }.sortedWith(
-            compareBy({ it.compLevel.order }, { it.setNumber }, { it.matchNumber })
-        )
-
-        val record = computeRecord(teamMatches, teamKey)
-
-        val playedMatches = teamMatches.filter { it.redScore >= 0 }
-        val unplayedMatches = teamMatches.filter { it.redScore < 0 }
-        val lastMatch = playedMatches.lastOrNull()
-        val nextMatch = unplayedMatches.firstOrNull()
-
-        updateAppWidgetState(applicationContext, glanceId) { prefs ->
-            prefs.updateTeamInfo(teamNumber, teamKey, teamNickname, avatar, now)
-            prefs[TeamTrackingWidgetKeys.EVENT_KEY] = eventKey
-            prefs[TeamTrackingWidgetKeys.EVENT_NAME] = eventName
-            prefs[TeamTrackingWidgetKeys.RECORD] = record
-            val nextAlliance = when {
-                nextMatch != null && teamKey in nextMatch.redTeamKeys -> "red"
-                nextMatch != null && teamKey in nextMatch.blueTeamKeys -> "blue"
-                else -> ""
-            }
-            prefs[TeamTrackingWidgetKeys.NEXT_ALLIANCE] = nextAlliance
-            prefs.remove(TeamTrackingWidgetKeys.UPCOMING_EVENTS)
-
-            if (lastMatch != null) {
-                prefs[TeamTrackingWidgetKeys.LAST_MATCH_LABEL] = lastMatch.getShortLabel(playoffType)
-                prefs[TeamTrackingWidgetKeys.LAST_MATCH_RED_TEAMS] = lastMatch.redTeamKeys.joinToString(",") { it.removePrefix("frc") }
-                prefs[TeamTrackingWidgetKeys.LAST_MATCH_BLUE_TEAMS] = lastMatch.blueTeamKeys.joinToString(",") { it.removePrefix("frc") }
-                prefs[TeamTrackingWidgetKeys.LAST_MATCH_RED_SCORE] = lastMatch.redScore.toString()
-                prefs[TeamTrackingWidgetKeys.LAST_MATCH_BLUE_SCORE] = lastMatch.blueScore.toString()
-                prefs[TeamTrackingWidgetKeys.LAST_MATCH_WINNING_ALLIANCE] = lastMatch.winningAlliance ?: ""
-                val rp = lastMatch.rpBonuses()
-                if (rp != null) {
-                    prefs[TeamTrackingWidgetKeys.LAST_MATCH_RED_RP] = rp.red.joinToString(",")
-                    prefs[TeamTrackingWidgetKeys.LAST_MATCH_BLUE_RP] = rp.blue.joinToString(",")
-                } else {
-                    prefs.remove(TeamTrackingWidgetKeys.LAST_MATCH_RED_RP)
-                    prefs.remove(TeamTrackingWidgetKeys.LAST_MATCH_BLUE_RP)
+        /**
+         * Pick the best event to display: currently running > most recently ended.
+         * Among concurrent events (e.g. division + Einstein at champs), prefer the one
+         * that still has unplayed matches for this team.
+         */
+        private suspend fun findCurrentEvent(
+            events: List<Event>,
+            teamKey: String,
+        ): Event? {
+            if (events.isEmpty()) return null
+            val today = LocalDate.now()
+            val currentEvents =
+                events.filter { event ->
+                    val start = event.startDate?.let { LocalDate.parse(it) } ?: return@filter false
+                    val end = event.endDate?.let { LocalDate.parse(it) } ?: start
+                    today in start..end
                 }
-            } else {
-                TeamTrackingWidgetKeys.ALL_LAST_MATCH_KEYS.forEach { prefs.remove(it) }
-            }
-
-            if (nextMatch != null) {
-                prefs[TeamTrackingWidgetKeys.NEXT_MATCH_LABEL] = nextMatch.getShortLabel(playoffType)
-                prefs[TeamTrackingWidgetKeys.NEXT_MATCH_RED_TEAMS] = nextMatch.redTeamKeys.joinToString(",") { it.removePrefix("frc") }
-                prefs[TeamTrackingWidgetKeys.NEXT_MATCH_BLUE_TEAMS] = nextMatch.blueTeamKeys.joinToString(",") { it.removePrefix("frc") }
-                prefs[TeamTrackingWidgetKeys.NEXT_MATCH_TIME] = formatMatchTime(nextMatch)
-                prefs[TeamTrackingWidgetKeys.NEXT_MATCH_TIME_IS_ESTIMATE] = isUsingPredictedTime(nextMatch).toString()
-            } else {
-                TeamTrackingWidgetKeys.ALL_NEXT_MATCH_KEYS.forEach { prefs.remove(it) }
-            }
-        }
-        TeamTrackingWidget().update(applicationContext, glanceId)
-        Log.d(TAG, "Widget updated for $teamKey at $eventKey")
-        return true
-    }
-
-    /**
-     * Pick the best event to display: currently running > most recently ended.
-     * Among concurrent events (e.g. division + Einstein at champs), prefer the one
-     * that still has unplayed matches for this team.
-     */
-    private suspend fun findCurrentEvent(
-        events: List<Event>,
-        teamKey: String,
-    ): Event? {
-        if (events.isEmpty()) return null
-        val today = LocalDate.now()
-        val currentEvents = events.filter { event ->
-            val start = event.startDate?.let { LocalDate.parse(it) } ?: return@filter false
-            val end = event.endDate?.let { LocalDate.parse(it) } ?: start
-            today in start..end
-        }
-        if (currentEvents.size > 1) {
-            // Multiple concurrent events (e.g. champs division + Einstein).
-            // Prefer the one with unplayed matches for this team.
-            for (event in currentEvents) {
-                try { matchRepository.refreshEventMatches(event.key) } catch (e: Exception) { Log.w(TAG, "Failed to refresh matches for ${event.key}", e) }
-                val matches = matchRepository.observeEventMatches(event.key).firstOrNull()
-                    ?: emptyList()
-                val hasUnplayed = matches.any { match ->
-                    (teamKey in match.redTeamKeys || teamKey in match.blueTeamKeys) &&
-                        match.redScore < 0
+            if (currentEvents.size > 1) {
+                // Multiple concurrent events (e.g. champs division + Einstein).
+                // Prefer the one with unplayed matches for this team.
+                for (event in currentEvents) {
+                    try {
+                        matchRepository.refreshEventMatches(event.key)
+                    } catch (
+                        e: Exception,
+                    ) {
+                        Log.w(TAG, "Failed to refresh matches for ${event.key}", e)
+                    }
+                    val matches =
+                        matchRepository.observeEventMatches(event.key).firstOrNull()
+                            ?: emptyList()
+                    val hasUnplayed =
+                        matches.any { match ->
+                            (teamKey in match.redTeamKeys || teamKey in match.blueTeamKeys) &&
+                                match.redScore < 0
+                        }
+                    if (hasUnplayed) return event
                 }
-                if (hasUnplayed) return event
+                // All events fully played — prefer championship finals (type 4) over division (type 3)
+                return currentEvents.maxBy { it.type ?: 0 }
             }
-            // All events fully played — prefer championship finals (type 4) over division (type 3)
-            return currentEvents.maxBy { it.type ?: 0 }
+            if (currentEvents.isNotEmpty()) return currentEvents.first()
+
+            // Most recently ended event (within the last day, scores may still be updating)
+            val recentPast =
+                events
+                    .filter { event ->
+                        val end = event.endDate?.let { LocalDate.parse(it) } ?: return@filter false
+                        end.isBefore(today) && end.isAfter(today.minusDays(2))
+                    }.maxByOrNull { it.endDate ?: "" }
+            if (recentPast != null) return recentPast
+
+            // Don't return upcoming events as "current" — they'll show in the upcoming events section
+            return null
         }
-        if (currentEvents.isNotEmpty()) return currentEvents.first()
 
-        // Most recently ended event (within the last day, scores may still be updating)
-        val recentPast = events.filter { event ->
-            val end = event.endDate?.let { LocalDate.parse(it) } ?: return@filter false
-            end.isBefore(today) && end.isAfter(today.minusDays(2))
-        }.maxByOrNull { it.endDate ?: "" }
-        if (recentPast != null) return recentPast
-
-        // Don't return upcoming events as "current" — they'll show in the upcoming events section
-        return null
-    }
-
-    private fun MutablePreferences.updateTeamInfo(
-        teamNumber: String,
-        teamKey: String,
-        teamNickname: String,
-        avatar: Media?,
-        now: String,
-    ) {
-        this[TeamTrackingWidgetKeys.TEAM_NUMBER] = teamNumber
-        this[TeamTrackingWidgetKeys.TEAM_KEY] = teamKey
-        this[TeamTrackingWidgetKeys.TEAM_NICKNAME] = teamNickname
-        if (avatar?.base64Image != null) {
-            this[TeamTrackingWidgetKeys.AVATAR_BASE64] = avatar.base64Image
-        } else {
-            remove(TeamTrackingWidgetKeys.AVATAR_BASE64)
-        }
-        this[TeamTrackingWidgetKeys.LAST_UPDATED] = now
-    }
-
-    private fun computeRecord(matches: List<Match>, teamKey: String): String {
-        var wins = 0
-        var losses = 0
-        var ties = 0
-        for (match in matches) {
-            if (match.redScore < 0) continue
-            val isOnRed = teamKey in match.redTeamKeys
-            when {
-                match.winningAlliance == "red" && isOnRed -> wins++
-                match.winningAlliance == "blue" && !isOnRed -> wins++
-                match.winningAlliance == "" || match.winningAlliance == null -> ties++
-                else -> losses++
+        private fun MutablePreferences.updateTeamInfo(
+            teamNumber: String,
+            teamKey: String,
+            teamNickname: String,
+            avatar: Media?,
+            now: String,
+        ) {
+            this[TeamTrackingWidgetKeys.TEAM_NUMBER] = teamNumber
+            this[TeamTrackingWidgetKeys.TEAM_KEY] = teamKey
+            this[TeamTrackingWidgetKeys.TEAM_NICKNAME] = teamNickname
+            if (avatar?.base64Image != null) {
+                this[TeamTrackingWidgetKeys.AVATAR_BASE64] = avatar.base64Image
+            } else {
+                remove(TeamTrackingWidgetKeys.AVATAR_BASE64)
             }
+            this[TeamTrackingWidgetKeys.LAST_UPDATED] = now
         }
-        return "$wins-$losses-$ties"
-    }
 
-    private fun formatMatchTime(match: Match): String {
-        val epochSeconds = match.predictedTime ?: match.time ?: return "TBD"
-        val instant = Instant.ofEpochSecond(epochSeconds)
-        val zoned = instant.atZone(ZoneId.systemDefault())
-        val today = LocalDate.now()
-        val format = if (zoned.toLocalDate() == today) timeFormat else timeWithDayFormat
-        return format.format(zoned)
-    }
+        private fun computeRecord(
+            matches: List<Match>,
+            teamKey: String,
+        ): String {
+            var wins = 0
+            var losses = 0
+            var ties = 0
+            for (match in matches) {
+                if (match.redScore < 0) continue
+                val isOnRed = teamKey in match.redTeamKeys
+                when {
+                    match.winningAlliance == "red" && isOnRed -> wins++
+                    match.winningAlliance == "blue" && !isOnRed -> wins++
+                    match.winningAlliance == "" || match.winningAlliance == null -> ties++
+                    else -> losses++
+                }
+            }
+            return "$wins-$losses-$ties"
+        }
 
-    private fun isUsingPredictedTime(match: Match): Boolean {
-        return match.predictedTime != null
+        private fun formatMatchTime(match: Match): String {
+            val epochSeconds = match.predictedTime ?: match.time ?: return "TBD"
+            val instant = Instant.ofEpochSecond(epochSeconds)
+            val zoned = instant.atZone(ZoneId.systemDefault())
+            val today = LocalDate.now()
+            val format = if (zoned.toLocalDate() == today) timeFormat else timeWithDayFormat
+            return format.format(zoned)
+        }
+
+        private fun isUsingPredictedTime(match: Match): Boolean = match.predictedTime != null
     }
-}

--- a/app/src/test/kotlin/com/thebluealliance/android/data/mappers/RankingMappersTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/data/mappers/RankingMappersTest.kt
@@ -7,18 +7,20 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class RankingMappersTest {
-
     @Test
     fun `toSortOrderEntity persists both sort order and extra stats metadata`() {
-        val response = RankingResponseDto(
-            sortOrderInfo = listOf(
-                RankingSortOrderDto(name = "Ranking Score", precision = 2),
-                RankingSortOrderDto(name = "Auto", precision = 0),
-            ),
-            extraStatsInfo = listOf(
-                RankingSortOrderDto(name = "Cargo", precision = 1),
-            ),
-        )
+        val response =
+            RankingResponseDto(
+                sortOrderInfo =
+                    listOf(
+                        RankingSortOrderDto(name = "Ranking Score", precision = 2),
+                        RankingSortOrderDto(name = "Auto", precision = 0),
+                    ),
+                extraStatsInfo =
+                    listOf(
+                        RankingSortOrderDto(name = "Cargo", precision = 1),
+                    ),
+            )
 
         val entity = response.toSortOrderEntity("2026test")
 
@@ -29,13 +31,15 @@ class RankingMappersTest {
 
     @Test
     fun `getSortOrderInfo decodes metadata names and precision`() {
-        val response = RankingResponseDto(
-            sortOrderInfo = listOf(
-                RankingSortOrderDto(name = "Ranking Score", precision = 2),
-                RankingSortOrderDto(name = "Auto", precision = 0),
-            ),
-            extraStatsInfo = emptyList(),
-        )
+        val response =
+            RankingResponseDto(
+                sortOrderInfo =
+                    listOf(
+                        RankingSortOrderDto(name = "Ranking Score", precision = 2),
+                        RankingSortOrderDto(name = "Auto", precision = 0),
+                    ),
+                extraStatsInfo = emptyList(),
+            )
         val entity = response.toSortOrderEntity("2026test")
         assertEquals(true, entity.sortOrderInfo.startsWith("["))
 
@@ -50,11 +54,12 @@ class RankingMappersTest {
 
     @Test
     fun `getExtraStatsInfo returns empty list for malformed json`() {
-        val entity = EventRankingSortOrderEntity(
-            eventKey = "2026test",
-            sortOrderInfo = "[]",
-            extraStatsInfo = "not-json",
-        )
+        val entity =
+            EventRankingSortOrderEntity(
+                eventKey = "2026test",
+                sortOrderInfo = "[]",
+                extraStatsInfo = "not-json",
+            )
 
         val extraStats = entity.getExtraStatsInfo()
 

--- a/app/src/test/kotlin/com/thebluealliance/android/data/repository/DistrictRepositoryTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/data/repository/DistrictRepositoryTest.kt
@@ -13,38 +13,58 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class DistrictRepositoryTest {
-
     private val api: TbaApi = mockk()
-    private val db: TBADatabase = mockk(relaxed = true) {
-        val executor = java.util.concurrent.Executors.newSingleThreadExecutor()
-        every { queryExecutor } returns executor
-        every { transactionExecutor } returns executor
-    }
+    private val db: TBADatabase =
+        mockk(relaxed = true) {
+            val executor =
+                java.util.concurrent.Executors
+                    .newSingleThreadExecutor()
+            every { queryExecutor } returns executor
+            every { transactionExecutor } returns executor
+        }
     private val districtDao: DistrictDao = mockk(relaxUnitFun = true)
     private val districtRankingDao: DistrictRankingDao = mockk(relaxUnitFun = true)
 
     private val repo = DistrictRepository(api, db, districtDao, districtRankingDao)
 
     @Test
-    fun `getDistrictHistory returns years sorted descending`() = runTest {
-        val dtos = listOf(
-            DistrictDto(abbreviation = "ne", displayName = "New England", key = "2022ne", year = 2022),
-            DistrictDto(abbreviation = "ne", displayName = "New England", key = "2024ne", year = 2024),
-            DistrictDto(abbreviation = "ne", displayName = "New England", key = "2023ne", year = 2023),
-        )
-        coEvery { api.getDistrictHistory("ne") } returns dtos
+    fun `getDistrictHistory returns years sorted descending`() =
+        runTest {
+            val dtos =
+                listOf(
+                    DistrictDto(
+                        abbreviation = "ne",
+                        displayName = "New England",
+                        key = "2022ne",
+                        year = 2022,
+                    ),
+                    DistrictDto(
+                        abbreviation = "ne",
+                        displayName = "New England",
+                        key = "2024ne",
+                        year = 2024,
+                    ),
+                    DistrictDto(
+                        abbreviation = "ne",
+                        displayName = "New England",
+                        key = "2023ne",
+                        year = 2023,
+                    ),
+                )
+            coEvery { api.getDistrictHistory("ne") } returns dtos
 
-        val years = repo.getDistrictHistory("ne")
+            val years = repo.getDistrictHistory("ne")
 
-        assertEquals(listOf(2024, 2023, 2022), years)
-    }
+            assertEquals(listOf(2024, 2023, 2022), years)
+        }
 
     @Test
-    fun `getDistrictHistory returns empty list when API returns empty`() = runTest {
-        coEvery { api.getDistrictHistory("ne") } returns emptyList()
+    fun `getDistrictHistory returns empty list when API returns empty`() =
+        runTest {
+            coEvery { api.getDistrictHistory("ne") } returns emptyList()
 
-        val years = repo.getDistrictHistory("ne")
+            val years = repo.getDistrictHistory("ne")
 
-        assertEquals(emptyList<Int>(), years)
-    }
+            assertEquals(emptyList<Int>(), years)
+        }
 }

--- a/app/src/test/kotlin/com/thebluealliance/android/data/repository/EventRepositoryTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/data/repository/EventRepositoryTest.kt
@@ -33,11 +33,14 @@ import org.junit.jupiter.api.Test
 
 class EventRepositoryTest {
     private val api: TbaApi = mockk()
-    private val db: TBADatabase = mockk(relaxed = true) {
-        val executor = java.util.concurrent.Executors.newSingleThreadExecutor()
-        every { queryExecutor } returns executor
-        every { transactionExecutor } returns executor
-    }
+    private val db: TBADatabase =
+        mockk(relaxed = true) {
+            val executor =
+                java.util.concurrent.Executors
+                    .newSingleThreadExecutor()
+            every { queryExecutor } returns executor
+            every { transactionExecutor } returns executor
+        }
     private val eventDao: EventDao = mockk(relaxUnitFun = true)
     private val awardDao: AwardDao = mockk(relaxUnitFun = true)
     private val rankingDao: RankingDao = mockk(relaxUnitFun = true)
@@ -50,128 +53,138 @@ class EventRepositoryTest {
     private val eventRankingSortOrderDao: EventRankingSortOrderDao = mockk(relaxUnitFun = true)
     private val teamEventStatusDao: TeamEventStatusDao = mockk(relaxUnitFun = true)
 
-    private val repo = EventRepository(
-        api,
-        db,
-        eventDao,
-        awardDao,
-        rankingDao,
-        allianceDao,
-        eventTeamDao,
-        eventDistrictPointsDao,
-        eventOPRsDao,
-        eventCOPRsDao,
-        eventInsightsDao,
-        eventRankingSortOrderDao,
-        teamEventStatusDao,
-    )
+    private val repo =
+        EventRepository(
+            api,
+            db,
+            eventDao,
+            awardDao,
+            rankingDao,
+            allianceDao,
+            eventTeamDao,
+            eventDistrictPointsDao,
+            eventOPRsDao,
+            eventCOPRsDao,
+            eventInsightsDao,
+            eventRankingSortOrderDao,
+            teamEventStatusDao,
+        )
 
     @Test
-    fun `refreshEventsForYear fetches from API and inserts into DAO`() = runTest {
-        val dto = EventDto(
-            key = "2024casj",
-            name = "Silicon Valley Regional",
-            eventCode = "casj",
-            year = 2024,
-            city = "San Jose",
-            stateProv = "CA",
-            country = "USA",
-            startDate = "2024-03-27",
-            endDate = "2024-03-30",
-        )
-        coEvery { api.getEventsForYear(2024) } returns listOf(dto)
+    fun `refreshEventsForYear fetches from API and inserts into DAO`() =
+        runTest {
+            val dto =
+                EventDto(
+                    key = "2024casj",
+                    name = "Silicon Valley Regional",
+                    eventCode = "casj",
+                    year = 2024,
+                    city = "San Jose",
+                    stateProv = "CA",
+                    country = "USA",
+                    startDate = "2024-03-27",
+                    endDate = "2024-03-30",
+                )
+            coEvery { api.getEventsForYear(2024) } returns listOf(dto)
 
-        val insertedSlot = slot<List<EventEntity>>()
-        coEvery { eventDao.insertAll(capture(insertedSlot)) } returns Unit
+            val insertedSlot = slot<List<EventEntity>>()
+            coEvery { eventDao.insertAll(capture(insertedSlot)) } returns Unit
 
-        repo.refreshEventsForYear(2024)
+            repo.refreshEventsForYear(2024)
 
-        coVerify(exactly = 1) { api.getEventsForYear(2024) }
-        coVerify(exactly = 1) { eventDao.deleteByYear(2024) }
-        coVerify(exactly = 1) { eventDao.insertAll(any()) }
+            coVerify(exactly = 1) { api.getEventsForYear(2024) }
+            coVerify(exactly = 1) { eventDao.deleteByYear(2024) }
+            coVerify(exactly = 1) { eventDao.insertAll(any()) }
 
-        val inserted = insertedSlot.captured
-        assertEquals(1, inserted.size)
-        assertEquals("2024casj", inserted[0].key)
-        assertEquals("Silicon Valley Regional", inserted[0].name)
-        assertEquals(2024, inserted[0].year)
-        assertEquals("CA", inserted[0].state)
-    }
-
-    @Test
-    fun `observeEventsForYear returns domain models from DAO`() = runTest {
-        val entity = EventEntity(
-            key = "2024casj",
-            name = "Silicon Valley Regional",
-            eventCode = "casj",
-            year = 2024,
-            type = null,
-            district = null,
-            city = "San Jose",
-            state = "CA",
-            country = "USA",
-            startDate = "2024-03-27",
-            endDate = "2024-03-30",
-            week = 4,
-            shortName = "Silicon Valley",
-            website = null,
-            timezone = null,
-            webcasts = null,
-            locationName = null,
-            address = null,
-            gmapsUrl = null,
-            playoffType = 8,
-        )
-        every { eventDao.observeByYear(2024) } returns flowOf(listOf(entity))
-
-        repo.observeEventsForYear(2024).test {
-            val events = awaitItem()
-            assertEquals(1, events.size)
-            assertEquals("2024casj", events[0].key)
-            assertEquals("Silicon Valley Regional", events[0].name)
-            assertEquals("CA", events[0].state)
-            awaitComplete()
+            val inserted = insertedSlot.captured
+            assertEquals(1, inserted.size)
+            assertEquals("2024casj", inserted[0].key)
+            assertEquals("Silicon Valley Regional", inserted[0].name)
+            assertEquals(2024, inserted[0].year)
+            assertEquals("CA", inserted[0].state)
         }
-    }
 
     @Test
-    fun `refreshEventRankings persists rankings and sort order metadata`() = runTest {
-        val eventKey = "2026test"
-        val response = RankingResponseDto(
-            rankings = listOf(
-                RankingItemDto(
-                    teamKey = "frc254",
-                    rank = 1,
-                    matchesPlayed = 12,
-                    record = TeamRecordDto(wins = 10, losses = 2, ties = 0),
-                    sortOrders = listOf(2.5, 1.0),
-                    extraStats = listOf(120.0),
-                ),
-            ),
-            sortOrderInfo = listOf(
-                RankingSortOrderDto(name = "Ranking Score", precision = 2),
-                RankingSortOrderDto(name = "Auto Points", precision = 0),
-            ),
-            extraStatsInfo = listOf(
-                RankingSortOrderDto(name = "Cargo Scored", precision = 0),
-            ),
-        )
-        coEvery { api.getEventRankings(eventKey) } returns response
+    fun `observeEventsForYear returns domain models from DAO`() =
+        runTest {
+            val entity =
+                EventEntity(
+                    key = "2024casj",
+                    name = "Silicon Valley Regional",
+                    eventCode = "casj",
+                    year = 2024,
+                    type = null,
+                    district = null,
+                    city = "San Jose",
+                    state = "CA",
+                    country = "USA",
+                    startDate = "2024-03-27",
+                    endDate = "2024-03-30",
+                    week = 4,
+                    shortName = "Silicon Valley",
+                    website = null,
+                    timezone = null,
+                    webcasts = null,
+                    locationName = null,
+                    address = null,
+                    gmapsUrl = null,
+                    playoffType = 8,
+                )
+            every { eventDao.observeByYear(2024) } returns flowOf(listOf(entity))
 
-        val sortOrderEntitySlot = slot<EventRankingSortOrderEntity>()
-        coEvery { eventRankingSortOrderDao.insert(capture(sortOrderEntitySlot)) } returns Unit
+            repo.observeEventsForYear(2024).test {
+                val events = awaitItem()
+                assertEquals(1, events.size)
+                assertEquals("2024casj", events[0].key)
+                assertEquals("Silicon Valley Regional", events[0].name)
+                assertEquals("CA", events[0].state)
+                awaitComplete()
+            }
+        }
 
-        repo.refreshEventRankings(eventKey)
+    @Test
+    fun `refreshEventRankings persists rankings and sort order metadata`() =
+        runTest {
+            val eventKey = "2026test"
+            val response =
+                RankingResponseDto(
+                    rankings =
+                        listOf(
+                            RankingItemDto(
+                                teamKey = "frc254",
+                                rank = 1,
+                                matchesPlayed = 12,
+                                record = TeamRecordDto(wins = 10, losses = 2, ties = 0),
+                                sortOrders = listOf(2.5, 1.0),
+                                extraStats = listOf(120.0),
+                            ),
+                        ),
+                    sortOrderInfo =
+                        listOf(
+                            RankingSortOrderDto(name = "Ranking Score", precision = 2),
+                            RankingSortOrderDto(name = "Auto Points", precision = 0),
+                        ),
+                    extraStatsInfo =
+                        listOf(
+                            RankingSortOrderDto(name = "Cargo Scored", precision = 0),
+                        ),
+                )
+            coEvery { api.getEventRankings(eventKey) } returns response
 
-        coVerify(exactly = 1) { api.getEventRankings(eventKey) }
-        coVerify(exactly = 1) { rankingDao.deleteByEvent(eventKey) }
-        coVerify(exactly = 1) { rankingDao.insertAll(any()) }
-        coVerify(exactly = 1) { eventRankingSortOrderDao.delete(eventKey) }
-        coVerify(exactly = 1) { eventRankingSortOrderDao.insert(any()) }
+            val sortOrderEntitySlot = slot<EventRankingSortOrderEntity>()
+            coEvery { eventRankingSortOrderDao.insert(capture(sortOrderEntitySlot)) } returns Unit
 
-        val entity = sortOrderEntitySlot.captured
-        assertEquals(eventKey, entity.eventKey)
-        assertEquals(true, entity.sortOrderInfo.contains("Ranking Score"))
-        assertEquals(true, entity.extraStatsInfo?.contains("Cargo Scored") == true)
-    }
+            repo.refreshEventRankings(eventKey)
+
+            coVerify(exactly = 1) { api.getEventRankings(eventKey) }
+            coVerify(exactly = 1) { rankingDao.deleteByEvent(eventKey) }
+            coVerify(exactly = 1) { rankingDao.insertAll(any()) }
+            coVerify(exactly = 1) { eventRankingSortOrderDao.delete(eventKey) }
+            coVerify(exactly = 1) { eventRankingSortOrderDao.insert(any()) }
+
+            val entity = sortOrderEntitySlot.captured
+            assertEquals(eventKey, entity.eventKey)
+            assertEquals(true, entity.sortOrderInfo.contains("Ranking Score"))
+            assertEquals(true, entity.extraStatsInfo?.contains("Cargo Scored") == true)
+        }
 }

--- a/app/src/test/kotlin/com/thebluealliance/android/data/repository/RegionalAdvancementRepositoryTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/data/repository/RegionalAdvancementRepositoryTest.kt
@@ -12,163 +12,188 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class RegionalAdvancementRepositoryTest {
-
     private val api: TbaApi = mockk()
     private val repository = RegionalAdvancementRepository(api)
 
     @Test
-    fun `getRegionalRankings maps and sorts rankings`() = runTest {
-        coEvery { api.getRegionalAdvancementRankings(2026) } returns listOf(
-            RegionalRankingDto(
-                teamKey = "frc254",
-                rank = 2,
-                pointTotal = 67.0,
-                eventPoints = listOf(RegionalEventPointsDto(eventKey = "2026cafr", total = 34.0)),
-            ),
-            RegionalRankingDto(
-                teamKey = "frc1114",
-                rank = 1,
-                pointTotal = 70.0,
-                rookieBonus = 0.0,
-                singleEventBonus = 3.0,
-                eventPoints = listOf(RegionalEventPointsDto(eventKey = "2026oncmp", total = 40.0)),
-            ),
-        )
-        coEvery { api.getRegionalAdvancement(2026) } returns emptyMap()
+    fun `getRegionalRankings maps and sorts rankings`() =
+        runTest {
+            coEvery { api.getRegionalAdvancementRankings(2026) } returns
+                listOf(
+                    RegionalRankingDto(
+                        teamKey = "frc254",
+                        rank = 2,
+                        pointTotal = 67.0,
+                        eventPoints =
+                            listOf(
+                                RegionalEventPointsDto(eventKey = "2026cafr", total = 34.0),
+                            ),
+                    ),
+                    RegionalRankingDto(
+                        teamKey = "frc1114",
+                        rank = 1,
+                        pointTotal = 70.0,
+                        rookieBonus = 0.0,
+                        singleEventBonus = 3.0,
+                        eventPoints =
+                            listOf(
+                                RegionalEventPointsDto(eventKey = "2026oncmp", total = 40.0),
+                            ),
+                    ),
+                )
+            coEvery { api.getRegionalAdvancement(2026) } returns emptyMap()
 
-        val rankings = repository.getRegionalRankings(2026)
+            val rankings = repository.getRegionalRankings(2026)
 
-        assertEquals(2, rankings.size)
-        assertEquals("frc1114", rankings[0].teamKey)
-        assertEquals(1, rankings[0].rank)
-        assertEquals("2026oncmp", rankings[0].eventPoints.first().eventKey)
-        assertEquals(3.0, rankings[0].singleEventBonus)
-    }
-
-    @Test
-    fun `getRegionalRankings includes championship qualification status`() = runTest {
-        coEvery { api.getRegionalAdvancementRankings(2026) } returns listOf(
-            RegionalRankingDto(
-                teamKey = "frc1816",
-                rank = 1,
-                pointTotal = 85.0,
-                eventPoints = listOf(
-                    RegionalEventPointsDto(eventKey = "2026week1", total = 45.0),
-                    RegionalEventPointsDto(eventKey = "2026week2", total = 40.0),
-                ),
-            ),
-            RegionalRankingDto(
-                teamKey = "frc254",
-                rank = 2,
-                pointTotal = 67.0,
-                eventPoints = listOf(RegionalEventPointsDto(eventKey = "2026cafr", total = 67.0)),
-            ),
-        )
-        coEvery { api.getRegionalAdvancement(2026) } returns mapOf(
-            "frc1816" to RegionalAdvancementDto(
-                cmp = true,
-                cmpStatus = "PreQualified",
-                qualifyingPoolWeek = 1,
-            )
-        )
-
-        val rankings = repository.getRegionalRankings(2026)
-
-        assertEquals(2, rankings.size)
-        assertEquals("frc1816", rankings[0].teamKey)
-        assertEquals("PreQualified", rankings[0].advancementMethod)
-        assertEquals("frc254", rankings[1].teamKey)
-        assertNull(rankings[1].advancementMethod)
-    }
+            assertEquals(2, rankings.size)
+            assertEquals("frc1114", rankings[0].teamKey)
+            assertEquals(1, rankings[0].rank)
+            assertEquals("2026oncmp", rankings[0].eventPoints.first().eventKey)
+            assertEquals(3.0, rankings[0].singleEventBonus)
+        }
 
     @Test
-    fun `getRegionalRankings handles various championship statuses`() = runTest {
-        coEvery { api.getRegionalAdvancementRankings(2026) } returns listOf(
-            RegionalRankingDto(teamKey = "frc1816", rank = 1, pointTotal = 90.0),
-            RegionalRankingDto(teamKey = "frc254", rank = 2, pointTotal = 85.0),
-            RegionalRankingDto(teamKey = "frc1114", rank = 3, pointTotal = 80.0),
-            RegionalRankingDto(teamKey = "frc971", rank = 4, pointTotal = 75.0),
-        )
-        coEvery { api.getRegionalAdvancement(2026) } returns mapOf(
-            "frc1816" to RegionalAdvancementDto(
-                cmp = true,
-                cmpStatus = "PreQualified",
-                qualifyingPoolWeek = 1,
-            ),
-            "frc254" to RegionalAdvancementDto(
-                cmp = true,
-                cmpStatus = "Qualified",
-                qualifyingPoolWeek = 3,
-            ),
-            "frc1114" to RegionalAdvancementDto(
-                cmp = true,
-                cmpStatus = "Waitlisted",
-                qualifyingPoolWeek = null,
-            ),
-        )
+    fun `getRegionalRankings includes championship qualification status`() =
+        runTest {
+            coEvery { api.getRegionalAdvancementRankings(2026) } returns
+                listOf(
+                    RegionalRankingDto(
+                        teamKey = "frc1816",
+                        rank = 1,
+                        pointTotal = 85.0,
+                        eventPoints =
+                            listOf(
+                                RegionalEventPointsDto(eventKey = "2026week1", total = 45.0),
+                                RegionalEventPointsDto(eventKey = "2026week2", total = 40.0),
+                            ),
+                    ),
+                    RegionalRankingDto(
+                        teamKey = "frc254",
+                        rank = 2,
+                        pointTotal = 67.0,
+                        eventPoints =
+                            listOf(
+                                RegionalEventPointsDto(eventKey = "2026cafr", total = 67.0),
+                            ),
+                    ),
+                )
+            coEvery { api.getRegionalAdvancement(2026) } returns
+                mapOf(
+                    "frc1816" to
+                        RegionalAdvancementDto(
+                            cmp = true,
+                            cmpStatus = "PreQualified",
+                            qualifyingPoolWeek = 1,
+                        ),
+                )
 
-        val rankings = repository.getRegionalRankings(2026)
+            val rankings = repository.getRegionalRankings(2026)
 
-        assertEquals(4, rankings.size)
-        assertEquals("PreQualified", rankings[0].advancementMethod)
-        assertEquals("Qualified", rankings[1].advancementMethod)
-        assertEquals("Waitlisted", rankings[2].advancementMethod)
-        assertNull(rankings[3].advancementMethod)
-    }
-
-    @Test
-    fun `getRegionalRankings handles null API responses`() = runTest {
-        coEvery { api.getRegionalAdvancementRankings(2026) } returns null
-        coEvery { api.getRegionalAdvancement(2026) } returns null
-
-        val rankings = repository.getRegionalRankings(2026)
-
-        assertEquals(0, rankings.size)
-    }
-
-    @Test
-    fun `getRegionalRankings handles empty event points`() = runTest {
-        coEvery { api.getRegionalAdvancementRankings(2026) } returns listOf(
-            RegionalRankingDto(
-                teamKey = "frc254",
-                rank = 1,
-                pointTotal = 50.0,
-                rookieBonus = 20.0,
-                singleEventBonus = 30.0,
-                eventPoints = emptyList(),
-            ),
-        )
-        coEvery { api.getRegionalAdvancement(2026) } returns emptyMap()
-
-        val rankings = repository.getRegionalRankings(2026)
-
-        assertEquals(1, rankings.size)
-        assertEquals("frc254", rankings[0].teamKey)
-        assertEquals(50.0, rankings[0].pointTotal)
-        assertEquals(20.0, rankings[0].rookieBonus)
-        assertEquals(30.0, rankings[0].singleEventBonus)
-        assertEquals(0, rankings[0].eventPoints.size)
-    }
+            assertEquals(2, rankings.size)
+            assertEquals("frc1816", rankings[0].teamKey)
+            assertEquals("PreQualified", rankings[0].advancementMethod)
+            assertEquals("frc254", rankings[1].teamKey)
+            assertNull(rankings[1].advancementMethod)
+        }
 
     @Test
-    fun `getRegionalRankings sorts by rank ascending`() = runTest {
-        coEvery { api.getRegionalAdvancementRankings(2026) } returns listOf(
-            RegionalRankingDto(teamKey = "frc254", rank = 5, pointTotal = 50.0),
-            RegionalRankingDto(teamKey = "frc1114", rank = 2, pointTotal = 80.0),
-            RegionalRankingDto(teamKey = "frc971", rank = 3, pointTotal = 75.0),
-            RegionalRankingDto(teamKey = "frc1816", rank = 1, pointTotal = 90.0),
-            RegionalRankingDto(teamKey = "frc118", rank = 4, pointTotal = 60.0),
-        )
-        coEvery { api.getRegionalAdvancement(2026) } returns emptyMap()
+    fun `getRegionalRankings handles various championship statuses`() =
+        runTest {
+            coEvery { api.getRegionalAdvancementRankings(2026) } returns
+                listOf(
+                    RegionalRankingDto(teamKey = "frc1816", rank = 1, pointTotal = 90.0),
+                    RegionalRankingDto(teamKey = "frc254", rank = 2, pointTotal = 85.0),
+                    RegionalRankingDto(teamKey = "frc1114", rank = 3, pointTotal = 80.0),
+                    RegionalRankingDto(teamKey = "frc971", rank = 4, pointTotal = 75.0),
+                )
+            coEvery { api.getRegionalAdvancement(2026) } returns
+                mapOf(
+                    "frc1816" to
+                        RegionalAdvancementDto(
+                            cmp = true,
+                            cmpStatus = "PreQualified",
+                            qualifyingPoolWeek = 1,
+                        ),
+                    "frc254" to
+                        RegionalAdvancementDto(
+                            cmp = true,
+                            cmpStatus = "Qualified",
+                            qualifyingPoolWeek = 3,
+                        ),
+                    "frc1114" to
+                        RegionalAdvancementDto(
+                            cmp = true,
+                            cmpStatus = "Waitlisted",
+                            qualifyingPoolWeek = null,
+                        ),
+                )
 
-        val rankings = repository.getRegionalRankings(2026)
+            val rankings = repository.getRegionalRankings(2026)
 
-        assertEquals(5, rankings.size)
-        assertEquals(1, rankings[0].rank)
-        assertEquals(2, rankings[1].rank)
-        assertEquals(3, rankings[2].rank)
-        assertEquals(4, rankings[3].rank)
-        assertEquals(5, rankings[4].rank)
-    }
+            assertEquals(4, rankings.size)
+            assertEquals("PreQualified", rankings[0].advancementMethod)
+            assertEquals("Qualified", rankings[1].advancementMethod)
+            assertEquals("Waitlisted", rankings[2].advancementMethod)
+            assertNull(rankings[3].advancementMethod)
+        }
+
+    @Test
+    fun `getRegionalRankings handles null API responses`() =
+        runTest {
+            coEvery { api.getRegionalAdvancementRankings(2026) } returns null
+            coEvery { api.getRegionalAdvancement(2026) } returns null
+
+            val rankings = repository.getRegionalRankings(2026)
+
+            assertEquals(0, rankings.size)
+        }
+
+    @Test
+    fun `getRegionalRankings handles empty event points`() =
+        runTest {
+            coEvery { api.getRegionalAdvancementRankings(2026) } returns
+                listOf(
+                    RegionalRankingDto(
+                        teamKey = "frc254",
+                        rank = 1,
+                        pointTotal = 50.0,
+                        rookieBonus = 20.0,
+                        singleEventBonus = 30.0,
+                        eventPoints = emptyList(),
+                    ),
+                )
+            coEvery { api.getRegionalAdvancement(2026) } returns emptyMap()
+
+            val rankings = repository.getRegionalRankings(2026)
+
+            assertEquals(1, rankings.size)
+            assertEquals("frc254", rankings[0].teamKey)
+            assertEquals(50.0, rankings[0].pointTotal)
+            assertEquals(20.0, rankings[0].rookieBonus)
+            assertEquals(30.0, rankings[0].singleEventBonus)
+            assertEquals(0, rankings[0].eventPoints.size)
+        }
+
+    @Test
+    fun `getRegionalRankings sorts by rank ascending`() =
+        runTest {
+            coEvery { api.getRegionalAdvancementRankings(2026) } returns
+                listOf(
+                    RegionalRankingDto(teamKey = "frc254", rank = 5, pointTotal = 50.0),
+                    RegionalRankingDto(teamKey = "frc1114", rank = 2, pointTotal = 80.0),
+                    RegionalRankingDto(teamKey = "frc971", rank = 3, pointTotal = 75.0),
+                    RegionalRankingDto(teamKey = "frc1816", rank = 1, pointTotal = 90.0),
+                    RegionalRankingDto(teamKey = "frc118", rank = 4, pointTotal = 60.0),
+                )
+            coEvery { api.getRegionalAdvancement(2026) } returns emptyMap()
+
+            val rankings = repository.getRegionalRankings(2026)
+
+            assertEquals(5, rankings.size)
+            assertEquals(1, rankings[0].rank)
+            assertEquals(2, rankings[1].rank)
+            assertEquals(3, rankings[2].rank)
+            assertEquals(4, rankings[3].rank)
+            assertEquals(5, rankings[4].rank)
+        }
 }
-

--- a/app/src/test/kotlin/com/thebluealliance/android/domain/MatchGroupExtensionTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/domain/MatchGroupExtensionTest.kt
@@ -4,33 +4,33 @@ import com.thebluealliance.android.domain.model.CompLevel
 import com.thebluealliance.android.domain.model.Match
 import com.thebluealliance.android.domain.model.MatchGroup
 import com.thebluealliance.android.domain.model.PlayoffType
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
 
 class MatchGroupExtensionTest {
-
     private fun createMatch(
         compLevel: CompLevel = CompLevel.QUAL,
         matchNumber: Int = 1,
         setNumber: Int = 1,
-    ): Match = Match(
-        key = "2023test_${compLevel.code}m${matchNumber}",
-        eventKey = "2023test",
-        compLevel = compLevel,
-        matchNumber = matchNumber,
-        setNumber = setNumber,
-        time = null,
-        actualTime = null,
-        predictedTime = null,
-        redTeamKeys = listOf("frc1", "frc2", "frc3"),
-        redScore = 100,
-        blueTeamKeys = listOf("frc4", "frc5", "frc6"),
-        blueScore = 110,
-        winningAlliance = "blue",
-    )
+    ): Match =
+        Match(
+            key = "2023test_${compLevel.code}m$matchNumber",
+            eventKey = "2023test",
+            compLevel = compLevel,
+            matchNumber = matchNumber,
+            setNumber = setNumber,
+            time = null,
+            actualTime = null,
+            predictedTime = null,
+            redTeamKeys = listOf("frc1", "frc2", "frc3"),
+            redScore = 100,
+            blueTeamKeys = listOf("frc4", "frc5", "frc6"),
+            blueScore = 110,
+            winningAlliance = "blue",
+        )
 
     @Nested
     inner class GetGroupTests {
@@ -254,7 +254,11 @@ class MatchGroupExtensionTest {
                     val match = createMatch(compLevel = CompLevel.OCTOFINAL, setNumber = setNum)
                     val result = match.getGroup(PlayoffType.LEGACY_DOUBLE_ELIM_8_TEAM)
                     val round = assertInstanceOf<MatchGroup.DoubleEliminationRound.Round>(result)
-                    assertEquals(1, round.number, "OCTOFINAL setNumber $setNum should map to Round 1")
+                    assertEquals(
+                        1,
+                        round.number,
+                        "OCTOFINAL setNumber $setNum should map to Round 1",
+                    )
                 }
             }
 
@@ -264,7 +268,11 @@ class MatchGroupExtensionTest {
                     val match = createMatch(compLevel = CompLevel.OCTOFINAL, setNumber = setNum)
                     val result = match.getGroup(PlayoffType.LEGACY_DOUBLE_ELIM_8_TEAM)
                     val round = assertInstanceOf<MatchGroup.DoubleEliminationRound.Round>(result)
-                    assertEquals(2, round.number, "OCTOFINAL setNumber $setNum should map to Round 2")
+                    assertEquals(
+                        2,
+                        round.number,
+                        "OCTOFINAL setNumber $setNum should map to Round 2",
+                    )
                 }
             }
 
@@ -286,7 +294,11 @@ class MatchGroupExtensionTest {
                     val match = createMatch(compLevel = CompLevel.QUARTERFINAL, setNumber = setNum)
                     val result = match.getGroup(PlayoffType.LEGACY_DOUBLE_ELIM_8_TEAM)
                     val round = assertInstanceOf<MatchGroup.DoubleEliminationRound.Round>(result)
-                    assertEquals(2, round.number, "QUARTERFINAL setNumber $setNum should map to Round 2")
+                    assertEquals(
+                        2,
+                        round.number,
+                        "QUARTERFINAL setNumber $setNum should map to Round 2",
+                    )
                 }
             }
 
@@ -296,7 +308,11 @@ class MatchGroupExtensionTest {
                     val match = createMatch(compLevel = CompLevel.QUARTERFINAL, setNumber = setNum)
                     val result = match.getGroup(PlayoffType.LEGACY_DOUBLE_ELIM_8_TEAM)
                     val round = assertInstanceOf<MatchGroup.DoubleEliminationRound.Round>(result)
-                    assertEquals(3, round.number, "QUARTERFINAL setNumber $setNum should map to Round 3")
+                    assertEquals(
+                        3,
+                        round.number,
+                        "QUARTERFINAL setNumber $setNum should map to Round 3",
+                    )
                 }
             }
 
@@ -367,16 +383,19 @@ class MatchGroupExtensionTest {
             val match = createMatch(compLevel = CompLevel.OCTOFINAL, matchNumber = 1, setNumber = 2)
             assertEquals("EF2-1", match.getShortLabel(PlayoffType.BRACKET_8_TEAM))
 
-            val match2 = createMatch(compLevel = CompLevel.OCTOFINAL, matchNumber = 3, setNumber = 4)
+            val match2 =
+                createMatch(compLevel = CompLevel.OCTOFINAL, matchNumber = 3, setNumber = 4)
             assertEquals("EF4-3", match2.getShortLabel(PlayoffType.BRACKET_8_TEAM))
         }
 
         @Test
         fun `QUARTERFINAL match label is QF followed by set and match number`() {
-            val match = createMatch(compLevel = CompLevel.QUARTERFINAL, matchNumber = 1, setNumber = 1)
+            val match =
+                createMatch(compLevel = CompLevel.QUARTERFINAL, matchNumber = 1, setNumber = 1)
             assertEquals("QF1-1", match.getShortLabel(PlayoffType.BRACKET_8_TEAM))
 
-            val match2 = createMatch(compLevel = CompLevel.QUARTERFINAL, matchNumber = 2, setNumber = 3)
+            val match2 =
+                createMatch(compLevel = CompLevel.QUARTERFINAL, matchNumber = 2, setNumber = 3)
             assertEquals("QF3-2", match2.getShortLabel(PlayoffType.BRACKET_8_TEAM))
         }
 
@@ -385,7 +404,8 @@ class MatchGroupExtensionTest {
             val match = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 1)
             assertEquals("SF1-1", match.getShortLabel(PlayoffType.BRACKET_8_TEAM))
 
-            val match2 = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 2, setNumber = 2)
+            val match2 =
+                createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 2, setNumber = 2)
             assertEquals("SF2-2", match2.getShortLabel(PlayoffType.BRACKET_8_TEAM))
         }
 
@@ -403,10 +423,12 @@ class MatchGroupExtensionTest {
             val match = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 1)
             assertEquals("R1-1", match.getShortLabel(PlayoffType.DOUBLE_ELIM_8_TEAM))
 
-            val match2 = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 5)
+            val match2 =
+                createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 5)
             assertEquals("R2-5", match2.getShortLabel(PlayoffType.DOUBLE_ELIM_8_TEAM))
 
-            val match3 = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 13)
+            val match3 =
+                createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 13)
             assertEquals("R5-13", match3.getShortLabel(PlayoffType.DOUBLE_ELIM_8_TEAM))
         }
 
@@ -421,7 +443,8 @@ class MatchGroupExtensionTest {
 
         @Test
         fun `Unknown double elim round uses comp level label`() {
-            val match = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 20)
+            val match =
+                createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 20)
             assertEquals("SF20-1", match.getShortLabel(PlayoffType.DOUBLE_ELIM_8_TEAM))
         }
 
@@ -448,16 +471,19 @@ class MatchGroupExtensionTest {
             val match = createMatch(compLevel = CompLevel.OCTOFINAL, matchNumber = 1, setNumber = 2)
             assertEquals("Eights 2-1", match.getFullLabel(PlayoffType.BRACKET_8_TEAM))
 
-            val match2 = createMatch(compLevel = CompLevel.OCTOFINAL, matchNumber = 3, setNumber = 4)
+            val match2 =
+                createMatch(compLevel = CompLevel.OCTOFINAL, matchNumber = 3, setNumber = 4)
             assertEquals("Eights 4-3", match2.getFullLabel(PlayoffType.BRACKET_8_TEAM))
         }
 
         @Test
         fun `QUARTERFINAL match full label is Quarters followed by set and match number`() {
-            val match = createMatch(compLevel = CompLevel.QUARTERFINAL, matchNumber = 1, setNumber = 1)
+            val match =
+                createMatch(compLevel = CompLevel.QUARTERFINAL, matchNumber = 1, setNumber = 1)
             assertEquals("Quarters 1-1", match.getFullLabel(PlayoffType.BRACKET_8_TEAM))
 
-            val match2 = createMatch(compLevel = CompLevel.QUARTERFINAL, matchNumber = 2, setNumber = 3)
+            val match2 =
+                createMatch(compLevel = CompLevel.QUARTERFINAL, matchNumber = 2, setNumber = 3)
             assertEquals("Quarters 3-2", match2.getFullLabel(PlayoffType.BRACKET_8_TEAM))
         }
 
@@ -466,7 +492,8 @@ class MatchGroupExtensionTest {
             val match = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 1)
             assertEquals("Semis 1-1", match.getFullLabel(PlayoffType.BRACKET_8_TEAM))
 
-            val match2 = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 2, setNumber = 2)
+            val match2 =
+                createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 2, setNumber = 2)
             assertEquals("Semis 2-2", match2.getFullLabel(PlayoffType.BRACKET_8_TEAM))
         }
 
@@ -484,10 +511,12 @@ class MatchGroupExtensionTest {
             val match = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 1)
             assertEquals("Match 1 (Round 1)", match.getFullLabel(PlayoffType.DOUBLE_ELIM_8_TEAM))
 
-            val match2 = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 5)
+            val match2 =
+                createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 5)
             assertEquals("Match 5 (Round 2)", match2.getFullLabel(PlayoffType.DOUBLE_ELIM_8_TEAM))
 
-            val match3 = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 13)
+            val match3 =
+                createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 13)
             assertEquals("Match 13 (Round 5)", match3.getFullLabel(PlayoffType.DOUBLE_ELIM_8_TEAM))
         }
 
@@ -502,7 +531,8 @@ class MatchGroupExtensionTest {
 
         @Test
         fun `Unknown double elim round uses comp level full label`() {
-            val match = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 20)
+            val match =
+                createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 20)
             assertEquals("Semis 20-1", match.getFullLabel(PlayoffType.DOUBLE_ELIM_8_TEAM))
         }
 
@@ -524,7 +554,8 @@ class MatchGroupExtensionTest {
 
         @Test
         fun `zero set number`() {
-            val match = createMatch(compLevel = CompLevel.QUARTERFINAL, matchNumber = 1, setNumber = 0)
+            val match =
+                createMatch(compLevel = CompLevel.QUARTERFINAL, matchNumber = 1, setNumber = 0)
             assertEquals("QF0-1", match.getShortLabel(PlayoffType.BRACKET_8_TEAM))
             assertEquals("Quarters 0-1", match.getFullLabel(PlayoffType.BRACKET_8_TEAM))
         }
@@ -538,7 +569,8 @@ class MatchGroupExtensionTest {
 
         @Test
         fun `very large set number in double elim`() {
-            val match = createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 1000)
+            val match =
+                createMatch(compLevel = CompLevel.SEMIFINAL, matchNumber = 1, setNumber = 1000)
             val result = match.getGroup(PlayoffType.DOUBLE_ELIM_8_TEAM)
             assertInstanceOf<MatchGroup.DoubleEliminationRound.Unknown>(result)
             assertEquals("SF1000-1", match.getShortLabel(PlayoffType.DOUBLE_ELIM_8_TEAM))

--- a/app/src/test/kotlin/com/thebluealliance/android/domain/model/AllianceTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/domain/model/AllianceTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class AllianceTest {
-
     private fun createAlliance(
         playoffStatus: String? = null,
         playoffLevel: String? = null,
@@ -25,21 +24,23 @@ class AllianceTest {
 
     @Test
     fun `playoff summary prefers double elim round when present`() {
-        val alliance = createAlliance(
-            playoffStatus = "eliminated",
-            playoffLevel = "sf",
-            playoffDoubleElimRound = "Round 5",
-        )
+        val alliance =
+            createAlliance(
+                playoffStatus = "eliminated",
+                playoffLevel = "sf",
+                playoffDoubleElimRound = "Round 5",
+            )
 
         assertEquals("Eliminated in Round 5", alliance.playoffSummary)
     }
 
     @Test
     fun `playoff summary renders won status as winner`() {
-        val alliance = createAlliance(
-            playoffStatus = "won",
-            playoffLevel = "f",
-        )
+        val alliance =
+            createAlliance(
+                playoffStatus = "won",
+                playoffLevel = "f",
+            )
 
         assertEquals("Winner 🏆", alliance.playoffSummary)
     }
@@ -60,10 +61,11 @@ class AllianceTest {
 
     @Test
     fun `playoff summary uses in the for comp level fallback`() {
-        val alliance = createAlliance(
-            playoffStatus = "playing",
-            playoffLevel = "sf",
-        )
+        val alliance =
+            createAlliance(
+                playoffStatus = "playing",
+                playoffLevel = "sf",
+            )
 
         assertEquals("Playing in the Semifinals", alliance.playoffSummary)
     }
@@ -75,5 +77,3 @@ class AllianceTest {
         assertEquals("Eliminated", alliance.playoffSummary)
     }
 }
-
-

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
@@ -2,7 +2,6 @@ package com.thebluealliance.android.ui.events
 
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.PlayoffType
-import com.thebluealliance.android.ui.components.SectionHeaderInfo
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -10,7 +9,6 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 class EventsUiStateTest {
-
     private fun makeEvent(
         key: String = "2026test",
         name: String = "Test Event",
@@ -23,7 +21,7 @@ class EventsUiStateTest {
     ) = Event(
         key = key,
         name = name,
-        eventCode = key.removePrefix("${year}"),
+        eventCode = key.removePrefix("$year"),
         year = year,
         type = type,
         district = district,
@@ -49,21 +47,28 @@ class EventsUiStateTest {
     fun `buildHeaderInfos calculates indices correctly with favorites`() {
         val favoriteKeys = setOf("w1r1", "w2o1")
 
-        val sections = listOf(
-            EventSection(
-                label = "Week 1",
-                subSections = listOf(
-                    EventSubSection("Regional", listOf(makeEvent(key = "w1r1"), makeEvent(key = "w1r2"))),
-                    EventSubSection("District", listOf(makeEvent(key = "w1d1")))
-                )
-            ),
-            EventSection(
-                label = "Week 2",
-                subSections = listOf(
-                    EventSubSection("", listOf(makeEvent(key = "w2o1"))) // Empty label = no header item
-                )
+        val sections =
+            listOf(
+                EventSection(
+                    label = "Week 1",
+                    subSections =
+                        listOf(
+                            EventSubSection(
+                                "Regional",
+                                listOf(makeEvent(key = "w1r1"), makeEvent(key = "w1r2")),
+                            ),
+                            EventSubSection("District", listOf(makeEvent(key = "w1d1"))),
+                        ),
+                ),
+                EventSection(
+                    label = "Week 2",
+                    subSections =
+                        listOf(
+                            // Empty label = no header item
+                            EventSubSection("", listOf(makeEvent(key = "w2o1"))),
+                        ),
+                ),
             )
-        )
 
         val infos = buildHeaderInfos(sections, favoriteKeys)
 
@@ -94,20 +99,23 @@ class EventsUiStateTest {
 
     @Test
     fun `buildHeaderInfos with no favorites has no extra sub-sections`() {
-        val sections = listOf(
-            EventSection(
-                label = "Week 1",
-                subSections = listOf(
-                    EventSubSection("Regional", listOf(makeEvent(key = "w1r1")))
-                )
-            ),
-            EventSection(
-                label = "Week 2",
-                subSections = listOf(
-                    EventSubSection("", listOf(makeEvent(key = "w2o1")))
-                )
+        val sections =
+            listOf(
+                EventSection(
+                    label = "Week 1",
+                    subSections =
+                        listOf(
+                            EventSubSection("Regional", listOf(makeEvent(key = "w1r1"))),
+                        ),
+                ),
+                EventSection(
+                    label = "Week 2",
+                    subSections =
+                        listOf(
+                            EventSubSection("", listOf(makeEvent(key = "w2o1"))),
+                        ),
+                ),
             )
-        )
 
         val infos = buildHeaderInfos(sections, emptySet())
 
@@ -122,26 +130,49 @@ class EventsUiStateTest {
 
     @Test
     fun `regional events within a section are sorted alphabetically by name`() {
-        val events = listOf(
-            makeEvent(key = "2026z", name = "Zebra Event", week = 0, startDate = "2026-03-04", endDate = "2026-03-07"),
-            makeEvent(key = "2026a", name = "Alpha Event", week = 0, startDate = "2026-03-06", endDate = "2026-03-08"),
-            makeEvent(key = "2026m", name = "Middle Event", week = 0, startDate = "2026-03-04", endDate = "2026-03-07"),
-        )
+        val events =
+            listOf(
+                makeEvent(
+                    key = "2026z",
+                    name = "Zebra Event",
+                    week = 0,
+                    startDate = "2026-03-04",
+                    endDate = "2026-03-07",
+                ),
+                makeEvent(
+                    key = "2026a",
+                    name = "Alpha Event",
+                    week = 0,
+                    startDate = "2026-03-06",
+                    endDate = "2026-03-08",
+                ),
+                makeEvent(
+                    key = "2026m",
+                    name = "Middle Event",
+                    week = 0,
+                    startDate = "2026-03-04",
+                    endDate = "2026-03-07",
+                ),
+            )
 
         val sections = buildEventSections(events)
         val week1 = sections.first { it.label == "Week 1" }
 
         // Sorted by name regardless of start date
-        assertEquals(listOf("Alpha Event", "Middle Event", "Zebra Event"), week1.events.map { it.name })
+        assertEquals(
+            listOf("Alpha Event", "Middle Event", "Zebra Event"),
+            week1.events.map { it.name },
+        )
     }
 
     // --- buildEventSections: sub-section labels ---
 
     @Test
     fun `regional events have Regional Events sub-section label`() {
-        val events = listOf(
-            makeEvent(name = "Regional 1", type = 0, week = 0),
-        )
+        val events =
+            listOf(
+                makeEvent(name = "Regional 1", type = 0, week = 0),
+            )
         val sections = buildEventSections(events)
         val week1 = sections.first { it.label == "Week 1" }
 
@@ -151,9 +182,10 @@ class EventsUiStateTest {
 
     @Test
     fun `championship events have empty sub-section label`() {
-        val events = listOf(
-            makeEvent(name = "CMP", type = 3, week = null),
-        )
+        val events =
+            listOf(
+                makeEvent(name = "CMP", type = 3, week = null),
+            )
         val sections = buildEventSections(events)
         val cmp = sections.first { it.label == "Championship" }
 
@@ -163,9 +195,10 @@ class EventsUiStateTest {
 
     @Test
     fun `district events use district name or fallback`() {
-        val events = listOf(
-            makeEvent(name = "District Event", type = 1, week = 0, district = "2026ne"),
-        )
+        val events =
+            listOf(
+                makeEvent(name = "District Event", type = 1, week = 0, district = "2026ne"),
+            )
         val sections = buildEventSections(events, districtNames = mapOf("2026ne" to "New England"))
         val week1 = sections.first { it.label == "Week 1" }
 
@@ -178,11 +211,28 @@ class EventsUiStateTest {
     @Test
     fun `preseason appears first when today is before preseason ends`() {
         val today = LocalDate.of(2026, 2, 20) // During preseason
-        val events = listOf(
-            makeEvent(key = "2026pre1", type = 100, startDate = "2026-02-14", endDate = "2026-02-21"),
-            makeEvent(key = "2026wk1", type = 0, week = 0, startDate = "2026-03-04", endDate = "2026-03-07"),
-            makeEvent(key = "2026cmp", type = 3, startDate = "2026-04-15", endDate = "2026-04-18"),
-        )
+        val events =
+            listOf(
+                makeEvent(
+                    key = "2026pre1",
+                    type = 100,
+                    startDate = "2026-02-14",
+                    endDate = "2026-02-21",
+                ),
+                makeEvent(
+                    key = "2026wk1",
+                    type = 0,
+                    week = 0,
+                    startDate = "2026-03-04",
+                    endDate = "2026-03-07",
+                ),
+                makeEvent(
+                    key = "2026cmp",
+                    type = 3,
+                    startDate = "2026-04-15",
+                    endDate = "2026-04-18",
+                ),
+            )
 
         val sections = buildEventSections(events, today)
 
@@ -193,16 +243,41 @@ class EventsUiStateTest {
     @Test
     fun `preseason appears after championship when today is after last preseason event`() {
         val today = LocalDate.of(2026, 3, 10) // After preseason ended
-        val events = listOf(
-            makeEvent(key = "2026pre1", type = 100, startDate = "2026-02-14", endDate = "2026-02-21"),
-            makeEvent(key = "2026wk1", type = 0, week = 0, startDate = "2026-03-04", endDate = "2026-03-07"),
-            makeEvent(key = "2026cmp", type = 3, startDate = "2026-04-15", endDate = "2026-04-18"),
-            makeEvent(key = "2026off1", type = 99, startDate = "2026-07-15", endDate = "2026-07-17"),
-        )
+        val events =
+            listOf(
+                makeEvent(
+                    key = "2026pre1",
+                    type = 100,
+                    startDate = "2026-02-14",
+                    endDate = "2026-02-21",
+                ),
+                makeEvent(
+                    key = "2026wk1",
+                    type = 0,
+                    week = 0,
+                    startDate = "2026-03-04",
+                    endDate = "2026-03-07",
+                ),
+                makeEvent(
+                    key = "2026cmp",
+                    type = 3,
+                    startDate = "2026-04-15",
+                    endDate = "2026-04-18",
+                ),
+                makeEvent(
+                    key = "2026off1",
+                    type = 99,
+                    startDate = "2026-07-15",
+                    endDate = "2026-07-17",
+                ),
+            )
 
         val sections = buildEventSections(events, today)
 
-        assertEquals(listOf("Week 1", "Championship", "Preseason", "Offseason"), sections.map { it.label })
+        assertEquals(
+            listOf("Week 1", "Championship", "Preseason", "Offseason"),
+            sections.map { it.label },
+        )
     }
 
     // --- computeThisWeekEvents (used by DistrictDetailScreen) ---
@@ -210,11 +285,27 @@ class EventsUiStateTest {
     @Test
     fun `regular season event happening today returns correct week label`() {
         val today = LocalDate.of(2026, 3, 11) // Wednesday
-        val events = listOf(
-            makeEvent(key = "2026abc", week = 2, startDate = "2026-03-09", endDate = "2026-03-14"),
-            makeEvent(key = "2026def", week = 2, startDate = "2026-03-10", endDate = "2026-03-13"),
-            makeEvent(key = "2026ghi", week = 3, startDate = "2026-03-16", endDate = "2026-03-20"),
-        )
+        val events =
+            listOf(
+                makeEvent(
+                    key = "2026abc",
+                    week = 2,
+                    startDate = "2026-03-09",
+                    endDate = "2026-03-14",
+                ),
+                makeEvent(
+                    key = "2026def",
+                    week = 2,
+                    startDate = "2026-03-10",
+                    endDate = "2026-03-13",
+                ),
+                makeEvent(
+                    key = "2026ghi",
+                    week = 3,
+                    startDate = "2026-03-16",
+                    endDate = "2026-03-20",
+                ),
+            )
 
         val result = computeThisWeekEvents(events, today, selectedYear = 2026)
 
@@ -227,9 +318,16 @@ class EventsUiStateTest {
     @Test
     fun `non-current year returns null`() {
         val today = LocalDate.of(2026, 3, 11)
-        val events = listOf(
-            makeEvent(key = "2024abc", year = 2024, week = 2, startDate = "2024-03-11", endDate = "2024-03-14"),
-        )
+        val events =
+            listOf(
+                makeEvent(
+                    key = "2024abc",
+                    year = 2024,
+                    week = 2,
+                    startDate = "2024-03-11",
+                    endDate = "2024-03-14",
+                ),
+            )
         assertNull(computeThisWeekEvents(events, today, selectedYear = 2024))
     }
 
@@ -244,10 +342,21 @@ class EventsUiStateTest {
     @Test
     fun `findCurrentCompetitionWeek prefers happening-today over upcoming`() {
         val today = LocalDate.of(2026, 3, 14) // Saturday, last day of week 2
-        val events = listOf(
-            makeEvent(key = "2026abc", week = 2, startDate = "2026-03-09", endDate = "2026-03-14"),
-            makeEvent(key = "2026def", week = 3, startDate = "2026-03-18", endDate = "2026-03-21"),
-        )
+        val events =
+            listOf(
+                makeEvent(
+                    key = "2026abc",
+                    week = 2,
+                    startDate = "2026-03-09",
+                    endDate = "2026-03-14",
+                ),
+                makeEvent(
+                    key = "2026def",
+                    week = 3,
+                    startDate = "2026-03-18",
+                    endDate = "2026-03-21",
+                ),
+            )
 
         val week = findCurrentCompetitionWeek(events, today)
 
@@ -257,9 +366,15 @@ class EventsUiStateTest {
     @Test
     fun `findCurrentCompetitionWeek returns null when gap is too large`() {
         val today = LocalDate.of(2026, 5, 1) // Long after any events
-        val events = listOf(
-            makeEvent(key = "2026abc", week = 2, startDate = "2026-03-09", endDate = "2026-03-14"),
-        )
+        val events =
+            listOf(
+                makeEvent(
+                    key = "2026abc",
+                    week = 2,
+                    startDate = "2026-03-09",
+                    endDate = "2026-03-14",
+                ),
+            )
 
         val week = findCurrentCompetitionWeek(events, today)
 

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTabLogicTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTabLogicTest.kt
@@ -5,22 +5,25 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class EventAdvancementTabLogicTest {
-
-    private val points = EventAdvancementPoints(
-        teamKey = "frc340",
-        qualPoints = 18,
-        elimPoints = 20,
-        alliancePoints = 8,
-        awardPoints = 5,
-        rookieBonus = 10,
-        total = 61,
-    )
+    private val points =
+        EventAdvancementPoints(
+            teamKey = "frc340",
+            qualPoints = 18,
+            elimPoints = 20,
+            alliancePoints = 8,
+            awardPoints = 5,
+            rookieBonus = 10,
+            total = 61,
+        )
 
     @Test
     fun `district breakdown excludes rookie bonus`() {
         val rows = advancementBreakdownRows(points, isDistrictEvent = true)
 
-        assertEquals(listOf("Qualification", "Elimination", "Alliance", "Awards"), rows.map { it.first })
+        assertEquals(
+            listOf("Qualification", "Elimination", "Alliance", "Awards"),
+            rows.map { it.first },
+        )
         assertEquals(listOf(18, 20, 8, 5), rows.map { it.second })
     }
 
@@ -35,6 +38,3 @@ class EventAdvancementTabLogicTest {
         assertEquals(listOf(18, 20, 8, 5, 10), rows.map { it.second })
     }
 }
-
-
-

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTabLogicTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTabLogicTest.kt
@@ -7,16 +7,16 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class EventAlliancesTabLogicTest {
-
-    private fun alliance(name: String?) = Alliance(
-        eventKey = "2025cmptx",
-        number = 6,
-        name = name,
-        picks = listOf("frc1", "frc2", "frc3"),
-        declines = emptyList(),
-        backupIn = null,
-        backupOut = null,
-    )
+    private fun alliance(name: String?) =
+        Alliance(
+            eventKey = "2025cmptx",
+            number = 6,
+            name = name,
+            picks = listOf("frc1", "frc2", "frc3"),
+            declines = emptyList(),
+            backupIn = null,
+            backupOut = null,
+        )
 
     @Test
     fun `Alliance displayTitle and displayTitleShort uses API name when present`() {
@@ -41,4 +41,3 @@ class EventAlliancesTabLogicTest {
         assertEquals("A6", alliance("Alliance 6").displayTitleShort)
     }
 }
-

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTabLogicTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTabLogicTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class EventRankingsTabLogicTest {
-
     private fun ranking(
         team: String,
         primary: Double,
@@ -27,12 +26,13 @@ class EventRankingsTabLogicTest {
 
     @Test
     fun `header labels use metadata when provided`() {
-        val labels = rankingHeaderLabels(
-            listOf(
-                RankingSortOrder(name = "Ranking Score", precision = 2),
-                RankingSortOrder(name = "Auto Points", precision = 0),
+        val labels =
+            rankingHeaderLabels(
+                listOf(
+                    RankingSortOrder(name = "Ranking Score", precision = 2),
+                    RankingSortOrder(name = "Auto Points", precision = 0),
+                ),
             )
-        )
 
         assertEquals("Ranking Score", labels.first)
         assertEquals("Auto Points", labels.second)
@@ -78,11 +78,12 @@ class EventRankingsTabLogicTest {
 
     @Test
     fun `primary sort descending by default`() {
-        val rankings = listOf(
-            ranking(team = "frc111", primary = 2.3, secondary = 5.0),
-            ranking(team = "frc222", primary = 3.0, secondary = 1.0),
-            ranking(team = "frc333", primary = 1.1, secondary = 9.0),
-        )
+        val rankings =
+            listOf(
+                ranking(team = "frc111", primary = 2.3, secondary = 5.0),
+                ranking(team = "frc222", primary = 3.0, secondary = 1.0),
+                ranking(team = "frc333", primary = 1.1, secondary = 9.0),
+            )
 
         val sorted = sortRankings(rankings, RankingSortState())
 
@@ -91,34 +92,37 @@ class EventRankingsTabLogicTest {
 
     @Test
     fun `team sort ascending orders numerically`() {
-        val rankings = listOf(
-            ranking(team = "frc971", primary = 1.0, secondary = 1.0),
-            ranking(team = "frc8", primary = 1.0, secondary = 1.0),
-            ranking(team = "frc254", primary = 1.0, secondary = 1.0),
-        )
+        val rankings =
+            listOf(
+                ranking(team = "frc971", primary = 1.0, secondary = 1.0),
+                ranking(team = "frc8", primary = 1.0, secondary = 1.0),
+                ranking(team = "frc254", primary = 1.0, secondary = 1.0),
+            )
 
-        val sorted = sortRankings(
-            rankings,
-            RankingSortState(column = RankingSortColumn.TEAM, ascending = true),
-        )
+        val sorted =
+            sortRankings(
+                rankings,
+                RankingSortState(column = RankingSortColumn.TEAM, ascending = true),
+            )
 
         assertEquals(listOf("frc8", "frc254", "frc971"), sorted.map { it.teamKey })
     }
 
     @Test
     fun `secondary sort descending orders by second sort order value`() {
-        val rankings = listOf(
-            ranking(team = "frc1", primary = 4.0, secondary = 0.2),
-            ranking(team = "frc2", primary = 1.0, secondary = 9.4),
-            ranking(team = "frc3", primary = 2.0, secondary = 7.7),
-        )
+        val rankings =
+            listOf(
+                ranking(team = "frc1", primary = 4.0, secondary = 0.2),
+                ranking(team = "frc2", primary = 1.0, secondary = 9.4),
+                ranking(team = "frc3", primary = 2.0, secondary = 7.7),
+            )
 
-        val sorted = sortRankings(
-            rankings,
-            RankingSortState(column = RankingSortColumn.SECONDARY, ascending = false),
-        )
+        val sorted =
+            sortRankings(
+                rankings,
+                RankingSortState(column = RankingSortColumn.SECONDARY, ascending = false),
+            )
 
         assertEquals(listOf("frc2", "frc3", "frc1"), sorted.map { it.teamKey })
     }
 }
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,4 +9,15 @@ plugins {
     alias(libs.plugins.aboutlibraries) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.play.publisher) apply false
+    alias(libs.plugins.ktlint) apply false
+}
+
+subprojects {
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
+        android.set(true)
+        outputToConsole.set(true)
+        ignoreFailures.set(false)
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ turbine = "1.2.1"
 mockk = "1.14.9"
 play-publisher = "4.0.0"
 lifecycle-process = "2.10.0"
+ktlint-gradle = "14.2.0"
 
 [libraries]
 # Compose
@@ -149,3 +150,4 @@ room = { id = "androidx.room", version.ref = "room" }
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics-plugin" }
 play-publisher = { id = "com.github.triplet.play", version.ref = "play-publisher" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -12,20 +12,29 @@ plugins {
     alias(libs.plugins.play.publisher)
 }
 
-val localProperties = Properties().apply {
-    val file = rootProject.file("local.properties")
-    if (file.exists()) load(FileInputStream(file))
-}
+val localProperties =
+    Properties().apply {
+        val file = rootProject.file("local.properties")
+        if (file.exists()) load(FileInputStream(file))
+    }
 
 // --- Git tag-based versioning (shared with :app, offset for multi-APK) ---
 // Wear version codes add 100_000_000 to avoid collisions with the phone app.
-val gitDescribeResult = providers.exec {
-    commandLine("git", "describe", "--tags", "--long", "--match", "v[0-9]*")
-    isIgnoreExitValue = true
-}
-val gitDescribe = gitDescribeResult.result.get().exitValue.let { exitCode ->
-    if (exitCode == 0) gitDescribeResult.standardOutput.asText.get().trim() else ""
-}
+val gitDescribeResult =
+    providers.exec {
+        commandLine("git", "describe", "--tags", "--long", "--match", "v[0-9]*")
+        isIgnoreExitValue = true
+    }
+val gitDescribe =
+    gitDescribeResult.result.get().exitValue.let { exitCode ->
+        if (exitCode == 0) {
+            gitDescribeResult.standardOutput.asText
+                .get()
+                .trim()
+        } else {
+            ""
+        }
+    }
 
 val versionPattern = Regex("""^v(\d+)\.(\d+)\.(\d+)-(\d+)-g[0-9a-f]+$""")
 val versionMatch = versionPattern.matchEntire(gitDescribe)
@@ -35,12 +44,14 @@ val vMinor = versionMatch?.groupValues?.get(2)?.toInt() ?: 0
 val vPatch = versionMatch?.groupValues?.get(3)?.toInt() ?: 0
 val commitDistance = versionMatch?.groupValues?.get(4)?.toInt() ?: 0
 
-val computedVersionCode = 100_000_000 + vMajor * 1_000_000 + vMinor * 10_000 + vPatch * 100 + commitDistance
-val computedVersionName = if (commitDistance == 0) {
-    "$vMajor.$vMinor.$vPatch"
-} else {
-    "$vMajor.$vMinor.$vPatch-dev.$commitDistance"
-}
+val computedVersionCode =
+    100_000_000 + vMajor * 1_000_000 + vMinor * 10_000 + vPatch * 100 + commitDistance
+val computedVersionName =
+    if (commitDistance == 0) {
+        "$vMajor.$vMinor.$vPatch"
+    } else {
+        "$vMajor.$vMinor.$vPatch-dev.$commitDistance"
+    }
 
 android {
     namespace = "com.thebluealliance.android.wear"
@@ -59,7 +70,10 @@ android {
 
     signingConfigs {
         create("release") {
-            storeFile = rootProject.file(localProperties.getProperty("release.store.file", "release.keystore"))
+            storeFile =
+                rootProject.file(
+                    localProperties.getProperty("release.store.file", "release.keystore"),
+                )
             storePassword = localProperties.getProperty("release.store.password", "")
             keyAlias = localProperties.getProperty("release.key.alias", "")
             keyPassword = localProperties.getProperty("release.key.password", "")
@@ -69,13 +83,21 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix = ".development"
-            buildConfigField("String", "TBA_BASE_URL", "\"${
-                localProperties.getProperty(
-                    "tba.url.debug",
-                    "http://10.0.2.2:8080/"
-                )
-            }\"")
-            buildConfigField("String", "TBA_API_KEY", "\"${localProperties.getProperty("tba.api.key.debug", "tba-dev-key")}\"")
+            buildConfigField(
+                "String",
+                "TBA_BASE_URL",
+                "\"${
+                    localProperties.getProperty(
+                        "tba.url.debug",
+                        "http://10.0.2.2:8080/",
+                    )
+                }\"",
+            )
+            buildConfigField(
+                "String",
+                "TBA_API_KEY",
+                "\"${localProperties.getProperty("tba.api.key.debug", "tba-dev-key")}\"",
+            )
         }
         release {
             signingConfig = signingConfigs.getByName("release")
@@ -83,7 +105,7 @@ android {
             isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -100,7 +122,11 @@ android {
 }
 
 play {
-    serviceAccountCredentials.set(rootProject.file(localProperties.getProperty("play.service.account.key", "play-service-account.json")))
+    serviceAccountCredentials.set(
+        rootProject.file(
+            localProperties.getProperty("play.service.account.key", "play-service-account.json"),
+        ),
+    )
     track.set("wear:alpha")
     defaultToAppBundles.set(true)
 }

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/WearApplication.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/WearApplication.kt
@@ -9,15 +9,19 @@ import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
 @HiltAndroidApp
-class WearApplication : Application(), Configuration.Provider {
-
+class WearApplication :
+    Application(),
+    Configuration.Provider {
     @Inject lateinit var workerFactory: HiltWorkerFactory
+
     @Inject lateinit var apiKeyProvider: ApiKeyProvider
 
     override val workManagerConfiguration: Configuration
-        get() = Configuration.Builder()
-            .setWorkerFactory(workerFactory)
-            .build()
+        get() =
+            Configuration
+                .Builder()
+                .setWorkerFactory(workerFactory)
+                .build()
 
     override fun onCreate() {
         super.onCreate()

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/AvatarConverter.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/AvatarConverter.kt
@@ -3,10 +3,10 @@ package com.thebluealliance.android.wear.complication
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Color
-import android.util.Base64
-import androidx.wear.watchface.complications.data.MonochromaticImage
-import androidx.core.graphics.createBitmap
 import android.graphics.drawable.Icon
+import android.util.Base64
+import androidx.core.graphics.createBitmap
+import androidx.wear.watchface.complications.data.MonochromaticImage
 
 /**
  * Converts a color avatar bitmap (base64-encoded PNG) into an alpha mask
@@ -18,21 +18,19 @@ import android.graphics.drawable.Icon
  * RGB is set to white so the tint color applies uniformly.
  */
 object AvatarConverter {
-
     fun toMonochromaticImage(base64: String): MonochromaticImage? {
         val bitmap = decodeBase64(base64) ?: return null
         val mask = toAlphaMask(bitmap)
         return MonochromaticImage.Builder(Icon.createWithBitmap(mask)).build()
     }
 
-    private fun decodeBase64(base64: String): Bitmap? {
-        return try {
+    private fun decodeBase64(base64: String): Bitmap? =
+        try {
             val bytes = Base64.decode(base64, Base64.DEFAULT)
             BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
         } catch (e: Exception) {
             null
         }
-    }
 
     /**
      * Convert a color bitmap to a white-on-transparent alpha mask.
@@ -50,7 +48,11 @@ object AvatarConverter {
         var maxLum = 0
         for (i in pixels.indices) {
             val pixel = pixels[i]
-            val lum = (0.299 * Color.red(pixel) + 0.587 * Color.green(pixel) + 0.114 * Color.blue(pixel)).toInt().coerceIn(0, 255)
+            val lum =
+                (
+                    0.299 * Color.red(pixel) + 0.587 * Color.green(pixel) +
+                        0.114 * Color.blue(pixel)
+                ).toInt().coerceIn(0, 255)
             luminances[i] = lum
             if (lum < minLum) minLum = lum
             if (lum > maxLum) maxLum = lum

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationConfigActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationConfigActivity.kt
@@ -34,7 +34,6 @@ import com.thebluealliance.android.wear.tracker.TeamTrackerPreferences
 import com.thebluealliance.android.wear.worker.TeamTrackingComplicationWorker
 
 class TeamTrackingComplicationConfigActivity : ComponentActivity() {
-
     private var complicationId: Int = -1
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -42,7 +41,7 @@ class TeamTrackingComplicationConfigActivity : ComponentActivity() {
 
         complicationId = intent?.getIntExtra(
             "android.support.wearable.complications.EXTRA_CONFIG_COMPLICATION_ID",
-            -1
+            -1,
         ) ?: -1
 
         // Support passing team number directly via intent (for ADB configuration)
@@ -85,10 +84,11 @@ class TeamTrackingComplicationConfigActivity : ComponentActivity() {
 
             TeamTrackingComplicationWorker.enqueueImmediateRefresh(this)
 
-            ComplicationDataSourceUpdateRequester.create(
-                this,
-                ComponentName(this, TeamTrackingComplicationService::class.java),
-            ).requestUpdateAll()
+            ComplicationDataSourceUpdateRequester
+                .create(
+                    this,
+                    ComponentName(this, TeamTrackingComplicationService::class.java),
+                ).requestUpdateAll()
         }
         setResult(Activity.RESULT_OK)
         finish()
@@ -112,9 +112,10 @@ private fun ConfigScreen(
     }
 
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -125,32 +126,35 @@ private fun ConfigScreen(
         )
         BasicTextField(
             state = textFieldState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    color = MaterialTheme.colorScheme.surfaceContainer,
-                    shape = MaterialTheme.shapes.medium,
-                )
-                .padding(horizontal = 12.dp, vertical = 8.dp),
-            textStyle = TextStyle(
-                color = MaterialTheme.colorScheme.onSurface,
-                fontSize = 20.sp,
-                textAlign = TextAlign.Center,
-            ),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = MaterialTheme.colorScheme.surfaceContainer,
+                        shape = MaterialTheme.shapes.medium,
+                    ).padding(horizontal = 12.dp, vertical = 8.dp),
+            textStyle =
+                TextStyle(
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 20.sp,
+                    textAlign = TextAlign.Center,
+                ),
             cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
             lineLimits = androidx.compose.foundation.text.input.TextFieldLineLimits.SingleLine,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number,
-            ),
+            keyboardOptions =
+                KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                ),
             decorator = { innerTextField ->
                 if (textFieldState.text.isEmpty() && initialTeam.isNotBlank()) {
                     Text(
                         text = initialTeam,
-                        style = TextStyle(
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            fontSize = 20.sp,
-                            textAlign = TextAlign.Center,
-                        ),
+                        style =
+                            TextStyle(
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                fontSize = 20.sp,
+                                textAlign = TextAlign.Center,
+                            ),
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -160,9 +164,10 @@ private fun ConfigScreen(
         FilledTonalButton(
             onClick = { save() },
             label = { Text("Save") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp),
         )
     }
 }

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationPreferences.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationPreferences.kt
@@ -8,8 +8,10 @@ import android.content.SharedPreferences
  * Each complication instance gets its own preference file keyed by complication ID.
  * The tracked team number is stored in [TeamTrackerPreferences] (single source of truth).
  */
-class TeamTrackingComplicationPreferences(context: Context, complicationId: Int) {
-
+class TeamTrackingComplicationPreferences(
+    context: Context,
+    complicationId: Int,
+) {
     private val prefs: SharedPreferences =
         context.getSharedPreferences("complication_$complicationId", Context.MODE_PRIVATE)
 
@@ -54,17 +56,25 @@ class TeamTrackingComplicationPreferences(context: Context, complicationId: Int)
             context.getSharedPreferences("complication_global", Context.MODE_PRIVATE)
 
         fun getActiveComplicationIds(context: Context): Set<Int> =
-            globalPrefs(context).getStringSet("active_ids", emptySet())
-                ?.mapNotNull { it.toIntOrNull() }?.toSet() ?: emptySet()
+            globalPrefs(context)
+                .getStringSet("active_ids", emptySet())
+                ?.mapNotNull { it.toIntOrNull() }
+                ?.toSet() ?: emptySet()
 
-        fun addComplicationId(context: Context, id: Int) {
+        fun addComplicationId(
+            context: Context,
+            id: Int,
+        ) {
             val prefs = globalPrefs(context)
             val ids = prefs.getStringSet("active_ids", emptySet())?.toMutableSet() ?: mutableSetOf()
             ids.add(id.toString())
             prefs.edit().putStringSet("active_ids", ids).apply()
         }
 
-        fun removeComplicationId(context: Context, id: Int) {
+        fun removeComplicationId(
+            context: Context,
+            id: Int,
+        ) {
             val prefs = globalPrefs(context)
             val ids = prefs.getStringSet("active_ids", emptySet())?.toMutableSet() ?: mutableSetOf()
             ids.remove(id.toString())

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationService.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationService.kt
@@ -16,28 +16,39 @@ import com.thebluealliance.android.wear.tracker.TeamTrackerActivity
 import com.thebluealliance.android.wear.tracker.TeamTrackerPreferences
 
 class TeamTrackingComplicationService : SuspendingComplicationDataSourceService() {
-
     override fun getPreviewData(type: ComplicationType): ComplicationData? {
-        val lamp = MonochromaticImage.Builder(
-            Icon.createWithResource(this, R.drawable.tba_lamp)
-        ).build()
+        val lamp =
+            MonochromaticImage
+                .Builder(
+                    Icon.createWithResource(this, R.drawable.tba_lamp),
+                ).build()
 
         return when (type) {
-            ComplicationType.SHORT_TEXT -> ShortTextComplicationData.Builder(
-                text = PlainComplicationText.Builder("~2:30P").build(),
-                contentDescription = PlainComplicationText.Builder("Team 177 next match: Q18 at ~2:30P").build(),
-            )
-                .setTitle(PlainComplicationText.Builder("Q18").build())
-                .setMonochromaticImage(lamp)
-                .build()
+            ComplicationType.SHORT_TEXT ->
+                ShortTextComplicationData
+                    .Builder(
+                        text = PlainComplicationText.Builder("~2:30P").build(),
+                        contentDescription =
+                            PlainComplicationText
+                                .Builder(
+                                    "Team 177 next match: Q18 at ~2:30P",
+                                ).build(),
+                    ).setTitle(PlainComplicationText.Builder("Q18").build())
+                    .setMonochromaticImage(lamp)
+                    .build()
 
-            ComplicationType.LONG_TEXT -> LongTextComplicationData.Builder(
-                text = PlainComplicationText.Builder("Q18 ~2:30P").build(),
-                contentDescription = PlainComplicationText.Builder("Team 177 next match: Q18 at ~2:30P").build(),
-            )
-                .setTitle(PlainComplicationText.Builder("177 — Hartford").build())
-                .setMonochromaticImage(lamp)
-                .build()
+            ComplicationType.LONG_TEXT ->
+                LongTextComplicationData
+                    .Builder(
+                        text = PlainComplicationText.Builder("Q18 ~2:30P").build(),
+                        contentDescription =
+                            PlainComplicationText
+                                .Builder(
+                                    "Team 177 next match: Q18 at ~2:30P",
+                                ).build(),
+                    ).setTitle(PlainComplicationText.Builder("177 — Hartford").build())
+                    .setMonochromaticImage(lamp)
+                    .build()
 
             else -> null
         }
@@ -60,18 +71,35 @@ class TeamTrackingComplicationService : SuspendingComplicationDataSourceService(
         val upcomingName = prefs.upcomingEventName
         val upcomingDate = prefs.upcomingEventDate
 
-        val image = avatarBase64?.let { AvatarConverter.toMonochromaticImage(it) }
-            ?: MonochromaticImage.Builder(
-                Icon.createWithResource(this, R.drawable.tba_lamp)
-            ).build()
+        val image =
+            avatarBase64?.let { AvatarConverter.toMonochromaticImage(it) }
+                ?: MonochromaticImage
+                    .Builder(
+                        Icon.createWithResource(this, R.drawable.tba_lamp),
+                    ).build()
 
         return when (request.complicationType) {
-            ComplicationType.SHORT_TEXT -> buildShortText(
-                teamNumber, matchLabel, matchTime, upcomingName, upcomingDate, image, tapAction,
-            )
-            ComplicationType.LONG_TEXT -> buildLongText(
-                teamNumber, matchLabel, matchTime, activeEventName, upcomingName, upcomingDate, image, tapAction,
-            )
+            ComplicationType.SHORT_TEXT ->
+                buildShortText(
+                    teamNumber,
+                    matchLabel,
+                    matchTime,
+                    upcomingName,
+                    upcomingDate,
+                    image,
+                    tapAction,
+                )
+            ComplicationType.LONG_TEXT ->
+                buildLongText(
+                    teamNumber,
+                    matchLabel,
+                    matchTime,
+                    activeEventName,
+                    upcomingName,
+                    upcomingDate,
+                    image,
+                    tapAction,
+                )
             else -> null
         }
     }
@@ -88,32 +116,40 @@ class TeamTrackingComplicationService : SuspendingComplicationDataSourceService(
         tapAction: PendingIntent,
     ): ShortTextComplicationData {
         if (matchLabel.isNotBlank()) {
-            return ShortTextComplicationData.Builder(
-                text = PlainComplicationText.Builder(matchTime).build(),
-                contentDescription = PlainComplicationText.Builder("Team $teamNumber next match: $matchLabel at $matchTime").build(),
-            )
-                .setTitle(PlainComplicationText.Builder(matchLabel).build())
+            return ShortTextComplicationData
+                .Builder(
+                    text = PlainComplicationText.Builder(matchTime).build(),
+                    contentDescription =
+                        PlainComplicationText
+                            .Builder(
+                                "Team $teamNumber next match: $matchLabel at $matchTime",
+                            ).build(),
+                ).setTitle(PlainComplicationText.Builder(matchLabel).build())
                 .setMonochromaticImage(image)
                 .setTapAction(tapAction)
                 .build()
         }
 
         if (upcomingName.isNotBlank()) {
-            return ShortTextComplicationData.Builder(
-                text = PlainComplicationText.Builder(upcomingDate).build(),
-                contentDescription = PlainComplicationText.Builder("Team $teamNumber: $upcomingName on $upcomingDate").build(),
-            )
-                .setTitle(PlainComplicationText.Builder(upcomingName).build())
+            return ShortTextComplicationData
+                .Builder(
+                    text = PlainComplicationText.Builder(upcomingDate).build(),
+                    contentDescription =
+                        PlainComplicationText
+                            .Builder(
+                                "Team $teamNumber: $upcomingName on $upcomingDate",
+                            ).build(),
+                ).setTitle(PlainComplicationText.Builder(upcomingName).build())
                 .setMonochromaticImage(image)
                 .setTapAction(tapAction)
                 .build()
         }
 
-        return ShortTextComplicationData.Builder(
-            text = PlainComplicationText.Builder(teamNumber).build(),
-            contentDescription = PlainComplicationText.Builder("Team $teamNumber").build(),
-        )
-            .setMonochromaticImage(image)
+        return ShortTextComplicationData
+            .Builder(
+                text = PlainComplicationText.Builder(teamNumber).build(),
+                contentDescription = PlainComplicationText.Builder("Team $teamNumber").build(),
+            ).setMonochromaticImage(image)
             .setTapAction(tapAction)
             .build()
     }
@@ -135,11 +171,15 @@ class TeamTrackingComplicationService : SuspendingComplicationDataSourceService(
         if (matchLabel.isNotBlank()) {
             // "Q18 ~2:30P" / "177 — Hartford"
             val eventSuffix = if (activeEventName.isNotBlank()) " — $activeEventName" else ""
-            return LongTextComplicationData.Builder(
-                text = PlainComplicationText.Builder("$matchLabel $matchTime").build(),
-                contentDescription = PlainComplicationText.Builder("Team $teamNumber next match: $matchLabel at $matchTime").build(),
-            )
-                .setTitle(PlainComplicationText.Builder("$teamNumber$eventSuffix").build())
+            return LongTextComplicationData
+                .Builder(
+                    text = PlainComplicationText.Builder("$matchLabel $matchTime").build(),
+                    contentDescription =
+                        PlainComplicationText
+                            .Builder(
+                                "Team $teamNumber next match: $matchLabel at $matchTime",
+                            ).build(),
+                ).setTitle(PlainComplicationText.Builder("$teamNumber$eventSuffix").build())
                 .setMonochromaticImage(image)
                 .setTapAction(tapAction)
                 .build()
@@ -147,48 +187,68 @@ class TeamTrackingComplicationService : SuspendingComplicationDataSourceService(
 
         if (upcomingName.isNotBlank()) {
             // "Mar 27" / "177 — Hartford"
-            return LongTextComplicationData.Builder(
-                text = PlainComplicationText.Builder(upcomingDate).build(),
-                contentDescription = PlainComplicationText.Builder("Team $teamNumber: $upcomingName on $upcomingDate").build(),
-            )
-                .setTitle(PlainComplicationText.Builder("$teamNumber — $upcomingName").build())
-                .setMonochromaticImage(image)
+            return LongTextComplicationData
+                .Builder(
+                    text = PlainComplicationText.Builder(upcomingDate).build(),
+                    contentDescription =
+                        PlainComplicationText
+                            .Builder(
+                                "Team $teamNumber: $upcomingName on $upcomingDate",
+                            ).build(),
+                ).setTitle(
+                    PlainComplicationText.Builder("$teamNumber — $upcomingName").build(),
+                ).setMonochromaticImage(image)
                 .setTapAction(tapAction)
                 .build()
         }
 
-        return LongTextComplicationData.Builder(
-            text = PlainComplicationText.Builder("Team $teamNumber").build(),
-            contentDescription = PlainComplicationText.Builder("Team $teamNumber").build(),
-        )
-            .setMonochromaticImage(image)
+        return LongTextComplicationData
+            .Builder(
+                text = PlainComplicationText.Builder("Team $teamNumber").build(),
+                contentDescription = PlainComplicationText.Builder("Team $teamNumber").build(),
+            ).setMonochromaticImage(image)
             .setTapAction(tapAction)
             .build()
     }
 
     // endregion
 
-    private fun buildFallback(type: ComplicationType, tapAction: PendingIntent): ComplicationData {
-        val lamp = MonochromaticImage.Builder(
-            Icon.createWithResource(this, R.drawable.tba_lamp)
-        ).build()
+    private fun buildFallback(
+        type: ComplicationType,
+        tapAction: PendingIntent,
+    ): ComplicationData {
+        val lamp =
+            MonochromaticImage
+                .Builder(
+                    Icon.createWithResource(this, R.drawable.tba_lamp),
+                ).build()
 
         return when (type) {
-            ComplicationType.LONG_TEXT -> LongTextComplicationData.Builder(
-                text = PlainComplicationText.Builder("The Blue Alliance").build(),
-                contentDescription = PlainComplicationText.Builder("The Blue Alliance — tap to configure").build(),
-            )
-                .setMonochromaticImage(lamp)
-                .setTapAction(tapAction)
-                .build()
+            ComplicationType.LONG_TEXT ->
+                LongTextComplicationData
+                    .Builder(
+                        text = PlainComplicationText.Builder("The Blue Alliance").build(),
+                        contentDescription =
+                            PlainComplicationText
+                                .Builder(
+                                    "The Blue Alliance — tap to configure",
+                                ).build(),
+                    ).setMonochromaticImage(lamp)
+                    .setTapAction(tapAction)
+                    .build()
 
-            else -> ShortTextComplicationData.Builder(
-                text = PlainComplicationText.Builder("TBA").build(),
-                contentDescription = PlainComplicationText.Builder("The Blue Alliance — tap to configure").build(),
-            )
-                .setMonochromaticImage(lamp)
-                .setTapAction(tapAction)
-                .build()
+            else ->
+                ShortTextComplicationData
+                    .Builder(
+                        text = PlainComplicationText.Builder("TBA").build(),
+                        contentDescription =
+                            PlainComplicationText
+                                .Builder(
+                                    "The Blue Alliance — tap to configure",
+                                ).build(),
+                    ).setMonochromaticImage(lamp)
+                    .setTapAction(tapAction)
+                    .build()
         }
     }
 
@@ -204,12 +264,21 @@ class TeamTrackingComplicationService : SuspendingComplicationDataSourceService(
 
     override fun onComplicationDeactivated(complicationInstanceId: Int) {
         super.onComplicationDeactivated(complicationInstanceId)
-        TeamTrackingComplicationPreferences.removeComplicationId(applicationContext, complicationInstanceId)
+        TeamTrackingComplicationPreferences.removeComplicationId(
+            applicationContext,
+            complicationInstanceId,
+        )
         TeamTrackingComplicationPreferences(applicationContext, complicationInstanceId).clear()
     }
 
-    override fun onComplicationActivated(complicationInstanceId: Int, type: ComplicationType) {
+    override fun onComplicationActivated(
+        complicationInstanceId: Int,
+        type: ComplicationType,
+    ) {
         super.onComplicationActivated(complicationInstanceId, type)
-        TeamTrackingComplicationPreferences.addComplicationId(applicationContext, complicationInstanceId)
+        TeamTrackingComplicationPreferences.addComplicationId(
+            applicationContext,
+            complicationInstanceId,
+        )
     }
 }

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/data/ApiKeyProvider.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/data/ApiKeyProvider.kt
@@ -10,45 +10,47 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ApiKeyProvider @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val remoteConfig: FirebaseRemoteConfig,
-) {
-    private val prefs: SharedPreferences =
-        context.getSharedPreferences("api_config", Context.MODE_PRIVATE)
+class ApiKeyProvider
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val remoteConfig: FirebaseRemoteConfig,
+    ) {
+        private val prefs: SharedPreferences =
+            context.getSharedPreferences("api_config", Context.MODE_PRIVATE)
 
-    val apiKey: String
-        get() {
-            if (BuildConfig.DEBUG) return BuildConfig.TBA_API_KEY
+        val apiKey: String
+            get() {
+                if (BuildConfig.DEBUG) return BuildConfig.TBA_API_KEY
 
-            val cached = prefs.getString(PREFS_KEY, null)
-            if (!cached.isNullOrEmpty()) return cached
+                val cached = prefs.getString(PREFS_KEY, null)
+                if (!cached.isNullOrEmpty()) return cached
 
-            val remoteKey = remoteConfig.getString(REMOTE_CONFIG_KEY)
-            if (remoteKey.isNotEmpty()) return remoteKey
+                val remoteKey = remoteConfig.getString(REMOTE_CONFIG_KEY)
+                if (remoteKey.isNotEmpty()) return remoteKey
 
-            return BuildConfig.TBA_API_KEY
-        }
+                return BuildConfig.TBA_API_KEY
+            }
 
-    fun init() {
-        if (BuildConfig.DEBUG) return
+        fun init() {
+            if (BuildConfig.DEBUG) return
 
-        remoteConfig.fetchAndActivate().addOnCompleteListener { task ->
-            if (task.isSuccessful) {
-                val key = remoteConfig.getString(REMOTE_CONFIG_KEY)
-                if (key.isNotEmpty()) {
-                    prefs.edit().putString(PREFS_KEY, key).apply()
-                    Log.d(TAG, "Updated API key from Remote Config")
+            remoteConfig.fetchAndActivate().addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    val key = remoteConfig.getString(REMOTE_CONFIG_KEY)
+                    if (key.isNotEmpty()) {
+                        prefs.edit().putString(PREFS_KEY, key).apply()
+                        Log.d(TAG, "Updated API key from Remote Config")
+                    }
+                } else {
+                    Log.w(TAG, "Failed to fetch Remote Config", task.exception)
                 }
-            } else {
-                Log.w(TAG, "Failed to fetch Remote Config", task.exception)
             }
         }
-    }
 
-    companion object {
-        private const val TAG = "ApiKeyProvider"
-        private const val REMOTE_CONFIG_KEY = "apiv3_auth_key"
-        private const val PREFS_KEY = "tba_api_key"
+        companion object {
+            private const val TAG = "ApiKeyProvider"
+            private const val REMOTE_CONFIG_KEY = "apiv3_auth_key"
+            private const val PREFS_KEY = "tba_api_key"
+        }
     }
-}

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/data/WearNetworkModule.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/data/WearNetworkModule.kt
@@ -19,42 +19,56 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object WearNetworkModule {
-
     @Provides
     @Singleton
     fun provideFirebaseRemoteConfig(): FirebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
 
     @Provides
     @Singleton
-    fun provideJson(): Json = Json {
-        ignoreUnknownKeys = true
-    }
+    fun provideJson(): Json =
+        Json {
+            ignoreUnknownKeys = true
+        }
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(apiKeyProvider: ApiKeyProvider): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(Interceptor { chain ->
-            val request = chain.request().newBuilder()
-                .addHeader("X-TBA-Auth-Key", apiKeyProvider.apiKey)
-                .build()
-            chain.proceed(request)
-        })
-        .addInterceptor(
-            HttpLoggingInterceptor().apply {
-                level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BASIC
-                else HttpLoggingInterceptor.Level.NONE
-            }
-        )
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(30, TimeUnit.SECONDS)
-        .build()
+    fun provideOkHttpClient(apiKeyProvider: ApiKeyProvider): OkHttpClient =
+        OkHttpClient
+            .Builder()
+            .addInterceptor(
+                Interceptor { chain ->
+                    val request =
+                        chain
+                            .request()
+                            .newBuilder()
+                            .addHeader("X-TBA-Auth-Key", apiKeyProvider.apiKey)
+                            .build()
+                    chain.proceed(request)
+                },
+            ).addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level =
+                        if (BuildConfig.DEBUG) {
+                            HttpLoggingInterceptor.Level.BASIC
+                        } else {
+                            HttpLoggingInterceptor.Level.NONE
+                        }
+                },
+            ).connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
 
     @Provides
     @Singleton
-    fun provideWearTbaApi(client: OkHttpClient, json: Json): WearTbaApi = Retrofit.Builder()
-        .baseUrl(BuildConfig.TBA_BASE_URL)
-        .client(client)
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-        .build()
-        .create(WearTbaApi::class.java)
+    fun provideWearTbaApi(
+        client: OkHttpClient,
+        json: Json,
+    ): WearTbaApi =
+        Retrofit
+            .Builder()
+            .baseUrl(BuildConfig.TBA_BASE_URL)
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(WearTbaApi::class.java)
 }

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/data/WearTbaApi.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/data/WearTbaApi.kt
@@ -8,7 +8,6 @@ import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface WearTbaApi {
-
     @GET("api/v3/team/{team_key}/events/{year}")
     suspend fun getTeamEvents(
         @Path("team_key") teamKey: String,

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -57,13 +57,13 @@ import com.thebluealliance.android.wear.complication.TeamTrackingComplicationCon
 import com.thebluealliance.android.wear.worker.TeamTrackingComplicationWorker
 
 class TeamTrackerActivity : ComponentActivity() {
-
     private lateinit var trackerPrefs: TeamTrackerPreferences
     private val state = mutableStateOf(TeamTrackerState())
 
-    private val prefListener = SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
-        loadState()
-    }
+    private val prefListener =
+        SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
+            loadState()
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -100,31 +100,34 @@ class TeamTrackerActivity : ComponentActivity() {
     }
 
     private fun loadState() {
-        state.value = TeamTrackerState(
-            teamNumber = trackerPrefs.teamNumber,
-            teamNickname = trackerPrefs.teamNickname,
-            avatarBase64 = trackerPrefs.avatarBase64,
-            eventName = trackerPrefs.eventName,
-            record = trackerPrefs.record,
-            hasActiveEvent = trackerPrefs.hasActiveEvent,
-            isLoading = trackerPrefs.isLoading,
-            lastMatchLabel = trackerPrefs.lastMatchLabel,
-            lastMatchRedTeams = trackerPrefs.lastMatchRedTeams,
-            lastMatchBlueTeams = trackerPrefs.lastMatchBlueTeams,
-            lastMatchRedScore = trackerPrefs.lastMatchRedScore,
-            lastMatchBlueScore = trackerPrefs.lastMatchBlueScore,
-            lastMatchWinningAlliance = trackerPrefs.lastMatchWinningAlliance,
-            lastAlliance = trackerPrefs.lastAlliance,
-            lastMatchBonusRp = trackerPrefs.lastMatchBonusRp,
-            nextMatchLabel = trackerPrefs.nextMatchLabel,
-            nextMatchRedTeams = trackerPrefs.nextMatchRedTeams,
-            nextMatchBlueTeams = trackerPrefs.nextMatchBlueTeams,
-            nextMatchTime = trackerPrefs.nextMatchTime,
-            nextMatchTimeIsEstimate = trackerPrefs.nextMatchTimeIsEstimate,
-            nextAlliance = trackerPrefs.nextAlliance,
-            upcomingEvents = trackerPrefs.upcomingEvents
-                .split("|").filter { it.isNotBlank() },
-        )
+        state.value =
+            TeamTrackerState(
+                teamNumber = trackerPrefs.teamNumber,
+                teamNickname = trackerPrefs.teamNickname,
+                avatarBase64 = trackerPrefs.avatarBase64,
+                eventName = trackerPrefs.eventName,
+                record = trackerPrefs.record,
+                hasActiveEvent = trackerPrefs.hasActiveEvent,
+                isLoading = trackerPrefs.isLoading,
+                lastMatchLabel = trackerPrefs.lastMatchLabel,
+                lastMatchRedTeams = trackerPrefs.lastMatchRedTeams,
+                lastMatchBlueTeams = trackerPrefs.lastMatchBlueTeams,
+                lastMatchRedScore = trackerPrefs.lastMatchRedScore,
+                lastMatchBlueScore = trackerPrefs.lastMatchBlueScore,
+                lastMatchWinningAlliance = trackerPrefs.lastMatchWinningAlliance,
+                lastAlliance = trackerPrefs.lastAlliance,
+                lastMatchBonusRp = trackerPrefs.lastMatchBonusRp,
+                nextMatchLabel = trackerPrefs.nextMatchLabel,
+                nextMatchRedTeams = trackerPrefs.nextMatchRedTeams,
+                nextMatchBlueTeams = trackerPrefs.nextMatchBlueTeams,
+                nextMatchTime = trackerPrefs.nextMatchTime,
+                nextMatchTimeIsEstimate = trackerPrefs.nextMatchTimeIsEstimate,
+                nextAlliance = trackerPrefs.nextAlliance,
+                upcomingEvents =
+                    trackerPrefs.upcomingEvents
+                        .split("|")
+                        .filter { it.isNotBlank() },
+            )
     }
 
     private fun launchConfigActivity() {
@@ -237,10 +240,11 @@ private fun TeamTrackerScreen(
                         redTeams = state.nextMatchRedTeams,
                         blueTeams = state.nextMatchBlueTeams,
                         trackedTeam = state.teamNumber,
-                        timeText = buildString {
-                            if (state.nextMatchTimeIsEstimate) append("~")
-                            append(state.nextMatchTime)
-                        }.takeIf { state.nextMatchTime.isNotBlank() },
+                        timeText =
+                            buildString {
+                                if (state.nextMatchTimeIsEstimate) append("~")
+                                append(state.nextMatchTime)
+                            }.takeIf { state.nextMatchTime.isNotBlank() },
                     )
                 }
             }
@@ -283,31 +287,34 @@ private fun EmptyState(onChangeTeam: () -> Unit) {
 
 @Composable
 private fun TeamHeader(state: TeamTrackerState) {
-    val bitmap = remember(state.avatarBase64) {
-        state.avatarBase64?.let { base64 ->
-            try {
-                val bytes = Base64.decode(base64, Base64.DEFAULT)
-                BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-            } catch (_: Exception) {
-                null
+    val bitmap =
+        remember(state.avatarBase64) {
+            state.avatarBase64?.let { base64 ->
+                try {
+                    val bytes = Base64.decode(base64, Base64.DEFAULT)
+                    BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                } catch (_: Exception) {
+                    null
+                }
             }
         }
-    }
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (bitmap != null) {
-            val bgColor = when (state.nextAlliance.ifBlank { state.lastAlliance }) {
-                "red" -> AllianceRedBg
-                "blue" -> AllianceBlueBg
-                else -> AllianceBlueBg
-            }
+            val bgColor =
+                when (state.nextAlliance.ifBlank { state.lastAlliance }) {
+                    "red" -> AllianceRedBg
+                    "blue" -> AllianceBlueBg
+                    else -> AllianceBlueBg
+                }
             Box(
-                modifier = Modifier
-                    .size(36.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(bgColor),
+                modifier =
+                    Modifier
+                        .size(36.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(bgColor),
                 contentAlignment = Alignment.Center,
             ) {
                 Image(
@@ -328,11 +335,12 @@ private fun TeamHeader(state: TeamTrackerState) {
 @Composable
 private fun EventSubtitle(state: TeamTrackerState) {
     if (state.hasActiveEvent) {
-        val text = if (state.record.isNotBlank()) {
-            "${state.record} at ${state.eventName}"
-        } else {
-            state.eventName
-        }
+        val text =
+            if (state.record.isNotBlank()) {
+                "${state.record} at ${state.eventName}"
+            } else {
+                state.eventName
+            }
         Text(
             text = text,
             style = MaterialTheme.typography.labelSmall,
@@ -376,9 +384,10 @@ private fun MatchSection(
     timeText: String? = null,
 ) {
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 6.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 6.dp),
     ) {
         Text(
             text = "$title \u2014 $matchLabel",
@@ -427,23 +436,25 @@ private fun AllianceRow(
     bonusRp: Int = 0,
 ) {
     val teamList = teams.split(", ")
-    val styledTeams = buildAnnotatedString {
-        teamList.forEachIndexed { index, team ->
-            if (team == trackedTeam) {
-                withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
+    val styledTeams =
+        buildAnnotatedString {
+            teamList.forEachIndexed { index, team ->
+                if (team == trackedTeam) {
+                    withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
+                        append(team)
+                    }
+                } else {
                     append(team)
                 }
-            } else {
-                append(team)
+                if (index < teamList.lastIndex) append(", ")
             }
-            if (index < teamList.lastIndex) append(", ")
         }
-    }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 1.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 1.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerPreferences.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerPreferences.kt
@@ -8,8 +8,9 @@ import android.content.SharedPreferences
  * Single source of truth for team number — complications read from here too.
  * Per-complication prefs ([TeamTrackingComplicationPreferences]) only store display data.
  */
-class TeamTrackerPreferences(context: Context) {
-
+class TeamTrackerPreferences(
+    context: Context,
+) {
     private val prefs: SharedPreferences =
         context.getSharedPreferences("team_tracker_app", Context.MODE_PRIVATE)
 
@@ -119,7 +120,9 @@ class TeamTrackerPreferences(context: Context) {
     /** Clear all cached data except the team number, and mark as loading. */
     fun clearCachedData() {
         val team = teamNumber
-        prefs.edit().clear()
+        prefs
+            .edit()
+            .clear()
             .putString(KEY_TEAM_NUMBER, team)
             .putBoolean(KEY_IS_LOADING, true)
             .apply()

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
@@ -18,11 +18,11 @@ import com.thebluealliance.android.wear.data.WearTbaApi
 import com.thebluealliance.android.wear.data.dto.EventDto
 import com.thebluealliance.android.wear.data.dto.MatchDto
 import com.thebluealliance.android.wear.tracker.TeamTrackerPreferences
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedInject
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -30,449 +30,512 @@ import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 
 @HiltWorker
-class TeamTrackingComplicationWorker @AssistedInject constructor(
-    @Assisted appContext: Context,
-    @Assisted workerParams: WorkerParameters,
-    private val api: WearTbaApi,
-) : CoroutineWorker(appContext, workerParams) {
+class TeamTrackingComplicationWorker
+    @AssistedInject
+    constructor(
+        @Assisted appContext: Context,
+        @Assisted workerParams: WorkerParameters,
+        private val api: WearTbaApi,
+    ) : CoroutineWorker(appContext, workerParams) {
+        companion object {
+            private const val TAG = "ComplicationRefresh"
+            private const val WORK_NAME = "complication_refresh"
+            private const val FAST_WORK_NAME = "complication_fast_refresh"
 
-    companion object {
-        private const val TAG = "ComplicationRefresh"
-        private const val WORK_NAME = "complication_refresh"
-        private const val FAST_WORK_NAME = "complication_fast_refresh"
+            private val timeFormat = DateTimeFormatter.ofPattern("h:mm")
 
-        private val timeFormat = DateTimeFormatter.ofPattern("h:mm")
+            fun enqueuePeriodicRefresh(context: Context) {
+                val request =
+                    PeriodicWorkRequestBuilder<TeamTrackingComplicationWorker>(
+                        6,
+                        TimeUnit.HOURS,
+                    ).build()
+                WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                    WORK_NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    request,
+                )
+            }
 
-        fun enqueuePeriodicRefresh(context: Context) {
-            val request = PeriodicWorkRequestBuilder<TeamTrackingComplicationWorker>(
-                6, TimeUnit.HOURS,
-            ).build()
-            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                WORK_NAME,
-                ExistingPeriodicWorkPolicy.KEEP,
-                request,
-            )
+            fun cancelPeriodicRefresh(context: Context) {
+                val wm = WorkManager.getInstance(context)
+                wm.cancelUniqueWork(WORK_NAME)
+                wm.cancelUniqueWork(FAST_WORK_NAME)
+            }
+
+            private fun enqueueFastRefresh(context: Context) {
+                val request =
+                    OneTimeWorkRequestBuilder<TeamTrackingComplicationWorker>()
+                        .setInitialDelay(15, TimeUnit.MINUTES)
+                        .build()
+                WorkManager.getInstance(context).enqueueUniqueWork(
+                    FAST_WORK_NAME,
+                    ExistingWorkPolicy.REPLACE,
+                    request,
+                )
+            }
+
+            fun enqueueImmediateRefresh(context: Context) {
+                val request = OneTimeWorkRequestBuilder<TeamTrackingComplicationWorker>().build()
+                WorkManager.getInstance(context).enqueueUniqueWork(
+                    "complication_immediate_refresh",
+                    ExistingWorkPolicy.REPLACE,
+                    request,
+                )
+            }
         }
 
-        fun cancelPeriodicRefresh(context: Context) {
-            val wm = WorkManager.getInstance(context)
-            wm.cancelUniqueWork(WORK_NAME)
-            wm.cancelUniqueWork(FAST_WORK_NAME)
-        }
+        /** Intermediate result of fetching a team's event/match data. */
+        private data class TeamEventData(
+            val events: List<EventDto>,
+            val currentEvent: EventDto?,
+            val teamMatches: List<MatchDto>,
+            val avatarBase64: String?,
+        )
 
-        private fun enqueueFastRefresh(context: Context) {
-            val request = OneTimeWorkRequestBuilder<TeamTrackingComplicationWorker>()
-                .setInitialDelay(15, TimeUnit.MINUTES)
-                .build()
-            WorkManager.getInstance(context).enqueueUniqueWork(
-                FAST_WORK_NAME,
-                ExistingWorkPolicy.REPLACE,
-                request,
-            )
-        }
+        override suspend fun doWork(): Result {
+            val trackerPrefs = TeamTrackerPreferences(applicationContext)
+            return try {
+                val trackerTeam = trackerPrefs.teamNumber
+                var anyActiveEvent = false
 
-        fun enqueueImmediateRefresh(context: Context) {
-            val request = OneTimeWorkRequestBuilder<TeamTrackingComplicationWorker>().build()
-            WorkManager.getInstance(context).enqueueUniqueWork(
-                "complication_immediate_refresh",
-                ExistingWorkPolicy.REPLACE,
-                request,
-            )
-        }
-    }
+                if (trackerTeam.isNotBlank()) {
+                    val teamKey = "frc$trackerTeam"
+                    val data = fetchTeamEventData(teamKey)
 
-    /** Intermediate result of fetching a team's event/match data. */
-    private data class TeamEventData(
-        val events: List<EventDto>,
-        val currentEvent: EventDto?,
-        val teamMatches: List<MatchDto>,
-        val avatarBase64: String?,
-    )
+                    // Update all active complications
+                    val complicationIds =
+                        TeamTrackingComplicationPreferences.getActiveComplicationIds(
+                            applicationContext,
+                        )
+                    for (complicationId in complicationIds) {
+                        try {
+                            val prefs =
+                                TeamTrackingComplicationPreferences(
+                                    applicationContext,
+                                    complicationId,
+                                )
+                            val hasActive = updateComplication(prefs, trackerTeam, data)
+                            if (hasActive) anyActiveEvent = true
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Failed to update complication $complicationId", e)
+                        }
+                    }
 
-    override suspend fun doWork(): Result {
-        val trackerPrefs = TeamTrackerPreferences(applicationContext)
-        return try {
-            val trackerTeam = trackerPrefs.teamNumber
-            var anyActiveEvent = false
-
-            if (trackerTeam.isNotBlank()) {
-                val teamKey = "frc$trackerTeam"
-                val data = fetchTeamEventData(teamKey)
-
-                // Update all active complications
-                val complicationIds = TeamTrackingComplicationPreferences.getActiveComplicationIds(applicationContext)
-                for (complicationId in complicationIds) {
+                    // Update app-level team tracker
                     try {
-                        val prefs = TeamTrackingComplicationPreferences(applicationContext, complicationId)
-                        val hasActive = updateComplication(prefs, trackerTeam, data)
+                        val hasActive = updateAppTracker(trackerPrefs, trackerTeam, data)
                         if (hasActive) anyActiveEvent = true
                     } catch (e: Exception) {
-                        Log.e(TAG, "Failed to update complication $complicationId", e)
+                        Log.e(TAG, "Failed to update app tracker", e)
                     }
                 }
 
-                // Update app-level team tracker
-                try {
-                    val hasActive = updateAppTracker(trackerPrefs, trackerTeam, data)
-                    if (hasActive) anyActiveEvent = true
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to update app tracker", e)
+                if (anyActiveEvent) {
+                    enqueueFastRefresh(applicationContext)
                 }
-            }
 
-            if (anyActiveEvent) {
-                enqueueFastRefresh(applicationContext)
-            }
+                // Request complication data update from the watch face
+                requestComplicationUpdate()
 
-            // Request complication data update from the watch face
-            requestComplicationUpdate()
-
-            Result.success()
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to update complications", e)
-            Result.retry()
-        } finally {
-            trackerPrefs.isLoading = false
-        }
-    }
-
-    private fun requestComplicationUpdate() {
-        val requester = ComplicationDataSourceUpdateRequester.create(
-            applicationContext,
-            ComponentName(applicationContext, TeamTrackingComplicationService::class.java),
-        )
-        requester.requestUpdateAll()
-    }
-
-    // region Data fetching
-
-    /** Fetch events, current event matches, and avatar for a team. */
-    private suspend fun fetchTeamEventData(teamKey: String): TeamEventData {
-        val year = LocalDate.now().year
-
-        // Let this throw — doWork() catches it and returns Result.retry(),
-        // preserving cached data instead of overwriting with empty values.
-        val events = api.getTeamEvents(teamKey, year)
-
-        val currentEvent = findCurrentEvent(events, teamKey)
-
-        val teamMatches = if (currentEvent != null) {
-            try {
-                api.getEventMatches(currentEvent.key)
-                    .filter { match ->
-                        val red = match.alliances?.red?.teamKeys ?: emptyList()
-                        val blue = match.alliances?.blue?.teamKeys ?: emptyList()
-                        teamKey in red || teamKey in blue
-                    }
-                    .sortedWith(
-                        compareBy(
-                            { compLevelOrder(it.compLevel) },
-                            { it.setNumber },
-                            { it.matchNumber },
-                        ),
-                    )
+                Result.success()
             } catch (e: Exception) {
-                Log.w(TAG, "Failed to fetch matches for ${currentEvent.key}", e)
-                emptyList()
+                Log.e(TAG, "Failed to update complications", e)
+                Result.retry()
+            } finally {
+                trackerPrefs.isLoading = false
             }
-        } else {
-            emptyList()
         }
 
-        val avatarBase64 = fetchAvatar(teamKey, year)
-
-        return TeamEventData(events, currentEvent, teamMatches, avatarBase64)
-    }
-
-    private suspend fun fetchAvatar(teamKey: String, year: Int): String? {
-        return try {
-            val media = api.getTeamMedia(teamKey, year)
-            val avatar = media.firstOrNull { it.type == "avatar" }
-                ?: api.getTeamMedia(teamKey, year - 1).firstOrNull { it.type == "avatar" }
-            avatar?.base64Image
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to fetch avatar for $teamKey", e)
-            null
+        private fun requestComplicationUpdate() {
+            val requester =
+                ComplicationDataSourceUpdateRequester.create(
+                    applicationContext,
+                    ComponentName(applicationContext, TeamTrackingComplicationService::class.java),
+                )
+            requester.requestUpdateAll()
         }
-    }
 
-    // endregion
+        // region Data fetching
 
-    // region Complication update
+        /** Fetch events, current event matches, and avatar for a team. */
+        private suspend fun fetchTeamEventData(teamKey: String): TeamEventData {
+            val year = LocalDate.now().year
 
-    /** Returns true if the team has an active event. */
-    private fun updateComplication(prefs: TeamTrackingComplicationPreferences, teamNumber: String, data: TeamEventData): Boolean {
+            // Let this throw — doWork() catches it and returns Result.retry(),
+            // preserving cached data instead of overwriting with empty values.
+            val events = api.getTeamEvents(teamKey, year)
 
-        if (data.currentEvent == null) {
-            prefs.matchLabel = ""
-            prefs.matchTime = ""
-            prefs.activeEventName = ""
+            val currentEvent = findCurrentEvent(events, teamKey)
 
-            val nextEvent = findUpcomingEvent(data.events)
-            if (nextEvent != null) {
-                prefs.upcomingEventName = nextEvent.shortName ?: nextEvent.name
-                prefs.upcomingEventDate = nextEvent.startDate?.let {
-                    LocalDate.parse(it).format(DateTimeFormatter.ofPattern("MMM d"))
-                } ?: ""
-            } else {
-                prefs.upcomingEventName = ""
-                prefs.upcomingEventDate = ""
+            val teamMatches =
+                if (currentEvent != null) {
+                    try {
+                        api
+                            .getEventMatches(currentEvent.key)
+                            .filter { match ->
+                                val red = match.alliances?.red?.teamKeys ?: emptyList()
+                                val blue = match.alliances?.blue?.teamKeys ?: emptyList()
+                                teamKey in red || teamKey in blue
+                            }.sortedWith(
+                                compareBy(
+                                    { compLevelOrder(it.compLevel) },
+                                    { it.setNumber },
+                                    { it.matchNumber },
+                                ),
+                            )
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to fetch matches for ${currentEvent.key}", e)
+                        emptyList()
+                    }
+                } else {
+                    emptyList()
+                }
+
+            val avatarBase64 = fetchAvatar(teamKey, year)
+
+            return TeamEventData(events, currentEvent, teamMatches, avatarBase64)
+        }
+
+        private suspend fun fetchAvatar(
+            teamKey: String,
+            year: Int,
+        ): String? =
+            try {
+                val media = api.getTeamMedia(teamKey, year)
+                val avatar =
+                    media.firstOrNull { it.type == "avatar" }
+                        ?: api.getTeamMedia(teamKey, year - 1).firstOrNull { it.type == "avatar" }
+                avatar?.base64Image
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to fetch avatar for $teamKey", e)
+                null
             }
 
-            if (data.avatarBase64 != null) prefs.avatarBase64 = data.avatarBase64
-            return false
-        }
+        // endregion
 
-        val nextMatch = data.teamMatches.firstOrNull { (it.alliances?.red?.score ?: -1) < 0 }
-        if (nextMatch != null) {
-            prefs.matchLabel = getShortLabel(nextMatch)
-            prefs.matchTime = formatMatchTime(nextMatch)
-        } else {
-            prefs.matchLabel = ""
-            prefs.matchTime = ""
-        }
-        prefs.activeEventName = data.currentEvent.shortName ?: data.currentEvent.name
+        // region Complication update
 
-        if (data.avatarBase64 != null) prefs.avatarBase64 = data.avatarBase64
-        return true
-    }
+        /** Returns true if the team has an active event. */
+        private fun updateComplication(
+            prefs: TeamTrackingComplicationPreferences,
+            teamNumber: String,
+            data: TeamEventData,
+        ): Boolean {
+            if (data.currentEvent == null) {
+                prefs.matchLabel = ""
+                prefs.matchTime = ""
+                prefs.activeEventName = ""
 
-    // endregion
-
-    // region App tracker update
-
-    /** Returns true if the team has an active event. */
-    private suspend fun updateAppTracker(prefs: TeamTrackerPreferences, teamNumber: String, data: TeamEventData): Boolean {
-        val teamKey = "frc$teamNumber"
-
-        // Fetch team nickname — keep existing on failure
-        prefs.teamNickname = try {
-            api.getTeam(teamKey).nickname ?: prefs.teamNickname
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to fetch team info for $teamKey", e)
-            prefs.teamNickname
-        }
-
-        if (data.avatarBase64 != null) prefs.avatarBase64 = data.avatarBase64
-
-        if (data.currentEvent == null) {
-            prefs.hasActiveEvent = false
-            prefs.eventName = ""
-            prefs.record = ""
-            clearLastMatch(prefs)
-            clearNextMatch(prefs)
-
-            val upcoming = findAllUpcomingEvents(data.events)
-            prefs.upcomingEvents = if (upcoming.isNotEmpty()) {
-                upcoming.joinToString("|") { event ->
-                    val name = event.shortName ?: event.name
-                    val date = event.startDate?.let {
+                val nextEvent = findUpcomingEvent(data.events)
+                if (nextEvent != null) {
+                    prefs.upcomingEventName = nextEvent.shortName ?: nextEvent.name
+                    prefs.upcomingEventDate = nextEvent.startDate?.let {
                         LocalDate.parse(it).format(DateTimeFormatter.ofPattern("MMM d"))
                     } ?: ""
-                    "$date \u2014 $name"
+                } else {
+                    prefs.upcomingEventName = ""
+                    prefs.upcomingEventDate = ""
                 }
+
+                if (data.avatarBase64 != null) prefs.avatarBase64 = data.avatarBase64
+                return false
+            }
+
+            val nextMatch = data.teamMatches.firstOrNull { (it.alliances?.red?.score ?: -1) < 0 }
+            if (nextMatch != null) {
+                prefs.matchLabel = getShortLabel(nextMatch)
+                prefs.matchTime = formatMatchTime(nextMatch)
             } else {
-                ""
+                prefs.matchLabel = ""
+                prefs.matchTime = ""
             }
-            return false
+            prefs.activeEventName = data.currentEvent.shortName ?: data.currentEvent.name
+
+            if (data.avatarBase64 != null) prefs.avatarBase64 = data.avatarBase64
+            return true
         }
 
-        prefs.hasActiveEvent = true
-        prefs.eventName = data.currentEvent.shortName ?: data.currentEvent.name
-        prefs.upcomingEvents = ""
+        // endregion
 
-        // Compute qual record
-        val qualMatches = data.teamMatches.filter {
-            it.compLevel == "qm" && (it.alliances?.red?.score ?: -1) >= 0
-        }
-        var wins = 0
-        var losses = 0
-        var ties = 0
-        for (match in qualMatches) {
-            val alliance = if (teamKey in (match.alliances?.red?.teamKeys ?: emptyList())) "red" else "blue"
-            when {
-                match.winningAlliance == alliance -> wins++
-                match.winningAlliance.isNullOrBlank() -> ties++
-                else -> losses++
-            }
-        }
-        prefs.record = "$wins-$losses-$ties"
+        // region App tracker update
 
-        // Last played match
-        val lastMatch = data.teamMatches.lastOrNull { (it.alliances?.red?.score ?: -1) >= 0 }
-        if (lastMatch != null) {
-            prefs.lastMatchLabel = getShortLabel(lastMatch)
-            prefs.lastMatchRedTeams = teamKeysToNumbers(lastMatch.alliances?.red?.teamKeys)
-            prefs.lastMatchBlueTeams = teamKeysToNumbers(lastMatch.alliances?.blue?.teamKeys)
-            prefs.lastMatchRedScore = lastMatch.alliances?.red?.score ?: -1
-            prefs.lastMatchBlueScore = lastMatch.alliances?.blue?.score ?: -1
-            prefs.lastMatchWinningAlliance = lastMatch.winningAlliance ?: ""
-            val lastAlliance = if (teamKey in (lastMatch.alliances?.red?.teamKeys ?: emptyList())) "red" else "blue"
-            prefs.lastAlliance = lastAlliance
-            prefs.lastMatchBonusRp = extractBonusRp(lastMatch, lastAlliance)
-        } else {
-            clearLastMatch(prefs)
-        }
+        /** Returns true if the team has an active event. */
+        private suspend fun updateAppTracker(
+            prefs: TeamTrackerPreferences,
+            teamNumber: String,
+            data: TeamEventData,
+        ): Boolean {
+            val teamKey = "frc$teamNumber"
 
-        // Next unplayed match
-        val nextMatch = data.teamMatches.firstOrNull { (it.alliances?.red?.score ?: -1) < 0 }
-        if (nextMatch != null) {
-            prefs.nextMatchLabel = getShortLabel(nextMatch)
-            prefs.nextMatchRedTeams = teamKeysToNumbers(nextMatch.alliances?.red?.teamKeys)
-            prefs.nextMatchBlueTeams = teamKeysToNumbers(nextMatch.alliances?.blue?.teamKeys)
-            prefs.nextMatchTimeIsEstimate = nextMatch.predictedTime != null
-            prefs.nextMatchTime = formatMatchTimeRaw(nextMatch)
-            prefs.nextAlliance = if (teamKey in (nextMatch.alliances?.red?.teamKeys ?: emptyList())) "red" else "blue"
-        } else {
-            clearNextMatch(prefs)
-        }
-
-        return true
-    }
-
-    private fun clearLastMatch(prefs: TeamTrackerPreferences) {
-        prefs.lastMatchLabel = ""
-        prefs.lastMatchRedTeams = ""
-        prefs.lastMatchBlueTeams = ""
-        prefs.lastMatchRedScore = -1
-        prefs.lastMatchBlueScore = -1
-        prefs.lastMatchWinningAlliance = ""
-        prefs.lastAlliance = ""
-        prefs.lastMatchBonusRp = 0
-    }
-
-    /** Extract bonus RPs (total minus win/tie RPs) from score_breakdown. */
-    private fun extractBonusRp(match: MatchDto, alliance: String): Int {
-        val breakdown = match.scoreBreakdown?.get(alliance)?.jsonObject ?: return 0
-        val totalRp = breakdown["rp"]?.jsonPrimitive?.intOrNull ?: return 0
-        val winRp = when {
-            match.winningAlliance == alliance -> 2
-            match.winningAlliance.isNullOrBlank() -> 1
-            else -> 0
-        }
-        return (totalRp - winRp).coerceAtLeast(0)
-    }
-
-    private fun clearNextMatch(prefs: TeamTrackerPreferences) {
-        prefs.nextMatchLabel = ""
-        prefs.nextMatchRedTeams = ""
-        prefs.nextMatchBlueTeams = ""
-        prefs.nextMatchTime = ""
-        prefs.nextMatchTimeIsEstimate = false
-        prefs.nextAlliance = ""
-    }
-
-    // endregion
-
-    // region Helpers
-
-    private fun teamKeysToNumbers(keys: List<String>?): String =
-        keys?.joinToString(", ") { it.removePrefix("frc") } ?: ""
-
-    private fun findUpcomingEvent(events: List<EventDto>): EventDto? =
-        findAllUpcomingEvents(events).firstOrNull()
-
-    private fun findAllUpcomingEvents(events: List<EventDto>): List<EventDto> {
-        val today = LocalDate.now()
-        return events.filter { event ->
-            val start = event.startDate?.let { LocalDate.parse(it) } ?: return@filter false
-            !start.isBefore(today)
-        }.sortedBy { it.startDate ?: "" }
-    }
-
-    /**
-     * Find the current event: running today > recently ended (within 3 days).
-     * Among concurrent events, prefer the one with unplayed matches.
-     */
-    private suspend fun findCurrentEvent(events: List<EventDto>, teamKey: String): EventDto? {
-        if (events.isEmpty()) return null
-        val today = LocalDate.now()
-
-        val currentEvents = events.filter { event ->
-            val start = event.startDate?.let { LocalDate.parse(it) } ?: return@filter false
-            val end = event.endDate?.let { LocalDate.parse(it) } ?: start
-            today in start..end
-        }
-
-        if (currentEvents.size > 1) {
-            for (event in currentEvents) {
+            // Fetch team nickname — keep existing on failure
+            prefs.teamNickname =
                 try {
-                    val matches = api.getEventMatches(event.key)
-                    val hasUnplayed = matches.any { match ->
-                        val red = match.alliances?.red?.teamKeys ?: emptyList()
-                        val blue = match.alliances?.blue?.teamKeys ?: emptyList()
-                        (teamKey in red || teamKey in blue) && (match.alliances?.red?.score ?: -1) < 0
-                    }
-                    if (hasUnplayed) return event
+                    api.getTeam(teamKey).nickname ?: prefs.teamNickname
                 } catch (e: Exception) {
-                    Log.w(TAG, "Failed to check matches for ${event.key}", e)
+                    Log.w(TAG, "Failed to fetch team info for $teamKey", e)
+                    prefs.teamNickname
+                }
+
+            if (data.avatarBase64 != null) prefs.avatarBase64 = data.avatarBase64
+
+            if (data.currentEvent == null) {
+                prefs.hasActiveEvent = false
+                prefs.eventName = ""
+                prefs.record = ""
+                clearLastMatch(prefs)
+                clearNextMatch(prefs)
+
+                val upcoming = findAllUpcomingEvents(data.events)
+                prefs.upcomingEvents =
+                    if (upcoming.isNotEmpty()) {
+                        upcoming.joinToString("|") { event ->
+                            val name = event.shortName ?: event.name
+                            val date =
+                                event.startDate?.let {
+                                    LocalDate.parse(it).format(DateTimeFormatter.ofPattern("MMM d"))
+                                } ?: ""
+                            "$date \u2014 $name"
+                        }
+                    } else {
+                        ""
+                    }
+                return false
+            }
+
+            prefs.hasActiveEvent = true
+            prefs.eventName = data.currentEvent.shortName ?: data.currentEvent.name
+            prefs.upcomingEvents = ""
+
+            // Compute qual record
+            val qualMatches =
+                data.teamMatches.filter {
+                    it.compLevel == "qm" && (it.alliances?.red?.score ?: -1) >= 0
+                }
+            var wins = 0
+            var losses = 0
+            var ties = 0
+            for (match in qualMatches) {
+                val alliance =
+                    if (teamKey in
+                        (match.alliances?.red?.teamKeys ?: emptyList())
+                    ) {
+                        "red"
+                    } else {
+                        "blue"
+                    }
+                when {
+                    match.winningAlliance == alliance -> wins++
+                    match.winningAlliance.isNullOrBlank() -> ties++
+                    else -> losses++
                 }
             }
-            return currentEvents.maxByOrNull { it.eventType ?: 0 }
+            prefs.record = "$wins-$losses-$ties"
+
+            // Last played match
+            val lastMatch = data.teamMatches.lastOrNull { (it.alliances?.red?.score ?: -1) >= 0 }
+            if (lastMatch != null) {
+                prefs.lastMatchLabel = getShortLabel(lastMatch)
+                prefs.lastMatchRedTeams = teamKeysToNumbers(lastMatch.alliances?.red?.teamKeys)
+                prefs.lastMatchBlueTeams = teamKeysToNumbers(lastMatch.alliances?.blue?.teamKeys)
+                prefs.lastMatchRedScore = lastMatch.alliances?.red?.score ?: -1
+                prefs.lastMatchBlueScore = lastMatch.alliances?.blue?.score ?: -1
+                prefs.lastMatchWinningAlliance = lastMatch.winningAlliance ?: ""
+                val lastAlliance =
+                    if (teamKey in
+                        (lastMatch.alliances?.red?.teamKeys ?: emptyList())
+                    ) {
+                        "red"
+                    } else {
+                        "blue"
+                    }
+                prefs.lastAlliance = lastAlliance
+                prefs.lastMatchBonusRp = extractBonusRp(lastMatch, lastAlliance)
+            } else {
+                clearLastMatch(prefs)
+            }
+
+            // Next unplayed match
+            val nextMatch = data.teamMatches.firstOrNull { (it.alliances?.red?.score ?: -1) < 0 }
+            if (nextMatch != null) {
+                prefs.nextMatchLabel = getShortLabel(nextMatch)
+                prefs.nextMatchRedTeams = teamKeysToNumbers(nextMatch.alliances?.red?.teamKeys)
+                prefs.nextMatchBlueTeams = teamKeysToNumbers(nextMatch.alliances?.blue?.teamKeys)
+                prefs.nextMatchTimeIsEstimate = nextMatch.predictedTime != null
+                prefs.nextMatchTime = formatMatchTimeRaw(nextMatch)
+                prefs.nextAlliance =
+                    if (teamKey in
+                        (nextMatch.alliances?.red?.teamKeys ?: emptyList())
+                    ) {
+                        "red"
+                    } else {
+                        "blue"
+                    }
+            } else {
+                clearNextMatch(prefs)
+            }
+
+            return true
         }
 
-        if (currentEvents.isNotEmpty()) return currentEvents.first()
-
-        // Most recently ended (within 3 days)
-        val recentPast = events.filter { event ->
-            val end = event.endDate?.let { LocalDate.parse(it) } ?: return@filter false
-            end.isBefore(today) && end.isAfter(today.minusDays(4))
-        }.maxByOrNull { it.endDate ?: "" }
-
-        return recentPast
-    }
-
-    private fun compLevelOrder(compLevel: String): Int = when (compLevel) {
-        "qm" -> 0
-        "ef" -> 1
-        "qf" -> 2
-        "sf" -> 3
-        "f" -> 4
-        else -> Int.MAX_VALUE
-    }
-
-    /** Simplified short label — "Q18", "SF2-1", "F1-1" */
-    private fun getShortLabel(match: MatchDto): String = when (match.compLevel) {
-        "qm" -> "Q${match.matchNumber}"
-        "ef" -> "EF${match.setNumber}-${match.matchNumber}"
-        "qf" -> "QF${match.setNumber}-${match.matchNumber}"
-        "sf" -> "SF${match.setNumber}-${match.matchNumber}"
-        "f" -> "F${match.setNumber}-${match.matchNumber}"
-        else -> "${match.compLevel}${match.setNumber}-${match.matchNumber}"
-    }
-
-    /** Format match time with estimate prefix for complication display. */
-    private fun formatMatchTime(match: MatchDto): String {
-        val epochSeconds = match.predictedTime ?: match.time ?: return "TBD"
-        val instant = Instant.ofEpochSecond(epochSeconds)
-        val zoned = instant.atZone(ZoneId.systemDefault())
-        val today = LocalDate.now()
-        val matchDate = zoned.toLocalDate()
-        val prefix = if (match.predictedTime != null) "~" else ""
-
-        return if (matchDate == today) {
-            val amPm = if (zoned.hour < 12) "A" else "P"
-            "$prefix${timeFormat.format(zoned)}$amPm"
-        } else {
-            zoned.format(DateTimeFormatter.ofPattern("EEE"))
+        private fun clearLastMatch(prefs: TeamTrackerPreferences) {
+            prefs.lastMatchLabel = ""
+            prefs.lastMatchRedTeams = ""
+            prefs.lastMatchBlueTeams = ""
+            prefs.lastMatchRedScore = -1
+            prefs.lastMatchBlueScore = -1
+            prefs.lastMatchWinningAlliance = ""
+            prefs.lastAlliance = ""
+            prefs.lastMatchBonusRp = 0
         }
-    }
 
-    /** Format match time without estimate prefix — app tracker stores the flag separately. */
-    private fun formatMatchTimeRaw(match: MatchDto): String {
-        val epochSeconds = match.predictedTime ?: match.time ?: return "TBD"
-        val instant = Instant.ofEpochSecond(epochSeconds)
-        val zoned = instant.atZone(ZoneId.systemDefault())
-        val today = LocalDate.now()
-        val matchDate = zoned.toLocalDate()
-
-        return if (matchDate == today) {
-            val amPm = if (zoned.hour < 12) "A" else "P"
-            "${timeFormat.format(zoned)}$amPm"
-        } else {
-            zoned.format(DateTimeFormatter.ofPattern("EEE"))
+        /** Extract bonus RPs (total minus win/tie RPs) from score_breakdown. */
+        private fun extractBonusRp(
+            match: MatchDto,
+            alliance: String,
+        ): Int {
+            val breakdown = match.scoreBreakdown?.get(alliance)?.jsonObject ?: return 0
+            val totalRp = breakdown["rp"]?.jsonPrimitive?.intOrNull ?: return 0
+            val winRp =
+                when {
+                    match.winningAlliance == alliance -> 2
+                    match.winningAlliance.isNullOrBlank() -> 1
+                    else -> 0
+                }
+            return (totalRp - winRp).coerceAtLeast(0)
         }
-    }
 
-    // endregion
-}
+        private fun clearNextMatch(prefs: TeamTrackerPreferences) {
+            prefs.nextMatchLabel = ""
+            prefs.nextMatchRedTeams = ""
+            prefs.nextMatchBlueTeams = ""
+            prefs.nextMatchTime = ""
+            prefs.nextMatchTimeIsEstimate = false
+            prefs.nextAlliance = ""
+        }
+
+        // endregion
+
+        // region Helpers
+
+        private fun teamKeysToNumbers(keys: List<String>?): String =
+            keys?.joinToString(", ") { it.removePrefix("frc") } ?: ""
+
+        private fun findUpcomingEvent(events: List<EventDto>): EventDto? =
+            findAllUpcomingEvents(events).firstOrNull()
+
+        private fun findAllUpcomingEvents(events: List<EventDto>): List<EventDto> {
+            val today = LocalDate.now()
+            return events
+                .filter { event ->
+                    val start = event.startDate?.let { LocalDate.parse(it) } ?: return@filter false
+                    !start.isBefore(today)
+                }.sortedBy { it.startDate ?: "" }
+        }
+
+        /**
+         * Find the current event: running today > recently ended (within 3 days).
+         * Among concurrent events, prefer the one with unplayed matches.
+         */
+        private suspend fun findCurrentEvent(
+            events: List<EventDto>,
+            teamKey: String,
+        ): EventDto? {
+            if (events.isEmpty()) return null
+            val today = LocalDate.now()
+
+            val currentEvents =
+                events.filter { event ->
+                    val start = event.startDate?.let { LocalDate.parse(it) } ?: return@filter false
+                    val end = event.endDate?.let { LocalDate.parse(it) } ?: start
+                    today in start..end
+                }
+
+            if (currentEvents.size > 1) {
+                for (event in currentEvents) {
+                    try {
+                        val matches = api.getEventMatches(event.key)
+                        val hasUnplayed =
+                            matches.any { match ->
+                                val red = match.alliances?.red?.teamKeys ?: emptyList()
+                                val blue = match.alliances?.blue?.teamKeys ?: emptyList()
+                                (teamKey in red || teamKey in blue) &&
+                                    (match.alliances?.red?.score ?: -1) < 0
+                            }
+                        if (hasUnplayed) return event
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to check matches for ${event.key}", e)
+                    }
+                }
+                return currentEvents.maxByOrNull { it.eventType ?: 0 }
+            }
+
+            if (currentEvents.isNotEmpty()) return currentEvents.first()
+
+            // Most recently ended (within 3 days)
+            val recentPast =
+                events
+                    .filter { event ->
+                        val end = event.endDate?.let { LocalDate.parse(it) } ?: return@filter false
+                        end.isBefore(today) && end.isAfter(today.minusDays(4))
+                    }.maxByOrNull { it.endDate ?: "" }
+
+            return recentPast
+        }
+
+        private fun compLevelOrder(compLevel: String): Int =
+            when (compLevel) {
+                "qm" -> 0
+                "ef" -> 1
+                "qf" -> 2
+                "sf" -> 3
+                "f" -> 4
+                else -> Int.MAX_VALUE
+            }
+
+        /** Simplified short label — "Q18", "SF2-1", "F1-1" */
+        private fun getShortLabel(match: MatchDto): String =
+            when (match.compLevel) {
+                "qm" -> "Q${match.matchNumber}"
+                "ef" -> "EF${match.setNumber}-${match.matchNumber}"
+                "qf" -> "QF${match.setNumber}-${match.matchNumber}"
+                "sf" -> "SF${match.setNumber}-${match.matchNumber}"
+                "f" -> "F${match.setNumber}-${match.matchNumber}"
+                else -> "${match.compLevel}${match.setNumber}-${match.matchNumber}"
+            }
+
+        /** Format match time with estimate prefix for complication display. */
+        private fun formatMatchTime(match: MatchDto): String {
+            val epochSeconds = match.predictedTime ?: match.time ?: return "TBD"
+            val instant = Instant.ofEpochSecond(epochSeconds)
+            val zoned = instant.atZone(ZoneId.systemDefault())
+            val today = LocalDate.now()
+            val matchDate = zoned.toLocalDate()
+            val prefix = if (match.predictedTime != null) "~" else ""
+
+            return if (matchDate == today) {
+                val amPm = if (zoned.hour < 12) "A" else "P"
+                "$prefix${timeFormat.format(zoned)}$amPm"
+            } else {
+                zoned.format(DateTimeFormatter.ofPattern("EEE"))
+            }
+        }
+
+        /** Format match time without estimate prefix — app tracker stores the flag separately. */
+        private fun formatMatchTimeRaw(match: MatchDto): String {
+            val epochSeconds = match.predictedTime ?: match.time ?: return "TBD"
+            val instant = Instant.ofEpochSecond(epochSeconds)
+            val zoned = instant.atZone(ZoneId.systemDefault())
+            val today = LocalDate.now()
+            val matchDate = zoned.toLocalDate()
+
+            return if (matchDate == today) {
+                val amPm = if (zoned.hour < 12) "A" else "P"
+                "${timeFormat.format(zoned)}$amPm"
+            } else {
+                zoned.format(DateTimeFormatter.ofPattern("EEE"))
+            }
+        }
+
+        // endregion
+    }


### PR DESCRIPTION
## Summary

Closes #1069.

Adds the `org.jlleitschuh.gradle.ktlint` plugin (v14.2.0) applied to all subprojects, plus a dedicated CI job that runs `ktlintCheck` on every push and PR. Also formats the entire codebase to comply.

The PR is split into 3 commits to make review tractable:

1. **`chore: add ktlint plugin and CI lint job`** — plugin setup, CI workflow, `.editorconfig` (disables `function-naming` for Compose `@Composable` PascalCase), and the manual fixes ktlint couldn't auto-correct: 5 wildcard import expansions, 4 backing-property renames (`_xxx` → `xxx`), build script line wraps, deleted empty `RegionalRanking.kt`, and renamed `NavigationKeys.kt` → `Screen.kt`.
2. **`chore: apply ktlint formatting to entire codebase`** — pure `ktlintFormat` output plus a handful of manual line wraps for things ktlint couldn't auto-correct (long Compose icon/contentColor if-expressions, string concatenations). No behavior changes.
3. **`chore: add ktlint format commit to .git-blame-ignore-revs`** — adds the format commit hash so `git blame` skips it. GitHub respects this file automatically.

### Notes for reviewers

- ktlint-gradle 12.x doesn't detect Android source sets with AGP 9, so I bumped to v14.2.0 which works.
- Used the latest ktlint version bundled with the plugin (no explicit pin).
- The ktlintCheck CI job is a separate workflow file (`.github/workflows/ci-lint.yaml`) so it runs in parallel with the existing app/wear builds and fails fast.

### Developer setup

Install the pre-commit hook locally (one-time):
```
./gradlew addKtlintCheckGitPreCommitHook
```

Auto-fix any issues:
```
./gradlew ktlintFormat
```

Locally enable the blame-ignore file:
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

## Test plan

- [x] `./gradlew ktlintCheck` passes with zero violations
- [x] `./gradlew :app:assembleDebug` builds
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] `./gradlew :wear:assembleDebug` builds
- [ ] CI lint job runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)