### PR TITLE
Add missing contentDescription to action icons

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -221,7 +221,7 @@ fun EventDetailScreen(
                                         leadingIcon = {
                                             Icon(
                                                 Icons.Filled.Share,
-                                                contentDescription = null,
+                                                contentDescription = "Share",
                                             )
                                         },
                                         onClick = {
@@ -244,7 +244,7 @@ fun EventDetailScreen(
                                                     painterResource(
                                                         R.drawable.ic_add_to_home_screen,
                                                     ),
-                                                contentDescription = null,
+                                                contentDescription = "Add to home screen",
                                             )
                                         },
                                         onClick = {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -125,7 +125,7 @@ fun EventInfoTab(
                 ) {
                     Icon(
                         Icons.Outlined.LocationOn,
-                        contentDescription = null,
+                        contentDescription = "Location",
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(18.dp),
                     )
@@ -153,7 +153,7 @@ fun EventInfoTab(
                 ) {
                     Icon(
                         Icons.Outlined.Language,
-                        contentDescription = null,
+                        contentDescription = "Website",
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(18.dp),
                     )
@@ -197,7 +197,7 @@ fun EventInfoTab(
                     ) {
                         Icon(
                             Icons.Outlined.PlayCircle,
-                            contentDescription = null,
+                            contentDescription = "Webcast",
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(18.dp),
                         )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -415,7 +415,7 @@ private fun FavoriteItem(
                         leadingIcon = {
                             Icon(
                                 painter = painterResource(R.drawable.ic_add_to_home_screen),
-                                contentDescription = null,
+                                contentDescription = "Add to home screen",
                             )
                         },
                         onClick = {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -239,7 +239,7 @@ fun TeamDetailScreen(
                                         leadingIcon = {
                                             Icon(
                                                 Icons.Filled.Share,
-                                                contentDescription = null,
+                                                contentDescription = "Share",
                                             )
                                         },
                                         onClick = {
@@ -264,7 +264,7 @@ fun TeamDetailScreen(
                                                     painterResource(
                                                         R.drawable.ic_add_to_home_screen,
                                                     ),
-                                                contentDescription = null,
+                                                contentDescription = "Add to home screen",
                                             )
                                         },
                                         onClick = {


### PR DESCRIPTION
## Summary
- Add `contentDescription` to interactive icons in **EventInfoTab** (location, website, webcast icons) so screen readers announce their purpose
- Add `contentDescription` to dropdown menu leading icons in **TeamDetailScreen** and **EventDetailScreen** (Share, Add to home screen)
- Add `contentDescription` to the "Add shortcut to home screen" menu icon in **MyTBAScreen**

## Notes
- Remaining `contentDescription = null` instances were audited and confirmed decorative (chevron arrows, TBA logo, menu icons with adjacent text labels in MoreScreen/EventRow/TeamRow/TBATopAppBar)

## Test plan
- [ ] Enable TalkBack and navigate to an event detail info tab -- verify location, website, and webcast icons are announced
- [ ] Open the overflow menu on team/event detail screens -- verify Share and Add to home screen icons are announced
- [ ] Run accessibility scanner on key screens to confirm no actionable icons lack descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)