### PR TITLE
fix: move ShortcutManagerCompat calls off main thread

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/shortcuts/TBAShortcutManager.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/shortcuts/TBAShortcutManager.kt
@@ -23,9 +23,11 @@ import com.thebluealliance.android.domain.model.Media
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.util.addRoundedCorners
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -55,13 +57,18 @@ class TBAShortcutManager
                 tbaRepository
                     .observeFavorites()
                     .collectLatest { favorites ->
-                        purgeUnfavoritedShortcuts(favorites)
+                        withContext(Dispatchers.IO) {
+                            purgeUnfavoritedShortcuts(favorites)
 
-                        val shortcuts =
-                            favorites
-                                .take(ShortcutManagerCompat.getMaxShortcutCountPerActivity(context))
-                                .mapNotNull { it.getShortcutInfo() }
-                        ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
+                            val shortcuts =
+                                favorites
+                                    .take(
+                                        ShortcutManagerCompat.getMaxShortcutCountPerActivity(
+                                            context,
+                                        ),
+                                    ).mapNotNull { it.getShortcutInfo() }
+                            ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
+                        }
                     }
             }
         }
@@ -124,7 +131,8 @@ class TBAShortcutManager
                     val density = context.resources.displayMetrics.density
                     val roundedBitmap = bitmap.addRoundedCorners(4f * density)
                     return IconCompat.createWithBitmap(roundedBitmap)
-                } catch (_: Exception) {
+                } catch (e: Exception) {
+                    Log.w("TBAShortcutManager", "Failed to decode avatar, using default icon", e)
                 }
             }
 


### PR DESCRIPTION
## Summary
- Wraps `ShortcutManagerCompat` binder calls in `withContext(Dispatchers.IO)` to prevent ANRs
- Fixes 3 Crashlytics ANR issues on v11.6.2: `setDynamicShortcuts`, `getDynamicShortcuts`, and `removeDynamicShortcuts` all perform binder transactions that block the main thread when called from `lifecycleScope.launch` (which defaults to `Dispatchers.Main`)
- Also logs avatar decode failures instead of silently swallowing the exception

## Crashlytics issues addressed
- `2b6e84a` — `TBAShortcutManager$beginSyncingShortcuts` ANR (binder transaction)
- `40272a1` — `TBAShortcutManager.canPinShortcuts` ANR (binder transaction)  
- `a738448` — `TBAShortcutManager.purgeUnfavoritedShortcuts` ANR (binder transaction)

## Test plan
- [x] `./gradlew :app:assembleDebug` builds
- [x] `./gradlew :app:testDebugUnitTest` passes
- [ ] Verify shortcuts still sync correctly after favoriting a team/event

🤖 Generated with [Claude Code](https://claude.com/claude-code)