### PR TITLE
fix: add windowSoftInputMode=adjustResize for proper IME insets

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,6 +34,10 @@ scripts/emu launch <package/activity>            # force-stop and start activity
 
 Use `find` before `tap` to verify unique matching; use `list` to explore the UI hierarchy.
 
+## Android Documentation
+
+When researching Android APIs, libraries, or best practices, use `android docs search "<query>"` and `android docs fetch "<url>"` instead of web search. This is an offline curated knowledge base that has up-to-date, authoritative Android documentation.
+
 ## Architecture
 
 - **UI:** Jetpack Compose with Material 3, MVVM via `@HiltViewModel`

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.TBA">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## Summary

- Adds `android:windowSoftInputMode="adjustResize"` to MainActivity in AndroidManifest.xml
- This is step 2 of the [official edge-to-edge setup guide](https://developer.android.com/develop/ui/compose/system/setup-e2e) — without it, the app doesn't receive IME insets and the keyboard overlaps content (e.g. search results are hidden behind the keyboard and untappable)
- Also adds `android` CLI docs search guidance to CLAUDE.md

## Test plan

- [ ] Open the app, tap the search icon, focus the search field
- [ ] Type a query that returns multiple results
- [ ] Verify the results list resizes above the keyboard and all results are scrollable

🤖 Generated with [Claude Code](https://claude.com/claude-code)