### PR TITLE
Replace hardcoded Color.White with M3 color tokens

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/SectionHeader.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/SectionHeader.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.ui.theme.TBAIndigo400
@@ -61,14 +60,14 @@ fun SectionHeader(
                 text = label,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                color = Color.White,
+                color = MaterialTheme.colorScheme.onPrimary,
             )
             if (isStuck) {
                 Spacer(modifier = Modifier.width(4.dp))
                 Icon(
                     imageVector = Icons.Default.ArrowDropDown,
                     contentDescription = "Jump to section",
-                    tint = Color.White,
+                    tint = MaterialTheme.colorScheme.onPrimary,
                     modifier = Modifier.size(20.dp),
                 )
             }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBATabRow.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBATabRow.kt
@@ -1,12 +1,12 @@
 package com.thebluealliance.android.ui.components
 
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.TabRowDefaults.SecondaryIndicator
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.ui.theme.TBABlue
 
@@ -20,16 +20,16 @@ fun TBATabRow(
         selectedTabIndex = selectedTabIndex,
         modifier = modifier,
         containerColor = TBABlue,
-        contentColor = Color.White,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
         edgePadding = 0.dp,
         divider = {
-            HorizontalDivider(color = Color.White)
+            HorizontalDivider(color = MaterialTheme.colorScheme.onPrimary)
         },
         indicator = {
             SecondaryIndicator(
                 modifier = Modifier.tabIndicatorOffset(selectedTabIndex),
                 height = 3.dp,
-                color = Color.White,
+                color = MaterialTheme.colorScheme.onPrimary,
             )
         },
         tabs = tabs,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBATopAppBar.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/TBATopAppBar.kt
@@ -5,13 +5,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.R
@@ -28,9 +28,9 @@ fun TBATopAppBar(
     colors: TopAppBarColors =
         TopAppBarDefaults.topAppBarColors(
             containerColor = TBABlue,
-            titleContentColor = Color.White,
-            navigationIconContentColor = Color.White,
-            actionIconContentColor = Color.White,
+            titleContentColor = MaterialTheme.colorScheme.onPrimary,
+            navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+            actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
         ),
     scrollBehavior: TopAppBarScrollBehavior? = null,
     showLamp: Boolean = false,
@@ -48,7 +48,7 @@ fun TBATopAppBar(
                             painter = painterResource(id = R.drawable.tba_lamp),
                             contentDescription = null,
                             modifier = Modifier.size(24.dp),
-                            tint = Color.White,
+                            tint = MaterialTheme.colorScheme.onPrimary,
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -128,9 +127,9 @@ fun DistrictDetailScreen(
                                         if (pagerState.currentPage ==
                                             index
                                         ) {
-                                            Color.White
+                                            MaterialTheme.colorScheme.onPrimary
                                         } else {
-                                            Color.White.copy(alpha = 0.7f)
+                                            MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f)
                                         },
                                 )
                             },
@@ -313,7 +312,7 @@ private fun RankingsTab(
                     text = "Rank",
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.10f),
                 )
@@ -321,7 +320,7 @@ private fun RankingsTab(
                     text = "Team",
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
                 )
@@ -329,7 +328,7 @@ private fun RankingsTab(
                     text = "Event\n1",
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
                 )
@@ -337,7 +336,7 @@ private fun RankingsTab(
                     text = "Event\n2",
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
                 )
@@ -345,7 +344,7 @@ private fun RankingsTab(
                     text = "DCMP",
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
                 )
@@ -353,7 +352,7 @@ private fun RankingsTab(
                     text = "Rookie\nBonus",
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
                 )
@@ -361,7 +360,7 @@ private fun RankingsTab(
                     text = "Total\nPoints",
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
                 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -391,15 +391,15 @@ private fun WeekFilterChips(
     val weekChipColors =
         FilterChipDefaults.filterChipColors(
             containerColor = Color.Transparent,
-            labelColor = Color.White.copy(alpha = 0.7f),
-            selectedContainerColor = Color.White,
+            labelColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f),
+            selectedContainerColor = MaterialTheme.colorScheme.onPrimary,
             selectedLabelColor = TBABlue,
         )
     val weekChipBorder =
         FilterChipDefaults.filterChipBorder(
             enabled = true,
             selected = false,
-            borderColor = Color.White.copy(alpha = 0.5f),
+            borderColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.5f),
             selectedBorderColor = Color.Transparent,
         )
 
@@ -439,7 +439,7 @@ private fun WeekFilterChips(
                         .padding(start = 8.dp, bottom = 4.dp)
                         .height(24.dp)
                         .width(1.dp)
-                        .background(Color.White.copy(alpha = 0.3f)),
+                        .background(MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f)),
             )
         }
         val fadeWidth = 24.dp
