### PR TITLE
chore: bump wear targetSdk from 34 to 36

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -60,7 +60,7 @@ android {
     defaultConfig {
         applicationId = "com.thebluealliance.androidclient"
         minSdk = 30
-        targetSdk = 34
+        targetSdk = 36
         versionCode = computedVersionCode
         versionName = computedVersionName
 


### PR DESCRIPTION
## Summary

- Bumps wear module `targetSdk` from 34 to 36, aligning with the phone app
- Wear OS 6 (API 36) behavior changes (granular health permissions, batched tile events) don't affect this app
- No code changes needed

## Test plan

- [x] `./gradlew :wear:testDebugUnitTest` passes
- [x] `./gradlew :wear:assembleDebug` builds cleanly
- [x] Visually verified on round watch emulator — main screen and config screen render correctly with no system bar clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)