### PR TITLE
Replace fontWeight overrides with M3 typography roles

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/EventRow.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/EventRow.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Event
 import java.time.LocalDate
@@ -39,8 +38,7 @@ fun EventRow(
             val name = if (showYear) "${event.year} ${event.name}" else event.name
             Text(
                 text = name,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
+                style = MaterialTheme.typography.titleMedium,
             )
             val location =
                 listOfNotNull(event.city, event.state, event.country)

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -188,8 +188,7 @@ fun MatchItem(
     ) {
         Text(
             text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Medium,
+            style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(0.15f),
         )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/SectionHeader.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/SectionHeader.kt
@@ -60,7 +60,6 @@ fun SectionHeader(
             Text(
                 text = label,
                 style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
                 color = Color.White,
             )
             if (isStuck) {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/TeamRow.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/TeamRow.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Team
 
@@ -35,8 +34,7 @@ fun TeamRow(
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = "${team.number} - ${team.nickname ?: team.name ?: ""}",
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
+                style = MaterialTheme.typography.titleMedium,
             )
             val location = listOfNotNull(team.city, team.state, team.country).joinToString(", ")
             val subtitle =

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -312,7 +311,6 @@ private fun RankingsTab(
                 Text(
                     text = "Rank",
                     style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.10f),
@@ -320,7 +318,6 @@ private fun RankingsTab(
                 Text(
                     text = "Team",
                     style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
@@ -328,7 +325,6 @@ private fun RankingsTab(
                 Text(
                     text = "Event\n1",
                     style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
@@ -336,7 +332,6 @@ private fun RankingsTab(
                 Text(
                     text = "Event\n2",
                     style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
@@ -344,7 +339,6 @@ private fun RankingsTab(
                 Text(
                     text = "DCMP",
                     style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
@@ -352,7 +346,6 @@ private fun RankingsTab(
                 Text(
                     text = "Rookie\nBonus",
                     style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
@@ -360,7 +353,6 @@ private fun RankingsTab(
                 Text(
                     text = "Total\nPoints",
                     style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
                     color = Color.White,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
@@ -404,8 +396,7 @@ private fun RankingsTab(
             ) {
                 Text(
                     text = "#${ranking.rank}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.labelLarge,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.10f),
                 )
@@ -441,8 +432,7 @@ private fun RankingsTab(
                 )
                 Text(
                     text = "${ranking.pointTotal.toInt()} pts",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.labelLarge,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),
                 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -146,8 +145,7 @@ private fun DistrictItem(
 ) {
     Text(
         text = district.displayName,
-        style = MaterialTheme.typography.bodyLarge,
-        fontWeight = FontWeight.Medium,
+        style = MaterialTheme.typography.titleMedium,
         modifier =
             Modifier
                 .fillMaxWidth()

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -508,7 +507,6 @@ private fun SimpleSectionHeader(label: String) {
         Text(
             text = label,
             style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
             color = Color.White,
         )
     }
@@ -526,7 +524,6 @@ private fun SubSectionHeader(label: String) {
         Text(
             text = label,
             style = MaterialTheme.typography.labelLarge,
-            fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.CmpAdvancement
@@ -134,15 +133,13 @@ private fun AdvancementPointsItem(
         ) {
             Text(
                 text = "#$rank",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.labelLarge,
                 modifier = Modifier.width(48.dp),
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = points.teamKey.removePrefix("frc"),
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
+                    style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.clickable { onTeamClick(points.teamKey) },
                 )
@@ -162,8 +159,7 @@ private fun AdvancementPointsItem(
             }
             Text(
                 text = "${points.total} pts",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.labelLarge,
             )
             Spacer(modifier = Modifier.width(4.dp))
             Icon(
@@ -203,14 +199,12 @@ private fun AdvancementPointsItem(
                 ) {
                     Text(
                         text = "Total",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.labelLarge,
                         modifier = Modifier.weight(1f),
                     )
                     Text(
                         text = points.total.toString(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.labelLarge,
                     )
                 }
                 // Qualification detail row
@@ -229,8 +223,7 @@ private fun AdvancementPointsItem(
                             )
                             Text(
                                 text = detail,
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = FontWeight.Medium,
+                                style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.primary,
                             )
                         }
@@ -288,8 +281,7 @@ private fun AdvancementBreakdownRow(
         )
         Text(
             text = value.toString(),
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Medium,
+            style = MaterialTheme.typography.labelMedium,
         )
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Alliance
 import com.thebluealliance.android.domain.model.displayTitle
@@ -65,7 +64,6 @@ fun EventAlliancesTab(
                     Text(
                         text = alliance.displayTitle,
                         style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.Bold,
                     )
                     alliance.playoffSummary?.let { summary ->
                         Surface(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAwardsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAwardsTab.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Award
 import com.thebluealliance.android.ui.common.EmptyBox
@@ -58,8 +57,7 @@ fun EventAwardsTab(
             ) {
                 Text(
                     text = award.name,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
+                    style = MaterialTheme.typography.titleMedium,
                 )
                 val recipient =
                     buildString {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.Webcast
@@ -174,7 +173,6 @@ fun EventInfoTab(
                 Text(
                     text = "Webcasts",
                     style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
                 )
             }
             itemsIndexed(event.webcasts, key = {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.EventCOPRs
 import com.thebluealliance.android.domain.model.EventInsights
@@ -368,14 +367,12 @@ private fun InsightsView(
                 Text(
                     text = insightHeader,
                     style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
                     color = Color.White,
                     modifier = Modifier.weight(1.5f),
                 )
                 Text(
                     text = "Value",
                     style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
                     color = Color.White,
                     modifier = Modifier.weight(1f),
                 )
@@ -822,7 +819,6 @@ private fun OprHeaderItem(
         Text(
             text = text,
             style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
             color = Color.White,
         )
         if (currentSort == sortColumn) {
@@ -853,7 +849,6 @@ private fun CoprHeaderItem(
         Text(
             text = text,
             style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
             color = Color.White,
         )
         if (currentSort == sortColumn) {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Ranking
@@ -180,7 +179,6 @@ private fun RankingHeaderRow(
         Text(
             text = "Rank",
             style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
             color = Color.White,
             modifier = Modifier.weight(0.12f),
         )
@@ -195,7 +193,6 @@ private fun RankingHeaderRow(
         Text(
             text = "Record",
             style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
             color = Color.White,
             modifier = Modifier.weight(0.22f),
         )
@@ -236,7 +233,6 @@ private fun RankingHeaderItem(
         Text(
             text = text,
             style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
             color = Color.White,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
@@ -280,18 +276,16 @@ private fun RankingItem(
         ) {
             Text(
                 text = "#${ranking.rank}",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.labelLarge,
                 modifier = Modifier.weight(0.12f),
             )
             Text(
                 text = ranking.teamKey.removePrefix("frc"),
-                style = MaterialTheme.typography.bodyLarge,
+                style = MaterialTheme.typography.titleMedium,
                 modifier =
                     Modifier
                         .weight(0.22f)
                         .clickable { onTeamClick(ranking.teamKey) },
-                fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.primary,
             )
             Text(
@@ -309,8 +303,7 @@ private fun RankingItem(
 
             Text(
                 text = primarySortValue,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.labelLarge,
                 modifier = Modifier.weight(0.18f),
             )
 
@@ -322,8 +315,7 @@ private fun RankingItem(
 
             Text(
                 text = secondarySortValue,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.labelLarge,
                 modifier = Modifier.weight(0.14f),
             )
 
@@ -361,7 +353,6 @@ private fun RankingItem(
                     Text(
                         text = "Tiebreakers:",
                         style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.Bold,
                         modifier = Modifier.padding(bottom = 4.dp),
                     )
 
@@ -389,8 +380,7 @@ private fun RankingItem(
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = formattedValue,
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = FontWeight.Medium,
+                                style = MaterialTheme.typography.labelMedium,
                             )
                         }
                     }
@@ -403,7 +393,6 @@ private fun RankingItem(
                     Text(
                         text = "Additional Stats:",
                         style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.Bold,
                         modifier = Modifier.padding(bottom = 4.dp),
                     )
                     ranking.extraStats.forEachIndexed { index, value ->
@@ -424,8 +413,7 @@ private fun RankingItem(
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = String.format(Locale.US, "%.${precision}f", value),
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = FontWeight.Medium,
+                                style = MaterialTheme.typography.labelMedium,
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -174,7 +174,6 @@ fun MatchDetailScreen(
                             Text(
                                 text = "Match Video",
                                 style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
                                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                             )
                         }
@@ -194,7 +193,6 @@ fun MatchDetailScreen(
                             Text(
                                 text = "Score Breakdown",
                                 style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
                                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                             )
                         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -58,7 +58,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -257,8 +256,8 @@ fun MyTBAScreen(
                         text = {
                             Text(
                                 text = title,
+                                style = MaterialTheme.typography.labelLarge,
                                 color = Color.White,
-                                fontWeight = FontWeight.Bold,
                             )
                         },
                     )
@@ -393,8 +392,7 @@ private fun FavoriteItem(
         ) {
             Text(
                 text = favorite.modelKey,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
+                style = MaterialTheme.typography.titleMedium,
             )
             Text(
                 text = typeLabel,
@@ -504,8 +502,7 @@ private fun SubscriptionItem(
         ) {
             Text(
                 text = subscription.modelKey,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
+                style = MaterialTheme.typography.titleMedium,
             )
             Text(
                 text = "$typeLabel · ${subscription.notifications.joinToString(", ")}",

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -173,43 +172,36 @@ private fun RankingsTableHeader() {
             Text(
                 text = "Rank",
                 style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(0.12f),
             )
             Text(
                 text = "Team",
                 style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(0.18f),
             )
             Text(
                 text = "Event 1",
                 style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(0.15f),
             )
             Text(
                 text = "Event 2",
                 style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(0.15f),
             )
             Text(
                 text = "Bonus",
                 style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(0.15f),
             )
             Text(
                 text = "Total Points",
                 style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(0.18f),
             )
             Text(
                 text = "Qualified",
                 style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(0.25f),
             )
         }
@@ -233,14 +225,12 @@ private fun RegionalRankingRow(
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = "${ranking.rank}",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.labelLarge,
                 modifier = Modifier.weight(0.12f),
             )
             Text(
                 text = ranking.teamKey.removePrefix("frc"),
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
+                style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.weight(0.18f),
             )
             val sortedEvents = ranking.eventPoints.sortedBy { it.eventKey }
@@ -301,8 +291,7 @@ private fun RegionalRankingRow(
             }
             Text(
                 text = "${ranking.pointTotal.toInt()}",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.labelLarge,
                 modifier = Modifier.weight(0.18f),
             )
             AdvancementBadge(method = ranking.advancementMethod, modifier = Modifier.weight(0.25f))

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -351,7 +350,6 @@ private fun SummaryTab(
                     Text(
                         text = "Info",
                         style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
                         color = Color.White,
                     )
                 }
@@ -445,7 +443,6 @@ private fun SummaryTab(
                     Text(
                         text = "Championship Qualification",
                         style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
                         color = Color.White,
                     )
                 }
@@ -482,7 +479,6 @@ private fun SummaryTab(
                         Text(
                             text = "Recent Matches",
                             style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
                             color = Color.White,
                         )
                     }
@@ -566,7 +562,6 @@ private fun InfoRow(
             Text(
                 text = label,
                 style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
             )
             if (labelSuffix != null) {
                 Text(
@@ -646,12 +641,10 @@ private fun StatsTab(
             Text(
                 text = if (isDistrictEvent) "District Points" else "Regional Points",
                 style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
             )
             Text(
                 text = "${points.total} pts",
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.titleMedium,
             )
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 advancementBreakdownRows(points, isDistrictEvent).forEach { (label, value) ->
@@ -663,8 +656,7 @@ private fun StatsTab(
                         )
                         Text(
                             text = value.toString(),
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium,
+                            style = MaterialTheme.typography.labelMedium,
                         )
                     }
                 }
@@ -689,8 +681,7 @@ private fun StatRow(
         )
         Text(
             text = "%.2f".format(value),
-            style = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.titleMedium,
         )
     }
 }
@@ -755,8 +746,7 @@ private fun AwardsTab(
             ) {
                 Text(
                     text = award.name,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.titleMedium,
                 )
                 if (award.awardee != null) {
                     Text(


### PR DESCRIPTION
## Summary
- Remove 65 hardcoded `fontWeight` overrides across 17 files by using the correct M3 type scale role
- No custom `Typography` — uses M3 defaults only
- 6 conditional overrides retained (match winner bold highlighting, selected section header)

I reviewed a set of screenshots - in general this makes fewer things bold, but a lot of stuff was bold that doesn't need to be. Feels semantically simpler, and better aligned with other material apps.

### Mapping
| Category | Before | After |
|----------|--------|-------|
| Section headers (16) | `titleMedium` + Bold | `titleMedium` (500) |
| Table column headers (17) | `labelSmall`/`labelLarge` + Bold | same role, no override (500) |
| Rank numbers / totals (11) | `bodyMedium` + Bold | `labelLarge` (500) |
| Clickable identifiers (9) | `bodyLarge` + Medium | `titleMedium` (500) |
| Secondary data values (5) | `bodyMedium` + Medium | `labelMedium` (500) |
| Sort values (2) | `bodyMedium` + SemiBold | `labelLarge` (500) |
| Other headers (5) | mixed + Bold | drop override |

Net: -108 lines, +30 lines

## Test plan
Before/after screenshots are in `screenshots/fontweight-before/` and `screenshots/fontweight-after/`. Key things to check:
- [x] Events list — event names and section headers are lighter but still distinct
- [x] Rankings table — column headers, rank numbers, sort values read clearly
- [x] Expanded ranking row — "Tiebreakers:" / "Additional Stats:" labels
- [x] Match list — winner bold highlighting still works
- [x] Match detail — scores still bold for winner, section headers lighter
- [x] District rankings — table headers and data
- [x] Alliances tab — "Alliance N" labels
- [x] Teams / Districts lists — list item names

🤖 Generated with [Claude Code](https://claude.com/claude-code)