@@ -509,7 +509,7 @@ private fun SimpleSectionHeader(label: String) {
             text = label,
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onPrimary,
         )
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -262,15 +261,17 @@ fun EventDetailScreen(
                     selectedTabIndex = pagerState.currentPage,
                     edgePadding = 0.dp,
                     containerColor = TBABlue,
-                    contentColor = Color.White,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
                     divider = {
-                        HorizontalDivider(color = Color.White.copy(alpha = 0.12f))
+                        HorizontalDivider(
+                            color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.12f),
+                        )
                     },
                     indicator = {
                         SecondaryIndicator(
                             modifier = Modifier.tabIndicatorOffset(pagerState.currentPage),
                             height = 3.dp,
-                            color = Color.White,
+                            color = MaterialTheme.colorScheme.onPrimary,
                         )
                     },
                 ) {
@@ -291,7 +292,7 @@ fun EventDetailScreen(
                                 ) {
                                     Text(
                                         text = tab.readableName(uiState.event),
-                                        color = Color.White,
+                                        color = MaterialTheme.colorScheme.onPrimary,
                                     )
 
                                     // Show number of teams as a badge

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
@@ -368,14 +368,14 @@ private fun InsightsView(
                     text = insightHeader,
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     modifier = Modifier.weight(1.5f),
                 )
                 Text(
                     text = "Value",
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     modifier = Modifier.weight(1f),
                 )
                 IconButton(
@@ -385,7 +385,7 @@ private fun InsightsView(
                     Icon(
                         imageVector = Icons.Default.MoreVert,
                         contentDescription = "Select stat type",
-                        tint = Color.White,
+                        tint = MaterialTheme.colorScheme.onPrimary,
                     )
                 }
             }
@@ -628,7 +628,7 @@ private fun StandardOPRsView(
                     Icon(
                         imageVector = Icons.Default.MoreVert,
                         contentDescription = "Select stat type",
-                        tint = Color.White,
+                        tint = MaterialTheme.colorScheme.onPrimary,
                     )
                 }
             }
@@ -761,7 +761,7 @@ private fun COPRView(
                     Icon(
                         imageVector = Icons.Default.MoreVert,
                         contentDescription = "Select stat type",
-                        tint = Color.White,
+                        tint = MaterialTheme.colorScheme.onPrimary,
                     )
                 }
             }
@@ -822,7 +822,7 @@ private fun OprHeaderItem(
             text = text,
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onPrimary,
         )
         if (currentSort == sortColumn) {
             Icon(
@@ -830,7 +830,7 @@ private fun OprHeaderItem(
                     if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
                 contentDescription =
                     if (ascending) "Sorted Ascending" else "Sorted Descending",
-                tint = Color.White,
+                tint = MaterialTheme.colorScheme.onPrimary,
             )
         }
     }
@@ -853,7 +853,7 @@ private fun CoprHeaderItem(
             text = text,
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onPrimary,
         )
         if (currentSort == sortColumn) {
             Icon(
@@ -861,7 +861,7 @@ private fun CoprHeaderItem(
                     if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
                 contentDescription =
                     if (ascending) "Sorted Ascending" else "Sorted Descending",
-                tint = Color.White,
+                tint = MaterialTheme.colorScheme.onPrimary,
             )
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -175,7 +175,7 @@ private fun RankingHeaderRow(
             text = "Rank",
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onPrimary,
             modifier = Modifier.weight(0.12f),
         )
         RankingHeaderItem(
@@ -190,7 +190,7 @@ private fun RankingHeaderRow(
             text = "Record",
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onPrimary,
             modifier = Modifier.weight(0.22f),
         )
         RankingHeaderItem(
@@ -231,7 +231,7 @@ private fun RankingHeaderItem(
             text = text,
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onPrimary,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
@@ -241,7 +241,7 @@ private fun RankingHeaderItem(
                     if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
                 contentDescription =
                     if (ascending) "Sorted Ascending" else "Sorted Descending",
-                tint = Color.White,
+                tint = MaterialTheme.colorScheme.onPrimary,
             )
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -230,15 +230,17 @@ fun MyTBAScreen(
                 selectedTabIndex = pagerState.currentPage,
                 edgePadding = 0.dp,
                 containerColor = Color(0xFF5C6BC0),
-                contentColor = Color.White,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
                 divider = {
-                    HorizontalDivider(color = Color.White.copy(alpha = 0.12f))
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.12f),
+                    )
                 },
                 indicator = {
                     TabRowDefaults.SecondaryIndicator(
                         modifier = Modifier.tabIndicatorOffset(pagerState.currentPage),
                         height = 3.dp,
-                        color = Color.White,
+                        color = MaterialTheme.colorScheme.onPrimary,
                     )
                 },
             ) {
@@ -255,7 +257,7 @@ fun MyTBAScreen(
                         text = {
                             Text(
                                 text = title,
-                                color = Color.White,
+                                color = MaterialTheme.colorScheme.onPrimary,
                                 fontWeight = FontWeight.Bold,
                             )
                         },

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -170,9 +170,9 @@ fun TeamEventDetailScreen(
                                         if (pagerState.currentPage ==
                                             index
                                         ) {
-                                            Color.White
+                                            MaterialTheme.colorScheme.onPrimary
                                         } else {
-                                            Color.White.copy(alpha = 0.7f)
+                                            MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f)
                                         },
                                 )
                             },
@@ -351,7 +351,7 @@ private fun SummaryTab(
                         text = "Info",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
-                        color = Color.White,
+                        color = MaterialTheme.colorScheme.onPrimary,
                     )
                 }
             }
@@ -445,7 +445,7 @@ private fun SummaryTab(
                         text = "Championship Qualification",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
-                        color = Color.White,
+                        color = MaterialTheme.colorScheme.onPrimary,
                     )
                 }
             }
