### PR TITLE
chore: bump Kotlin to 2.3.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "9.2.0"
-kotlin = "2.3.20"
+kotlin = "2.3.21"
 ksp = "2.3.7"
 
 compose-bom = "2026.04.01"


### PR DESCRIPTION
## Summary
- Bump Kotlin from 2.3.20 to 2.3.21
- Fixes `NewerVersionAvailable` lint errors for `plugin.compose` and `plugin.serialization`

🤖 Generated with [Claude Code](https://claude.com/claude-code)