### PR TITLE
chore: bump AGP to 9.2.0 and compileSdk to 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,7 +59,7 @@ val computedVersionName =
 
 android {
     namespace = "com.thebluealliance.android"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.thebluealliance.androidclient"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.1"
+agp = "9.2.0"
 kotlin = "2.3.20"
 ksp = "2.3.6"
 

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -55,7 +55,7 @@ val computedVersionName =
 
 android {
     namespace = "com.thebluealliance.android.wear"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.thebluealliance.androidclient"


### PR DESCRIPTION
## Summary

- Bumps Android Gradle Plugin from 9.1.1 to 9.2.0
- Bumps compileSdk from 36 to 37 (Android 16.1) in both app and wear modules
- Resolves `AndroidGradlePluginVersion` and `GradleDependency` lint errors

## Test plan

- [x] `./gradlew :app:assembleDebug :wear:assembleDebug` builds cleanly
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] `./gradlew :app:lintDebug` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)