@@ -482,7 +482,7 @@ private fun SummaryTab(
                             text = "Recent Matches",
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
-                            color = Color.White,
+                            color = MaterialTheme.colorScheme.onPrimary,
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -296,9 +296,9 @@ fun TeamDetailScreen(
                                         if (pagerState.currentPage ==
                                             index
                                         ) {
-                                            Color.White
+                                            MaterialTheme.colorScheme.onPrimary
                                         } else {
-                                            Color.White.copy(alpha = 0.7f)
+                                            MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f)
                                         },
                                 )
                             },

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetConfigActivity.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetConfigActivity.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -99,13 +98,13 @@ class TeamTrackingWidgetConfigActivity : ComponentActivity() {
                                 Icon(
                                     painter = painterResource(R.drawable.tba_lamp),
                                     contentDescription = null,
-                                    tint = Color.White,
+                                    tint = MaterialTheme.colorScheme.onPrimary,
                                     modifier = Modifier.size(20.dp),
                                 )
                                 Text(
                                     text = "Team Tracker",
                                     style = MaterialTheme.typography.titleMedium,
-                                    color = Color.White,
+                                    color = MaterialTheme.colorScheme.onPrimary,
                                     modifier = Modifier.weight(1f).padding(start = 8.dp),
                                 )
                                 IconButton(
@@ -115,7 +114,7 @@ class TeamTrackingWidgetConfigActivity : ComponentActivity() {
                                     Icon(
                                         imageVector = Icons.Default.Close,
                                         contentDescription = "Close",
-                                        tint = Color.White,
+                                        tint = MaterialTheme.colorScheme.onPrimary,
                                     )
                                 }
                             }


### PR DESCRIPTION
## Summary
- Replaced all hardcoded `Color.White` usages in 12 Compose UI files with `MaterialTheme.colorScheme.onPrimary` for proper Material 3 theming and future dark mode support
- Removed unused `Color` imports from files where `Color.White` was the only usage (TBATopAppBar, TBATabRow, SectionHeader, DistrictDetailScreen)
- Intentionally preserved `Color.White` in `MediaGrid.kt` (YouTube play icon on dark overlay — always white regardless of theme) and `Theme.kt` (the theme definition itself)

### Files changed
- `TBATopAppBar.kt` — title, nav icon, action icon content colors + lamp tint
- `TBATabRow.kt` — content color, divider, indicator
- `SectionHeader.kt` — label text + dropdown arrow tint
- `EventDetailScreen.kt` — inline tab row content color, divider, indicator, tab text
- `EventsScreen.kt` — filter chip colors, borders, divider, section header text
- `EventRankingsTab.kt` — ranking header text + sort arrow tint
- `EventInsightsTab.kt` — all header text + icon tints (OPR, COPR, Insights views)
- `MyTBAScreen.kt` — tab row content color, divider, indicator, tab text
- `TeamEventDetailScreen.kt` — tab text (selected/unselected) + section header text
- `DistrictDetailScreen.kt` — tab text (selected/unselected) + ranking header columns
- `TeamDetailScreen.kt` — tab text (selected/unselected)
- `TeamTrackingWidgetConfigActivity.kt` — header lamp tint, title, close icon

## Test plan
- [ ] Verify the app compiles successfully (`./gradlew :app:assembleDebug`)
- [ ] Visually verify top app bars, tab rows, section headers, and ranking headers still appear white-on-blue in light mode
- [ ] Verify filter chips on the Events screen look correct
- [ ] Spot-check EventInsightsTab and EventRankingsTab header rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)