### PR TITLE
fix: refresh widgets on app start to prevent stale PendingIntent crashes

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/TBAApplication.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/TBAApplication.kt
@@ -4,11 +4,13 @@ import android.app.Application
 import android.os.Build
 import android.util.Log
 import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.updateAll
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import com.thebluealliance.android.config.ApiKeyProvider
 import com.thebluealliance.android.messaging.NotificationChannelManager
 import com.thebluealliance.android.shortcuts.TBAShortcutManager
+import com.thebluealliance.android.widget.TeamTrackingWidget
 import com.thebluealliance.android.widget.TeamTrackingWidgetReceiver
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.MainScope
@@ -40,9 +42,16 @@ class TBAApplication :
         notificationChannelManager.createChannels()
         shortcutManager.beginSyncingShortcuts()
 
-        // Publish generated widget previews for the widget picker (API 35+)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            MainScope().launch {
+        MainScope().launch {
+            // Refresh all widgets so PendingIntents stay fresh after app updates
+            try {
+                TeamTrackingWidget().updateAll(this@TBAApplication)
+            } catch (e: Exception) {
+                Log.w("TBAApplication", "Failed to refresh widgets", e)
+            }
+
+            // Publish generated widget previews for the widget picker (API 35+)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
                 try {
                     GlanceAppWidgetManager(this@TBAApplication)
                         .setWidgetPreviews(TeamTrackingWidgetReceiver::class)


### PR DESCRIPTION
## Summary
- Calls `TeamTrackingWidget().updateAll(context)` on every app start to rebuild widget RemoteViews with fresh PendingIntents
- Fixes Crashlytics crash `babbf34` — "List adapter activity trampoline invoked without specifying target intent" — which still occurs on v11.6.2 despite the OpenAction fix in #1286
- Root cause: after an app update, Android may cache old RemoteViews with stale PendingIntents that reference `ActionTrampolineActivity` without the expected `ACTION_INTENT` extra. The `updateAll()` call ensures widgets are re-rendered with current state on every cold start.

## Crashlytics issue addressed
- `babbf34` — `ActionTrampolineKt.launchTrampolineAction` crash (5 events on v11.6.2, 10 on v11.6.1)

## Test plan
- [x] `./gradlew :app:assembleDebug` builds
- [x] `./gradlew :app:testDebugUnitTest` passes
- [ ] Add widget to home screen, force-stop app, relaunch — widget should still be tappable without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)