### PR TITLE
Adopt M3 Expressive motion tokens

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -41,6 +41,7 @@ import com.thebluealliance.android.ui.teamevent.TeamEventDetailViewModel
 import com.thebluealliance.android.ui.teams.TeamDetailScreen
 import com.thebluealliance.android.ui.teams.TeamDetailViewModel
 import com.thebluealliance.android.ui.teams.TeamsScreen
+import com.thebluealliance.android.ui.theme.TBAMotionTokens
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
@@ -85,16 +86,34 @@ fun TBANavigation(
                     .fillMaxSize()
                     .background(MaterialTheme.colorScheme.background),
             transitionSpec = {
-                slideInHorizontally(initialOffsetX = { it }) togetherWith
-                    slideOutHorizontally(targetOffsetX = { -it })
+                slideInHorizontally(
+                    animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                    initialOffsetX = { it },
+                ) togetherWith
+                    slideOutHorizontally(
+                        animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                        targetOffsetX = { -it },
+                    )
             },
             popTransitionSpec = {
-                slideInHorizontally(initialOffsetX = { -it }) togetherWith
-                    slideOutHorizontally(targetOffsetX = { it })
+                slideInHorizontally(
+                    animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                    initialOffsetX = { -it },
+                ) togetherWith
+                    slideOutHorizontally(
+                        animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                        targetOffsetX = { it },
+                    )
             },
             predictivePopTransitionSpec = {
-                slideInHorizontally(initialOffsetX = { -it }) togetherWith
-                    slideOutHorizontally(targetOffsetX = { it })
+                slideInHorizontally(
+                    animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                    initialOffsetX = { -it },
+                ) togetherWith
+                    slideOutHorizontally(
+                        animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                        targetOffsetX = { it },
+                    )
             },
             onBack = { navigator.goBack() },
             entries =
@@ -337,8 +356,16 @@ fun TBANavigation(
 
         AnimatedVisibility(
             visible = showBottomBar,
-            enter = slideInVertically(initialOffsetY = { it }),
-            exit = slideOutVertically(targetOffsetY = { it }),
+            enter =
+                slideInVertically(
+                    animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                    initialOffsetY = { it },
+                ),
+            exit =
+                slideOutVertically(
+                    animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                    targetOffsetY = { it },
+                ),
         ) {
             TBABottomBar(
                 currentRoute = navState.currentRoute,

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/Transitions.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/Transitions.kt
@@ -1,15 +1,14 @@
 package com.thebluealliance.android.navigation
 
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.LinearOutSlowInEasing
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.togetherWith
 import androidx.navigation3.ui.NavDisplay
+import com.thebluealliance.android.ui.theme.TBAMotionTokens
 
 object Transitions {
     private val tabTransition =
-        fadeIn(tween(200, easing = LinearOutSlowInEasing)) togetherWith
+        fadeIn(TBAMotionTokens.fastEffectsSpec()) togetherWith
             ExitTransition.None
 
     /**

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/FastScrollbar.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/FastScrollbar.kt
@@ -1,7 +1,6 @@
 package com.thebluealliance.android.ui.components
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
@@ -31,6 +30,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import com.thebluealliance.android.ui.theme.TBAMotionTokens
 import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 
@@ -61,10 +61,10 @@ fun FastScrollbar(
     val alpha = remember { Animatable(0f) }
     LaunchedEffect(isScrolling, isDragging) {
         if (isScrolling || isDragging) {
-            alpha.animateTo(1f, tween(150))
+            alpha.animateTo(1f, TBAMotionTokens.fastEffectsSpec())
         } else {
             delay(1500)
-            alpha.animateTo(0f, tween(300))
+            alpha.animateTo(0f, TBAMotionTokens.defaultEffectsSpec())
         }
     }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
@@ -2,6 +2,10 @@ package com.thebluealliance.android.ui.events.detail.tabs
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -39,6 +43,7 @@ import com.thebluealliance.android.domain.model.EventAdvancementPoints
 import com.thebluealliance.android.domain.model.Team
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
+import com.thebluealliance.android.ui.theme.TBAMotionTokens
 
 internal fun advancementBreakdownRows(
     points: EventAdvancementPoints,
@@ -114,6 +119,7 @@ private fun AdvancementPointsItem(
     var expanded by remember { mutableStateOf(false) }
     val rotationAngle by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
+        animationSpec = TBAMotionTokens.fastSpatialSpec(),
         label = "advancement_chevron_rotation",
     )
 
@@ -168,7 +174,17 @@ private fun AdvancementPointsItem(
             )
         }
 
-        AnimatedVisibility(visible = expanded) {
+        AnimatedVisibility(
+            visible = expanded,
+            enter =
+                expandVertically(
+                    animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                ) + fadeIn(TBAMotionTokens.defaultEffectsSpec()),
+            exit =
+                shrinkVertically(
+                    animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                ) + fadeOut(TBAMotionTokens.fastEffectsSpec()),
+        ) {
             Column(
                 modifier =
                     Modifier

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -2,6 +2,10 @@ package com.thebluealliance.android.ui.events.detail.tabs
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -39,6 +43,7 @@ import com.thebluealliance.android.domain.model.Ranking
 import com.thebluealliance.android.domain.model.RankingSortOrder
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
+import com.thebluealliance.android.ui.theme.TBAMotionTokens
 import java.util.Locale
 
 enum class RankingSortColumn {
@@ -257,6 +262,7 @@ private fun RankingItem(
     var expanded by remember { mutableStateOf(false) }
     val rotationAngle by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
+        animationSpec = TBAMotionTokens.fastSpatialSpec(),
         label = "chevron_rotation",
     )
 
@@ -331,7 +337,17 @@ private fun RankingItem(
             )
         }
 
-        AnimatedVisibility(visible = expanded) {
+        AnimatedVisibility(
+            visible = expanded,
+            enter =
+                expandVertically(
+                    animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                ) + fadeIn(TBAMotionTokens.defaultEffectsSpec()),
+            exit =
+                shrinkVertically(
+                    animationSpec = TBAMotionTokens.defaultSpatialSpec(),
+                ) + fadeOut(TBAMotionTokens.fastEffectsSpec()),
+        ) {
             Column(
                 modifier =
                     Modifier

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/theme/TBAMotionTokens.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/theme/TBAMotionTokens.kt
@@ -1,0 +1,39 @@
+package com.thebluealliance.android.ui.theme
+
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.spring
+
+/**
+ * M3 Expressive motion tokens, mirroring `ExpressiveMotionTokens` from
+ * `androidx.compose.material3.tokens` (which is internal in material3 1.4.0).
+ *
+ * Values are copied verbatim from the library source (v0_14_0).
+ * Effects specs are identical between Standard and Expressive schemes.
+ * TODO: Replace with `MaterialTheme.motionScheme` once it becomes public API.
+ */
+object TBAMotionTokens {
+    // M3 emphasized easing curves (from MotionTokens v0_103)
+    val EmphasizedDecelerateEasing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1.0f)
+    val EmphasizedAccelerateEasing = CubicBezierEasing(0.3f, 0.0f, 0.8f, 0.15f)
+
+    // --- Expressive motion scheme spring specs (from ExpressiveMotionTokens v0_14_0) ---
+
+    fun <T> defaultSpatialSpec(): FiniteAnimationSpec<T> =
+        spring(dampingRatio = 0.8f, stiffness = 380.0f)
+
+    fun <T> fastSpatialSpec(): FiniteAnimationSpec<T> =
+        spring(dampingRatio = 0.6f, stiffness = 800.0f)
+
+    fun <T> slowSpatialSpec(): FiniteAnimationSpec<T> =
+        spring(dampingRatio = 0.8f, stiffness = 200.0f)
+
+    fun <T> defaultEffectsSpec(): FiniteAnimationSpec<T> =
+        spring(dampingRatio = 1.0f, stiffness = 1600.0f)
+
+    fun <T> fastEffectsSpec(): FiniteAnimationSpec<T> =
+        spring(dampingRatio = 1.0f, stiffness = 3800.0f)
+
+    fun <T> slowEffectsSpec(): FiniteAnimationSpec<T> =
+        spring(dampingRatio = 1.0f, stiffness = 800.0f)
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded `tween` durations and M2-era `LinearOutSlowInEasing` with M3 Expressive spring-based specs
- Add `TBAMotionTokens.kt` mirroring `ExpressiveMotionTokens` from material3 1.4.0 (the API is `internal` in this version; can be replaced with `MaterialTheme.motionScheme` once public)
- Spatial animations (screen slides, expand/collapse, chevron rotation, bottom bar) use spring physics
- Effect animations (tab fades, scrollbar fade in/out) use critically-damped springs

## What changed
| Animation | Before | After |
|-----------|--------|-------|
| Tab fade | `tween(200, LinearOutSlowInEasing)` | `fastEffectsSpec` spring(1.0, 3800) |
| Screen slides | default spring | `defaultSpatialSpec` spring(0.8, 380) |
| Bottom bar show/hide | default spring | `defaultSpatialSpec` spring(0.8, 380) |
| Chevron rotation | default spring (no spec) | `fastSpatialSpec` spring(0.6, 800) |
| Row expand/collapse | default spring + fade | spatial spring(0.8, 380) + effects spring |
| Scrollbar fade | `tween(150)`/`tween(300)` | `fastEffectsSpec`/`defaultEffectsSpec` |

Values sourced from `ExpressiveMotionTokens v0_14_0` in the material3 library source.

Ref: [M3 Expressive motion](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary)

## Test plan
- [ ] Tab switching (Events/Teams/Districts) — fade feels snappy
- [ ] Navigate into event/team detail — slide transition is fluid
- [ ] Press back / predictive back — slide out matches
- [ ] Bottom bar show/hide when entering/leaving detail screens
- [ ] Rankings tab → tap row → chevron rotates, detail expands/collapses
- [ ] Advancement tab → same expand/collapse behavior
- [ ] Long list scroll — scrollbar thumb fades in/out
- [ ] Developer Options → Animator duration scale 10x to inspect curves

🤖 Generated with [Claude Code](https://claude.com/claude-code)