### PR TITLE
Consolidate duplicate indigo color to TBAIndigo400 token

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
@@ -43,6 +43,7 @@ import com.thebluealliance.android.domain.model.EventInsights
 import com.thebluealliance.android.domain.model.EventOPRs
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
+import com.thebluealliance.android.ui.theme.TBAIndigo400
 import com.thebluealliance.android.util.openUrl
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -360,7 +361,7 @@ private fun InsightsView(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .background(Color(0xFF5C6BC0))
+                        .background(TBAIndigo400)
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -561,7 +562,7 @@ private fun StandardOPRsView(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .background(Color(0xFF5C6BC0))
+                        .background(TBAIndigo400)
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -722,7 +723,7 @@ private fun COPRView(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .background(Color(0xFF5C6BC0))
+                        .background(TBAIndigo400)
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -39,6 +39,7 @@ import com.thebluealliance.android.domain.model.Ranking
 import com.thebluealliance.android.domain.model.RankingSortOrder
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
+import com.thebluealliance.android.ui.theme.TBAIndigo400
 import java.util.Locale
 
 enum class RankingSortColumn {
@@ -167,7 +168,7 @@ private fun RankingHeaderRow(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .background(Color(0xFF5C6BC0))
+                .background(TBAIndigo400)
                 .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -67,6 +67,7 @@ import com.thebluealliance.android.domain.model.Favorite
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.domain.model.Subscription
 import com.thebluealliance.android.ui.components.TBATopAppBar
+import com.thebluealliance.android.ui.theme.TBAIndigo400
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
@@ -229,7 +230,7 @@ fun MyTBAScreen(
             PrimaryScrollableTabRow(
                 selectedTabIndex = pagerState.currentPage,
                 edgePadding = 0.dp,
-                containerColor = Color(0xFF5C6BC0),
+                containerColor = TBAIndigo400,
                 contentColor = Color.White,
                 divider = {
                     HorizontalDivider(color = Color.White.copy(alpha = 0.12f))

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -60,6 +60,7 @@ import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.TeamRow
 import com.thebluealliance.android.ui.events.detail.EventDetailTab
 import com.thebluealliance.android.ui.events.detail.tabs.advancementBreakdownRows
+import com.thebluealliance.android.ui.theme.TBAIndigo400
 import com.thebluealliance.android.util.openUrl
 import kotlinx.coroutines.launch
 
@@ -344,7 +345,7 @@ private fun SummaryTab(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .background(Color(0xFF5C6BC0))
+                            .background(TBAIndigo400)
                             .padding(horizontal = 16.dp, vertical = 8.dp),
                 ) {
                     Text(
@@ -438,7 +439,7 @@ private fun SummaryTab(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .background(Color(0xFF5C6BC0))
+                            .background(TBAIndigo400)
                             .padding(horizontal = 16.dp, vertical = 8.dp),
                 ) {
                     Text(
@@ -475,7 +476,7 @@ private fun SummaryTab(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .background(Color(0xFF5C6BC0))
+                                .background(TBAIndigo400)
                                 .padding(horizontal = 16.dp, vertical = 8.dp),
                     ) {
                         Text(


### PR DESCRIPTION
## Summary
- Replace 8 inline `Color(0xFF5C6BC0)` usages across 4 files with the existing `TBAIndigo400` theme token
- Affected files: `TeamEventDetailScreen.kt` (3), `EventRankingsTab.kt` (1), `EventInsightsTab.kt` (3), `MyTBAScreen.kt` (1)
- No behavioral change; purely a cleanup to consolidate duplicated color values

## Test plan
- [ ] Verify section headers in Team@Event detail screen render with correct indigo background
- [ ] Verify rankings tab header renders correctly
- [ ] Verify insights tab section headers render correctly
- [ ] Verify myTBA tab bar renders with correct indigo background

🤖 Generated with [Claude Code](https://claude.com/claude-code)