### PR TITLE
fix: catch IllegalStateException when pinning shortcut from background

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/shortcuts/TBAShortcutManager.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/shortcuts/TBAShortcutManager.kt
@@ -186,14 +186,20 @@ class TBAShortcutManager
                 return
             }
 
-            val success = ShortcutManagerCompat.requestPinShortcut(context, shortcutInfo, null)
-            if (!success) {
-                Toast
-                    .makeText(
-                        context,
-                        "Failed to add shortcut to home screen",
-                        Toast.LENGTH_SHORT,
-                    ).show()
+            try {
+                val success = ShortcutManagerCompat.requestPinShortcut(context, shortcutInfo, null)
+                if (!success) {
+                    Toast
+                        .makeText(
+                            context,
+                            "Failed to add shortcut to home screen",
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            } catch (e: IllegalStateException) {
+                // requestPinShortcut throws if the app is no longer in the foreground
+                // (e.g. user switched away during the network fetch for shortcut info)
+                Log.w("TBAShortcutManager", "Cannot pin shortcut while in background", e)
             }
         }
     }


### PR DESCRIPTION
## Summary

- `requestPinShortcut` crashes with `IllegalStateException` when the app goes to background between the user tapping "Add to home screen" and the actual pin call (which happens after network I/O to build the shortcut info)
- Wraps the call in a try-catch — if the user has left, the shortcut silently doesn't get pinned, which is the correct behavior
- 3 crashes on 11.7.1, 1 user (also seen on prior versions)

Closes #1320

## Test plan

- [ ] Open a team detail screen, tap overflow → "Add to home screen" — verify shortcut is pinned
- [ ] Repeat but quickly switch to home screen after tapping — verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)