### PR TITLE
feat: add Remove option to myTBA favorites and subscriptions

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
@@ -281,14 +282,18 @@ fun MyTBAScreen(
                                 listState = favoritesListState,
                                 canPinShortcuts = uiState.canPinShortcuts,
                                 onAddShortcut = viewModel::requestPinShortcut,
+                                onRemoveFavorite = viewModel::removeFavorite,
                             )
 
                         MyTBATabs.NOTIFICATIONS ->
                             NotificationsTab(
-                                uiState.subscriptions,
-                                onNavigateToTeam,
-                                onNavigateToEvent,
-                                notificationsListState,
+                                subscriptions = uiState.subscriptions,
+                                onNavigateToTeam = onNavigateToTeam,
+                                onNavigateToEvent = onNavigateToEvent,
+                                listState = notificationsListState,
+                                onRemoveSubscription = { sub ->
+                                    viewModel.removeSubscription(sub.modelKey, sub.modelType)
+                                },
                             )
                     }
                 }
@@ -331,6 +336,7 @@ private fun FavoritesTab(
     listState: LazyListState,
     canPinShortcuts: Boolean,
     onAddShortcut: (Favorite) -> Unit,
+    onRemoveFavorite: (Favorite) -> Unit,
 ) {
     if (favorites.isEmpty()) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -348,8 +354,9 @@ private fun FavoritesTab(
                         ModelType.EVENT -> onNavigateToEvent(favorite.modelKey)
                     }
                 },
-                showMenu = canPinShortcuts,
+                canPinShortcuts = canPinShortcuts,
                 onAddShortcut = { onAddShortcut(favorite) },
+                onRemove = { onRemoveFavorite(favorite) },
             )
         }
     }
