### PR TITLE
fix: time shouldn't scroll off when switching teams

### DIFF
--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -189,7 +189,7 @@ private fun TeamTrackerScreen(
         edgeButton = {
             EdgeButton(
                 onClick = onChangeTeam,
-                buttonSize = EdgeButtonSize.Medium,
+                buttonSize = EdgeButtonSize.Small,
             ) {
                 Icon(
                     painter = painterResource(R.drawable.ic_settings),
@@ -206,6 +206,13 @@ private fun TeamTrackerScreen(
         ) {
             item { Spacer(modifier = Modifier.height(8.dp)) }
             item { TeamHeader(state) }
+
+            val hasMatchData =
+                state.lastMatchLabel.isNotBlank() || state.nextMatchLabel.isNotBlank()
+            val sparseContent = !hasMatchData && state.upcomingEvents.size <= 1
+            if (!state.isLoading && sparseContent) {
+                item { Spacer(modifier = Modifier.height(4.dp)) }
+            }
 
             if (state.isLoading) {
                 item {

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -204,6 +204,7 @@ private fun TeamTrackerScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             contentPadding = contentPadding,
         ) {
+            item { Spacer(modifier = Modifier.height(8.dp)) }
             item { TeamHeader(state) }
 
             if (state.isLoading) {

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,6 +21,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,8 +41,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
-import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.CircularProgressIndicator
 import androidx.wear.compose.material3.EdgeButton
@@ -177,10 +177,15 @@ private fun TeamTrackerScreen(
         return
     }
 
-    val listState = rememberScalingLazyListState()
+    val columnState = rememberTransformingLazyColumnState()
+
+    // Reset scroll position when team changes
+    LaunchedEffect(state.teamNumber) {
+        columnState.scrollToItem(0)
+    }
 
     ScreenScaffold(
-        scrollState = listState,
+        scrollState = columnState,
         edgeButton = {
             EdgeButton(
                 onClick = onChangeTeam,
@@ -192,13 +197,12 @@ private fun TeamTrackerScreen(
                 )
             }
         },
-    ) {
-        ScalingLazyColumn(
-            state = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = columnState,
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
-            autoCentering = null,
-            contentPadding = PaddingValues(top = 28.dp, start = 10.dp, end = 10.dp, bottom = 60.dp),
+            contentPadding = contentPadding,
         ) {
             item { TeamHeader(state) }
 
@@ -366,6 +370,14 @@ private fun EventSubtitle(state: TeamTrackerState) {
                 )
             }
         }
+    } else {
+        Text(
+            text = stringResource(R.string.no_upcoming_events),
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(vertical = 2.dp),
+        )
     }
 }
 

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="last_match">Last match</string>
     <string name="next_match">Next match</string>
     <string name="set_tracked_team">Set team</string>
+    <string name="no_upcoming_events">No upcoming events</string>
 </resources>


### PR DESCRIPTION
## Summary
- Migrate Wear OS from `ScalingLazyColumn` to `TransformingLazyColumn` (Wear M3)
- `ScreenScaffold` now provides `contentPadding` based on actual watch geometry — no more hardcoded `28.dp` top padding
- Fixes bug where TimeText scrolled halfway off screen after team data loaded
- Add "No upcoming events" fallback text when a team has no events (addresses Play Store rejection for empty screen)
- Reset scroll position when tracked team changes via `LaunchedEffect`

## Test plan
- [ ] Set a tracked team → data loads → time stays fully visible
- [ ] Change to a different team → content resets to top, time stays visible
- [ ] Team with no events → shows "No upcoming events" instead of empty space
- [ ] Scroll down and back up — content respects round screen edges
- [ ] EdgeButton (settings) still works at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)