### PR TITLE
fix: exclude dev tags from git describe in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -276,7 +276,7 @@ preflight() {
 
 get_version_info() {
     local desc
-    desc=$(git describe --tags --long --match 'v[0-9]*' 2>/dev/null || echo "")
+    desc=$(git describe --tags --long --match 'v[0-9]*' --exclude '*-dev*' 2>/dev/null || echo "")
     if [[ -z "$desc" ]]; then
         die "No version tags found. Create one first: git tag v1.0.0"
     fi


### PR DESCRIPTION
## Summary
- Add `--exclude '*-dev*'` to `git describe` in release.sh
- Fixes parse failure when stale `-dev.N` tags exist from earlier `gh release create` runs