@@ -359,8 +366,9 @@ private fun FavoritesTab(
 private fun FavoriteItem(
     favorite: Favorite,
     onClick: () -> Unit,
-    showMenu: Boolean,
+    canPinShortcuts: Boolean,
     onAddShortcut: () -> Unit,
+    onRemove: () -> Unit,
 ) {
     val typeLabel =
         when (favorite.modelType) {
@@ -376,12 +384,7 @@ private fun FavoriteItem(
             Modifier
                 .fillMaxWidth()
                 .clickable(onClick = onClick)
-                .padding(
-                    start = 16.dp,
-                    top = if (showMenu) 8.dp else 12.dp,
-                    bottom = if (showMenu) 8.dp else 12.dp,
-                    end = if (showMenu) 4.dp else 16.dp,
-                ),
+                .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(
@@ -398,18 +401,18 @@ private fun FavoriteItem(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        if (showMenu) {
-            Box {
-                IconButton(onClick = { menuExpanded = true }) {
-                    Icon(
-                        imageVector = Icons.Default.MoreVert,
-                        contentDescription = "More options",
-                    )
-                }
-                DropdownMenu(
-                    expanded = menuExpanded,
-                    onDismissRequest = { menuExpanded = false },
-                ) {
+        Box {
+            IconButton(onClick = { menuExpanded = true }) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = "More options",
+                )
+            }
+            DropdownMenu(
+                expanded = menuExpanded,
+                onDismissRequest = { menuExpanded = false },
+            ) {
+                if (canPinShortcuts) {
                     DropdownMenuItem(
                         text = { Text("Add shortcut to home screen") },
                         leadingIcon = {
@@ -424,6 +427,19 @@ private fun FavoriteItem(
                         },
                     )
                 }
+                DropdownMenuItem(
+                    text = { Text("Remove") },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = null,
+                        )
+                    },
+                    onClick = {
+                        menuExpanded = false
+                        onRemove()
+                    },
+                )
             }
         }
     }
@@ -435,6 +451,7 @@ private fun NotificationsTab(
     onNavigateToTeam: (String) -> Unit,
     onNavigateToEvent: (String) -> Unit,
     listState: LazyListState,
+    onRemoveSubscription: (Subscription) -> Unit,
 ) {
     if (subscriptions.isEmpty()) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -444,33 +461,80 @@ private fun NotificationsTab(
     }
     LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
         items(subscriptions, key = { "${it.modelType}_${it.modelKey}" }) { subscription ->
-            val typeLabel =
-                when (subscription.modelType) {
-                    ModelType.EVENT -> "Event"
-                    ModelType.TEAM -> "Team"
-                    ModelType.MATCH -> "Match"
-                    else -> "Other"
-                }
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .clickable {
-                            when (subscription.modelType) {
-                                ModelType.TEAM -> onNavigateToTeam(subscription.modelKey)
-                                ModelType.EVENT -> onNavigateToEvent(subscription.modelKey)
-                            }
-                        }.padding(horizontal = 16.dp, vertical = 12.dp),
-            ) {
-                Text(
-                    text = subscription.modelKey,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
+            SubscriptionItem(
+                subscription = subscription,
+                onClick = {
+                    when (subscription.modelType) {
+                        ModelType.TEAM -> onNavigateToTeam(subscription.modelKey)
+                        ModelType.EVENT -> onNavigateToEvent(subscription.modelKey)
+                    }
+                },
+                onRemove = { onRemoveSubscription(subscription) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SubscriptionItem(
+    subscription: Subscription,
+    onClick: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    val typeLabel =
+        when (subscription.modelType) {
+            ModelType.EVENT -> "Event"
+            ModelType.TEAM -> "Team"
+            ModelType.MATCH -> "Match"
+            else -> "Other"
+        }
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                text = subscription.modelKey,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = "$typeLabel · ${subscription.notifications.joinToString(", ")}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Box {
+            IconButton(onClick = { menuExpanded = true }) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = "More options",
                 )
-                Text(
-                    text = "$typeLabel · ${subscription.notifications.joinToString(", ")}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+            }
+            DropdownMenu(
+                expanded = menuExpanded,
+                onDismissRequest = { menuExpanded = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text("Remove") },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = null,
+                        )
+                    },
+                    onClick = {
+                        menuExpanded = false
+                        onRemove()
+                    },
                 )
             }
         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
@@ -77,6 +77,34 @@ class MyTBAViewModel
             }
         }
 
+        fun removeFavorite(favorite: Favorite) {
+            viewModelScope.launch {
+                try {
+                    myTBARepository.removeFavorite(favorite.modelKey, favorite.modelType)
+                } catch (e: Exception) {
+                    android.util.Log.w("MyTBAViewModel", "Failed to remove favorite", e)
+                }
+            }
+        }
+
+        fun removeSubscription(modelKey: String, modelType: Int) {
+            viewModelScope.launch {
+                try {
+                    val isFavorited = uiState.value.favorites.any {
+                        it.modelKey == modelKey && it.modelType == modelType
+                    }
+                    myTBARepository.updatePreferences(
+                        modelKey = modelKey,
+                        modelType = modelType,
+                        favorite = isFavorited,
+                        notifications = emptyList(),
+                    )
+                } catch (e: Exception) {
+                    android.util.Log.w("MyTBAViewModel", "Failed to remove subscription", e)
+                }
+            }
+        }
+
         fun refresh() {
             viewModelScope.launch {
                 if (!authRepository.isSignedIn()) return@launch

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
@@ -87,12 +87,16 @@ class MyTBAViewModel
             }
         }
 
-        fun removeSubscription(modelKey: String, modelType: Int) {
+        fun removeSubscription(
+            modelKey: String,
+            modelType: Int,
+        ) {
             viewModelScope.launch {
                 try {
-                    val isFavorited = uiState.value.favorites.any {
-                        it.modelKey == modelKey && it.modelType == modelType
-                    }
+                    val isFavorited =
+                        uiState.value.favorites.any {
+                            it.modelKey == modelKey && it.modelType == modelType
+                        }
                     myTBARepository.updatePreferences(
                         modelKey = modelKey,
                         modelType = modelType,


### PR DESCRIPTION
## Summary
- Adds a "Remove" menu item with trash icon to the overflow menu on every favorite and subscription row in the myTBA screen
- Users can now delete stale favorites/subscriptions for **any model type** (including Match or other unsupported types) directly from the list
- The overflow menu on favorites is now always visible (previously only appeared when the device supported shortcut pinning)
- Subscriptions tab now has an overflow menu with Remove (previously had no menu at all)

## Test plan
- [x] `./gradlew :app:assembleDebug` builds
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] Verified favorites overflow menu shows both "Add shortcut" and "Remove"
- [x] Verify removing a favorite removes it from the list
- [x] Verify removing a subscription removes it without affecting favorite status

🤖 Generated with [Claude Code](https://claude.com/claude-code)