### PR TITLE
[RFC] Increase FastScrollbar touch target to 48dp

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/FastScrollbar.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/FastScrollbar.kt
@@ -36,7 +36,7 @@ import kotlin.math.roundToInt
 
 private val ThumbWidth = 4.dp
 private val ThumbHeight = 48.dp
-private val TouchTargetWidth = 24.dp
+private val TouchTargetWidth = 48.dp
 
 @Composable
 fun FastScrollbar(


### PR DESCRIPTION
## Summary

- Increases `TouchTargetWidth` from 24dp to 48dp in `FastScrollbar.kt` to meet WCAG 2.5.8 minimum touch target size (48x48dp)
- The visible scrollbar thumb remains 4dp wide with 4dp end padding — only the invisible drag-target strip grows wider
- No visual change: the thumb and its animations are rendered by a separate `Box` that is unaffected by the touch target width

## Approach

The `FastScrollbar` composable uses two overlapping `Box` elements aligned to `TopEnd`:

1. **Touch target** — a full-height invisible strip that captures drag gestures
2. **Visible thumb** — a narrow 4dp rounded indicator with fade-in/out animation

Since these are independent layout elements, widening the touch target from 24dp to 48dp has no effect on the visual thumb. The touch strip simply extends further left from the right edge, giving users a larger area to initiate a scroll drag.

## Test plan

- [x] Verify scrollbar thumb still appears as a thin indicator on the right edge
- [x] Verify drag-to-scroll works across the full 48dp touch area
- [x] Verify no layout shift or visual difference in lists that use FastScrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)