### PR TITLE
fix: pass ANDROID_SERIAL through to emu in screenshot playbook

### DIFF
--- a/scripts/screenshot-playbook.sh
+++ b/scripts/screenshot-playbook.sh
@@ -33,7 +33,8 @@ for arg in "$@"; do
   esac
 done
 
-EMU="$(dirname "$0")/emu"
+SERIAL="${ANDROID_SERIAL:-}"
+EMU="$(dirname "$0")/emu${SERIAL:+ -s $SERIAL}"
 PKG="com.thebluealliance.androidclient"
 DEV_PKG="com.thebluealliance.androidclient.development"
 MAIN_ACTIVITY="com.thebluealliance.android.MainActivity"


### PR DESCRIPTION
## Summary
- When multiple emulators are running, the screenshot playbook's `emu` calls could target the wrong device
- Now reads `ANDROID_SERIAL` env var and passes it as `-s` flag to the `emu` tool
- Usage: `ANDROID_SERIAL=emulator-5556 bash scripts/screenshot-playbook.sh`

## Test plan
- [x] Verified playbook runs correctly with `ANDROID_SERIAL=emulator-5556` when both phone and wear emulators are connected
- [x] Without `ANDROID_SERIAL` set, behavior is unchanged (no `-s` flag passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)