### PR TITLE
Natively Render Nexus Pit Maps

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -150,6 +150,9 @@ android {
         // Advisory rule that fires whenever a newer (beta) SDK exists. We
         // bump targetSdk deliberately, not on every API release.
         disable += "OldTargetApi"
+        // False positive for adaptive-icon XML in mipmap-anydpi alongside
+        // legacy PNG fallbacks in density buckets — this is intentional.
+        disable += "IconXmlAndPng"
     }
 
     @Suppress("UnstableApiUsage")

--- a/app/src/main/kotlin/com/thebluealliance/android/TBAApplication.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/TBAApplication.kt
@@ -7,6 +7,9 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.updateAll
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
 import com.thebluealliance.android.config.ApiKeyProvider
 import com.thebluealliance.android.messaging.NotificationChannelManager
 import com.thebluealliance.android.shortcuts.TBAShortcutManager
@@ -20,7 +23,8 @@ import javax.inject.Inject
 @HiltAndroidApp
 class TBAApplication :
     Application(),
-    Configuration.Provider {
+    Configuration.Provider,
+    SingletonImageLoader.Factory {
     @Inject lateinit var apiKeyProvider: ApiKeyProvider
 
     @Inject lateinit var notificationChannelManager: NotificationChannelManager
@@ -35,6 +39,11 @@ class TBAApplication :
                 .Builder()
                 .setWorkerFactory(workerFactory)
                 .build()
+
+    override fun newImageLoader(context: PlatformContext): ImageLoader =
+        ImageLoader
+            .Builder(context)
+            .build()
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/entity/EventEntity.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/entity/EventEntity.kt
@@ -25,4 +25,5 @@ data class EventEntity(
     val address: String?,
     val gmapsUrl: String?,
     val playoffType: Int,
+    val firstEventCode: String? = null,
 )

--- a/app/src/main/kotlin/com/thebluealliance/android/data/mappers/Mappers.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/mappers/Mappers.kt
@@ -106,6 +106,7 @@ fun EventDto.toEntity() =
         address = address,
         gmapsUrl = gmapsUrl,
         playoffType = playoffType ?: PlayoffType.OTHER.typeInt,
+        firstEventCode = firstEventCode,
     )
 
 fun EventEntity.toDomain() =
@@ -129,6 +130,7 @@ fun EventEntity.toDomain() =
         address = address,
         gmapsUrl = gmapsUrl,
         playoffType = PlayoffType.fromInt(playoffType),
+        firstEventCode = firstEventCode,
         webcasts =
             webcasts?.let { raw ->
                 try {

--- a/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/EventDto.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/remote/dto/EventDto.kt
@@ -26,6 +26,7 @@ data class EventDto(
     @SerialName("start_date") val startDate: String? = null,
     @SerialName("end_date") val endDate: String? = null,
     @SerialName("playoff_type") val playoffType: Int? = null,
+    @SerialName("first_event_code") val firstEventCode: String? = null,
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/Event.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/Event.kt
@@ -21,6 +21,7 @@ data class Event(
     val gmapsUrl: String?,
     val webcasts: List<Webcast>,
     val playoffType: PlayoffType,
+    val firstEventCode: String? = null,
 )
 
 data class Webcast(

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/DeeplinkMatcher.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/DeeplinkMatcher.kt
@@ -8,6 +8,12 @@ class DeeplinkMatcher {
         val segments = uri.pathSegments
         if (segments.isEmpty()) return null
 
+        // https://www.thebluealliance.com/event/{eventKey}/pitmap
+        if (segments[0] == "event" && segments.size >= 3 && segments[2] == "pitmap") {
+            val teamsCsv = uri.getQueryParameter("teams") ?: ""
+            return Screen.EventPitMap(segments[1], teamsCsv)
+        }
+
         // https://www.thebluealliance.com/event/{eventKey}
         if (segments[0] == "event" && segments.size >= 2) {
             return Screen.EventDetail(segments[1])

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/Screen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/Screen.kt
@@ -56,6 +56,17 @@ sealed interface Screen : NavKey {
     @Serializable data object About : Screen
 
     @Serializable data object Thanks : Screen
+
+    @Serializable data class PitMap(
+        val eventKey: String,
+        val highlightedTeamKeys: List<String> = emptyList(),
+    ) : Screen
+
+    /** Used when navigating via a TBA web deeplink (carries raw CSV team string from the URL). */
+    @Serializable data class EventPitMap(
+        val eventKey: String,
+        val teamsCsv: String = "",
+    ) : Screen
 }
 
 /**

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -29,6 +29,8 @@ import com.thebluealliance.android.ui.events.EventsScreen
 import com.thebluealliance.android.ui.events.EventsViewModel
 import com.thebluealliance.android.ui.events.detail.EventDetailScreen
 import com.thebluealliance.android.ui.events.detail.EventDetailViewModel
+import com.thebluealliance.android.ui.events.detail.PitMapScreen
+import com.thebluealliance.android.ui.events.detail.PitMapViewModel
 import com.thebluealliance.android.ui.matches.MatchDetailScreen
 import com.thebluealliance.android.ui.matches.MatchDetailViewModel
 import com.thebluealliance.android.ui.more.AboutScreen
@@ -43,8 +45,6 @@ import com.thebluealliance.android.ui.teamevent.TeamEventDetailViewModel
 import com.thebluealliance.android.ui.teams.TeamDetailScreen
 import com.thebluealliance.android.ui.teams.TeamDetailViewModel
 import com.thebluealliance.android.ui.teams.TeamsScreen
-import com.thebluealliance.android.ui.events.detail.PitMapScreen
-import com.thebluealliance.android.ui.events.detail.PitMapViewModel
 import com.thebluealliance.android.ui.theme.TBAMotionTokens
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -277,7 +277,9 @@ fun TBANavigation(
                                         navigator.navigate(Screen.DistrictDetail(districtKey))
                                     },
                                     onNavigateToPitMap = { eventKey, highlightedTeamKeys ->
-                                        navigator.navigate(Screen.PitMap(eventKey, highlightedTeamKeys))
+                                        navigator.navigate(
+                                            Screen.PitMap(eventKey, highlightedTeamKeys),
+                                        )
                                     },
                                     initialTab = eventDetail.initialTab,
                                 )
@@ -366,7 +368,9 @@ fun TBANavigation(
                                     },
                                     onNavigateToSearch = { navigator.navigate(Screen.Search) },
                                     onNavigateToPitMap = { eventKey, highlightedTeamKeys ->
-                                        navigator.navigate(Screen.PitMap(eventKey, highlightedTeamKeys))
+                                        navigator.navigate(
+                                            Screen.PitMap(eventKey, highlightedTeamKeys),
+                                        )
                                     },
                                 )
                             }
@@ -383,13 +387,15 @@ fun TBANavigation(
                                 )
                             }
                             entry<Screen.EventPitMap> { eventPitMap ->
-                                val pitMapKey = Screen.PitMap(
-                                    eventKey = eventPitMap.eventKey,
-                                    highlightedTeamKeys = eventPitMap.teamsCsv
-                                        .split(",")
-                                        .map { it.trim() }
-                                        .filter { it.isNotEmpty() },
-                                )
+                                val pitMapKey =
+                                    Screen.PitMap(
+                                        eventKey = eventPitMap.eventKey,
+                                        highlightedTeamKeys =
+                                            eventPitMap.teamsCsv
+                                                .split(",")
+                                                .map { it.trim() }
+                                                .filter { it.isNotEmpty() },
+                                    )
                                 val viewModel: PitMapViewModel =
                                     hiltViewModel(
                                         creationCallback = { f: PitMapViewModel.Factory ->

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -43,6 +43,8 @@ import com.thebluealliance.android.ui.teamevent.TeamEventDetailViewModel
 import com.thebluealliance.android.ui.teams.TeamDetailScreen
 import com.thebluealliance.android.ui.teams.TeamDetailViewModel
 import com.thebluealliance.android.ui.teams.TeamsScreen
+import com.thebluealliance.android.ui.events.detail.PitMapScreen
+import com.thebluealliance.android.ui.events.detail.PitMapViewModel
 import com.thebluealliance.android.ui.theme.TBAMotionTokens
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -274,6 +276,9 @@ fun TBANavigation(
                                     onNavigateToDistrict = { districtKey ->
                                         navigator.navigate(Screen.DistrictDetail(districtKey))
                                     },
+                                    onNavigateToPitMap = { eventKey, highlightedTeamKeys ->
+                                        navigator.navigate(Screen.PitMap(eventKey, highlightedTeamKeys))
+                                    },
                                     initialTab = eventDetail.initialTab,
                                 )
                             }
@@ -360,6 +365,40 @@ fun TBANavigation(
                                         navigator.navigate(Screen.EventDetail(eventKey, initialTab))
                                     },
                                     onNavigateToSearch = { navigator.navigate(Screen.Search) },
+                                    onNavigateToPitMap = { eventKey, highlightedTeamKeys ->
+                                        navigator.navigate(Screen.PitMap(eventKey, highlightedTeamKeys))
+                                    },
+                                )
+                            }
+                            entry<Screen.PitMap> { pitMap ->
+                                val viewModel: PitMapViewModel =
+                                    hiltViewModel(
+                                        creationCallback = { f: PitMapViewModel.Factory ->
+                                            f.create(pitMap)
+                                        },
+                                    )
+                                PitMapScreen(
+                                    viewModel = viewModel,
+                                    onNavigateUp = { navigator.navigateUp() },
+                                )
+                            }
+                            entry<Screen.EventPitMap> { eventPitMap ->
+                                val pitMapKey = Screen.PitMap(
+                                    eventKey = eventPitMap.eventKey,
+                                    highlightedTeamKeys = eventPitMap.teamsCsv
+                                        .split(",")
+                                        .map { it.trim() }
+                                        .filter { it.isNotEmpty() },
+                                )
+                                val viewModel: PitMapViewModel =
+                                    hiltViewModel(
+                                        creationCallback = { f: PitMapViewModel.Factory ->
+                                            f.create(pitMapKey)
+                                        },
+                                    )
+                                PitMapScreen(
+                                    viewModel = viewModel,
+                                    onNavigateUp = { navigator.navigateUp() },
                                 )
                             }
                         },

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -91,6 +91,7 @@ fun EventDetailScreen(
     onNavigateToMyTBA: () -> Unit = {},
     onNavigateToTeamEvent: (teamKey: String, eventKey: String) -> Unit = { _, _ -> },
     onNavigateToDistrict: (districtKey: String) -> Unit = {},
+    onNavigateToPitMap: (eventKey: String, highlightedTeamKeys: List<String>) -> Unit = { _, _ -> },
     initialTab: EventDetailTab = EventDetailTab.INFO,
     viewModel: EventDetailViewModel,
 ) {
@@ -340,7 +341,10 @@ fun EventDetailScreen(
                         EventInfoTab(
                             event = uiState.event,
                             districtDisplayName = uiState.districtDisplayName,
+                            pitLocations = uiState.pitLocations,
+                            favoriteTeamKeys = uiState.favoriteTeamKeysAtEvent,
                             onNavigateToDistrict = onNavigateToDistrict,
+                            onNavigateToPitMap = onNavigateToPitMap,
                             innerPadding = bottomPadding,
                         )
                     EventDetailTab.TEAMS ->

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailUiState.kt
@@ -29,4 +29,5 @@ data class EventDetailUiState(
     val regionalCmpAdvancementByTeam: Map<String, CmpAdvancement> = emptyMap(),
     val districtDisplayName: String? = null,
     val pitLocations: Map<String, String> = emptyMap(),
+    val favoriteTeamKeysAtEvent: List<String> = emptyList(),
 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
@@ -163,11 +163,17 @@ class EventDetailViewModel
                         baseState.event?.district?.let { districtRepository.observeDistrict(it) }
                             ?: flowOf(null),
                         eventRepository.observeEventPitLocations(eventKey),
-                    ) { insights, district, pitLocations ->
+                        myTBARepository.observeFavorites(),
+                    ) { insights, district, pitLocations, favorites ->
+                        val eventTeamKeys = baseState.teams?.map { it.key }?.toSet() ?: emptySet()
+                        val favTeamKeys = favorites
+                            .filter { it.modelType == ModelType.TEAM && it.modelKey in eventTeamKeys }
+                            .map { it.modelKey }
                         baseState.copy(
                             insights = insights,
                             districtDisplayName = district?.displayName,
                             pitLocations = pitLocations,
+                            favoriteTeamKeysAtEvent = favTeamKeys,
                         )
                     }
                 }.stateIn(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
@@ -166,9 +166,11 @@ class EventDetailViewModel
                         myTBARepository.observeFavorites(),
                     ) { insights, district, pitLocations, favorites ->
                         val eventTeamKeys = baseState.teams?.map { it.key }?.toSet() ?: emptySet()
-                        val favTeamKeys = favorites
-                            .filter { it.modelType == ModelType.TEAM && it.modelKey in eventTeamKeys }
-                            .map { it.modelKey }
+                        val favTeamKeys =
+                            favorites
+                                .filter {
+                                    it.modelType == ModelType.TEAM && it.modelKey in eventTeamKeys
+                                }.map { it.modelKey }
                         baseState.copy(
                             insights = insights,
                             districtDisplayName = district?.displayName,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapScreen.kt
@@ -35,27 +35,30 @@ fun PitMapScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val tbaMapAvailable by viewModel.tbaMapAvailable.collectAsStateWithLifecycle()
 
-    val pitMapUrl = remember(viewModel.eventKey, viewModel.highlightedTeamKeys) {
-        buildTbaPitMapUrl(viewModel.eventKey, viewModel.highlightedTeamKeys)
-    }
+    val pitMapUrl =
+        remember(viewModel.eventKey, viewModel.highlightedTeamKeys) {
+            buildTbaPitMapUrl(viewModel.eventKey, viewModel.highlightedTeamKeys)
+        }
 
     // When TBA has no pit map, fall back to the Nexus map. Nexus event codes are case-insensitive.
     // We defer until the event has loaded so we have the correct code — especially important for
     // CMP divisions whose TBA key differs from the FIRST API code (e.g. "2026cmptxcur" → "CUR").
-    val nexusPitMapUrl = remember(uiState.nexusEventCode, viewModel.highlightedTeamKeys) {
-        buildNexusPitMapUrl(uiState.nexusEventCode, viewModel.highlightedTeamKeys.firstOrNull())
-    }
+    val nexusPitMapUrl =
+        remember(uiState.nexusEventCode, viewModel.highlightedTeamKeys) {
+            buildNexusPitMapUrl(uiState.nexusEventCode, viewModel.highlightedTeamKeys.firstOrNull())
+        }
 
     // CSS selector for the SVG element to center on after load.
     // TBA SVG uses data-team-key on pit <g> elements and data-label-key on division labels.
     // Nexus is a JS SPA — onPageFinished fires before content renders, so skip centering there.
-    val tbaCenterSelector = remember(viewModel.eventKey, viewModel.highlightedTeamKeys) {
-        if (viewModel.highlightedTeamKeys.isNotEmpty()) {
-            "[data-team-key=\"${viewModel.highlightedTeamKeys.first()}\"]"
-        } else {
-            "[data-label-key=\"${viewModel.eventKey}\"]"
+    val tbaCenterSelector =
+        remember(viewModel.eventKey, viewModel.highlightedTeamKeys) {
+            if (viewModel.highlightedTeamKeys.isNotEmpty()) {
+                "[data-team-key=\"${viewModel.highlightedTeamKeys.first()}\"]"
+            } else {
+                "[data-label-key=\"${viewModel.eventKey}\"]"
+            }
         }
-    }
 
     // Show a spinner while:
     //  - the HEAD check is still running (tbaMapAvailable == null), OR
@@ -68,8 +71,11 @@ fun PitMapScreen(
             TBATopAppBar(
                 title = {
                     Text(
-                        if (uiState.eventTitle.isNotEmpty()) "${uiState.eventTitle} Pit Map"
-                        else "Pit Map",
+                        if (uiState.eventTitle.isNotEmpty()) {
+                            "${uiState.eventTitle} Pit Map"
+                        } else {
+                            "Pit Map"
+                        },
                     )
                 },
                 navigationIcon = {
@@ -86,9 +92,10 @@ fun PitMapScreen(
         when {
             showSpinner -> {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
                     contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator()
@@ -97,9 +104,10 @@ fun PitMapScreen(
             showNexusFallback -> {
                 PitMapWebView(
                     pitMapUrl = nexusPitMapUrl,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
                     // Nexus is a JS SPA — onPageFinished fires before content renders.
                     centerSelector = null,
                 )
@@ -107,9 +115,10 @@ fun PitMapScreen(
             else -> {
                 PitMapWebView(
                     pitMapUrl = pitMapUrl,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
                     centerSelector = tbaCenterSelector,
                 )
             }
@@ -146,66 +155,89 @@ private fun PitMapWebView(
                 // Hide until centering is done to avoid showing the map at the wrong position.
                 alpha = 0f
 
-                webViewClient = object : WebViewClient() {
-                    override fun onScaleChanged(view: WebView?, oldScale: Float, newScale: Float) {
-                        currentScale[0] = newScale
-                    }
+                webViewClient =
+                    object : WebViewClient() {
+                        override fun onScaleChanged(
+                            view: WebView?,
+                            oldScale: Float,
+                            newScale: Float,
+                        ) {
+                            currentScale[0] = newScale
+                        }
 
-                    override fun onPageFinished(view: WebView?, url: String?) {
-                        val wv = webViewRef[0] ?: run { showWebView(view); return }
-                        val selector = latestSelector[0] ?: run { showWebView(wv); return }
-
-                        // Wait 400 ms for layout to settle (same delay as the iOS implementation),
-                        // then ask JS for element's document-space centre, scale by current zoom,
-                        // and scroll natively.
-                        wv.postDelayed({
-                            // Single-quoted JS string so the selector's double-quotes are safe.
-                            val js = """
-                                (() => {
-                                  const el = document.querySelector('$selector');
-                                  if (!el) return null;
-                                  const rect = el.getBoundingClientRect();
-                                  return [
-                                    rect.left + window.scrollX + rect.width  / 2,
-                                    rect.top  + window.scrollY + rect.height / 2,
-                                  ];
-                                })()
-                            """.trimIndent()
-                            wv.evaluateJavascript(js) { result ->
-                                try {
-                                    if (result != null && result != "null") {
-                                        // result is a JSON array string, e.g. "[1234.5,678.9]"
-                                        val coords = result.trim('[', ']')
-                                            .split(',')
-                                            .map { it.trim().toDouble() }
-                                        if (coords.size >= 2) {
-                                            val zoom = currentScale[0]
-                                            val targetX = (coords[0] * zoom - wv.width  / 2)
-                                                .toInt().coerceAtLeast(0)
-                                            val targetY = (coords[1] * zoom - wv.height / 2)
-                                                .toInt().coerceAtLeast(0)
-                                            wv.scrollTo(targetX, targetY)
-                                        }
-                                    }
-                                } catch (_: Exception) {
-                                    // Ignore parse errors; the map is still usable without centering.
-                                } finally {
-                                    showWebView(wv)
+                        override fun onPageFinished(
+                            view: WebView?,
+                            url: String?,
+                        ) {
+                            val wv =
+                                webViewRef[0] ?: run {
+                                    showWebView(view)
+                                    return
                                 }
-                            }
-                        }, 400L)
-                    }
+                            val selector =
+                                latestSelector[0] ?: run {
+                                    showWebView(wv)
+                                    return
+                                }
 
-                    override fun onReceivedError(
-                        view: WebView?,
-                        request: WebResourceRequest?,
-                        error: WebResourceError?,
-                    ) {
-                        // Only act on main-frame errors. Sub-resource errors (images, fonts, etc.)
-                        // are common in SVG maps and should not trigger a visibility change.
-                        if (request?.isForMainFrame == true) showWebView(view)
+                            // Wait 400 ms for layout to settle (same delay as the iOS implementation),
+                            // then ask JS for element's document-space centre, scale by current zoom,
+                            // and scroll natively.
+                            wv.postDelayed({
+                                // Single-quoted JS string so the selector's double-quotes are safe.
+                                val js =
+                                    """
+                                    (() => {
+                                      const el = document.querySelector('$selector');
+                                      if (!el) return null;
+                                      const rect = el.getBoundingClientRect();
+                                      return [
+                                        rect.left + window.scrollX + rect.width  / 2,
+                                        rect.top  + window.scrollY + rect.height / 2,
+                                      ];
+                                    })()
+                                    """.trimIndent()
+                                wv.evaluateJavascript(js) { result ->
+                                    try {
+                                        if (result != null && result != "null") {
+                                            // result is a JSON array string, e.g. "[1234.5,678.9]"
+                                            val coords =
+                                                result
+                                                    .trim('[', ']')
+                                                    .split(',')
+                                                    .map { it.trim().toDouble() }
+                                            if (coords.size >= 2) {
+                                                val zoom = currentScale[0]
+                                                val targetX =
+                                                    (coords[0] * zoom - wv.width / 2)
+                                                        .toInt()
+                                                        .coerceAtLeast(0)
+                                                val targetY =
+                                                    (coords[1] * zoom - wv.height / 2)
+                                                        .toInt()
+                                                        .coerceAtLeast(0)
+                                                wv.scrollTo(targetX, targetY)
+                                            }
+                                        }
+                                    } catch (_: Exception) {
+                                        // Ignore parse errors; the map is still usable without centering.
+                                    } finally {
+                                        showWebView(wv)
+                                    }
+                                }
+                            }, 400L)
+                        }
+
+                        override fun onReceivedError(
+                            view: WebView?,
+                            request: WebResourceRequest?,
+                            error: WebResourceError?,
+                        ) {
+                            // Only act on main-frame errors. Sub-resource errors (images, fonts, etc.)
+                            // are common in SVG maps and should not trigger a visibility change.
+                            if (request?.isForMainFrame == true) showWebView(view)
+                        }
                     }
-                }
                 settings.apply {
                     // JavaScript is required for evaluateJavascript centering injection.
                     // This WebView only ever loads trusted TBA and Nexus URLs.
@@ -233,5 +265,9 @@ private fun PitMapWebView(
 
 /** Fades the WebView in over 150 ms, matching the iOS fade in the same PR. */
 private fun showWebView(view: WebView?) {
-    view?.animate()?.alpha(1f)?.setDuration(150)?.start()
+    view
+        ?.animate()
+        ?.alpha(1f)
+        ?.setDuration(150)
+        ?.start()
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,16 +25,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.util.buildNexusPitMapUrl
 import com.thebluealliance.android.util.buildTbaPitMapUrl
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import java.net.HttpURLConnection
-import java.net.URL
-
-private enum class PitMapAvailability {
-    AVAILABLE,
-    NOT_FOUND,
-    UNKNOWN,
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,18 +33,15 @@ fun PitMapScreen(
     viewModel: PitMapViewModel,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val tbaMapAvailable by viewModel.tbaMapAvailable.collectAsStateWithLifecycle()
 
     val pitMapUrl = remember(viewModel.eventKey, viewModel.highlightedTeamKeys) {
         buildTbaPitMapUrl(viewModel.eventKey, viewModel.highlightedTeamKeys)
     }
 
-    val availability by produceState<PitMapAvailability>(initialValue = PitMapAvailability.UNKNOWN, pitMapUrl) {
-        value = withContext(Dispatchers.IO) { fetchPitMapAvailability(pitMapUrl) }
-    }
-
-    // When TBA has no pit map, fall back to the Nexus map. Nexus event codes are case-insensitive,
-    // so the lowercase nexusEventCode is fine. We defer until the event has loaded so we have the
-    // correct code (especially important for CMP divisions whose TBA key ≠ FIRST code).
+    // When TBA has no pit map, fall back to the Nexus map. Nexus event codes are case-insensitive.
+    // We defer until the event has loaded so we have the correct code — especially important for
+    // CMP divisions whose TBA key differs from the FIRST API code (e.g. "2026cmptxcur" → "CUR").
     val nexusPitMapUrl = remember(uiState.nexusEventCode, viewModel.highlightedTeamKeys) {
         buildNexusPitMapUrl(uiState.nexusEventCode, viewModel.highlightedTeamKeys.firstOrNull())
     }
@@ -71,13 +57,19 @@ fun PitMapScreen(
         }
     }
 
+    // Show a spinner while:
+    //  - the HEAD check is still running (tbaMapAvailable == null), OR
+    //  - TBA returned 404 but the event hasn't loaded yet (nexus code not ready)
+    val showNexusFallback = tbaMapAvailable == false && uiState.isLoaded
+    val showSpinner = tbaMapAvailable == null || (tbaMapAvailable == false && !uiState.isLoaded)
+
     Scaffold(
         topBar = {
             TBATopAppBar(
                 title = {
                     Text(
                         if (uiState.eventTitle.isNotEmpty()) "${uiState.eventTitle} Pit Map"
-                        else "Pit Map"
+                        else "Pit Map",
                     )
                 },
                 navigationIcon = {
@@ -91,10 +83,8 @@ fun PitMapScreen(
             )
         },
     ) { innerPadding ->
-        val showingFallback = availability == PitMapAvailability.NOT_FOUND && uiState.isLoaded
         when {
-            availability == PitMapAvailability.UNKNOWN ||
-                (availability == PitMapAvailability.NOT_FOUND && !uiState.isLoaded) -> {
+            showSpinner -> {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -104,13 +94,14 @@ fun PitMapScreen(
                     CircularProgressIndicator()
                 }
             }
-            showingFallback -> {
+            showNexusFallback -> {
                 PitMapWebView(
                     pitMapUrl = nexusPitMapUrl,
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(innerPadding),
-                    centerSelector = null, // Nexus is a JS SPA; content renders after onPageFinished
+                    // Nexus is a JS SPA — onPageFinished fires before content renders.
+                    centerSelector = null,
                 )
             }
             else -> {
@@ -127,10 +118,12 @@ fun PitMapScreen(
 }
 
 /**
- * @param pitMapUrl URL to load in the WebView.
- * @param centerSelector Optional CSS selector for the element to center the viewport on after
- *   the page loads. For TBA SVGs this is either `[data-team-key="frcXXX"]` (team pit) or
- *   `[data-label-key="eventKey"]` (division label). Null skips centering.
+ * WebView composable that loads a pit map URL and, once loaded, scrolls to center the element
+ * identified by [centerSelector] (a CSS selector). Pass `null` to skip centering.
+ *
+ * Centering logic mirrors the iOS implementation from
+ * https://github.com/the-blue-alliance/the-blue-alliance-ios/pull/1094 — JS returns the
+ * element's document-space centre, Kotlin scales by the current zoom and calls [WebView.scrollTo].
  */
 @Composable
 private fun PitMapWebView(
@@ -138,12 +131,12 @@ private fun PitMapWebView(
     modifier: Modifier = Modifier,
     centerSelector: String? = null,
 ) {
-    // Array refs so the static WebViewClient can always read the latest values without the
+    // Array refs so the static WebViewClient always sees the latest values without the
     // AndroidView being recreated (which would flash and reset scroll position).
     val latestSelector = remember { arrayOf(centerSelector) }
     latestSelector[0] = centerSelector
     val webViewRef = remember { arrayOf<WebView?>(null) }
-    // Track the current page scale via onScaleChanged (avoids deprecated WebView.scale).
+    // Track the current page scale via onScaleChanged to avoid the deprecated WebView.scale.
     val currentScale = remember { floatArrayOf(1f) }
 
     AndroidView(
@@ -162,12 +155,11 @@ private fun PitMapWebView(
                         val wv = webViewRef[0] ?: run { showWebView(view); return }
                         val selector = latestSelector[0] ?: run { showWebView(wv); return }
 
-                        // Mirror the iOS implementation: wait 400 ms for layout to settle,
-                        // then ask JS for the element's document-space centre coordinates,
-                        // scale by the current zoom and scroll natively — identical math to
-                        // https://github.com/the-blue-alliance/the-blue-alliance-ios/pull/1094
+                        // Wait 400 ms for layout to settle (same delay as the iOS implementation),
+                        // then ask JS for element's document-space centre, scale by current zoom,
+                        // and scroll natively.
                         wv.postDelayed({
-                            // Single-quoted JS string so selector's double-quotes are safe.
+                            // Single-quoted JS string so the selector's double-quotes are safe.
                             val js = """
                                 (() => {
                                   const el = document.querySelector('$selector');
@@ -182,7 +174,7 @@ private fun PitMapWebView(
                             wv.evaluateJavascript(js) { result ->
                                 try {
                                     if (result != null && result != "null") {
-                                        // result arrives as a JSON array string, e.g. "[1234.5,678.9]"
+                                        // result is a JSON array string, e.g. "[1234.5,678.9]"
                                         val coords = result.trim('[', ']')
                                             .split(',')
                                             .map { it.trim().toDouble() }
@@ -209,14 +201,14 @@ private fun PitMapWebView(
                         request: WebResourceRequest?,
                         error: WebResourceError?,
                     ) {
-                        // Silently ignore sub-resource errors; the SVG is self-contained.
-                        // Also ensure WebView becomes visible if we never reach a page finish.
-                        showWebView(view)
+                        // Only act on main-frame errors. Sub-resource errors (images, fonts, etc.)
+                        // are common in SVG maps and should not trigger a visibility change.
+                        if (request?.isForMainFrame == true) showWebView(view)
                     }
                 }
                 settings.apply {
                     // JavaScript is required for evaluateJavascript centering injection.
-                    // This WebView only loads trusted TBA and Nexus URLs.
+                    // This WebView only ever loads trusted TBA and Nexus URLs.
                     @Suppress("SetJavaScriptEnabled")
                     javaScriptEnabled = true
                     useWideViewPort = true
@@ -239,29 +231,7 @@ private fun PitMapWebView(
     )
 }
 
-/** Fades the WebView in, matching the iOS 150 ms fade from the same PR. */
+/** Fades the WebView in over 150 ms, matching the iOS fade in the same PR. */
 private fun showWebView(view: WebView?) {
     view?.animate()?.alpha(1f)?.setDuration(150)?.start()
-}
-
-private fun fetchPitMapAvailability(url: String): PitMapAvailability {
-    return try {
-        val connection = URL(url).openConnection() as HttpURLConnection
-        connection.requestMethod = "HEAD"
-        connection.instanceFollowRedirects = true
-        connection.connectTimeout = 8000
-        connection.readTimeout = 8000
-        connection.connect()
-
-        val responseCode = connection.responseCode
-        connection.disconnect()
-
-        if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
-            PitMapAvailability.NOT_FOUND
-        } else {
-            PitMapAvailability.AVAILABLE
-        }
-    } catch (_: Exception) {
-        PitMapAvailability.UNKNOWN
-    }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapScreen.kt
@@ -1,0 +1,267 @@
+package com.thebluealliance.android.ui.events.detail
+
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.thebluealliance.android.ui.components.TBATopAppBar
+import com.thebluealliance.android.util.buildNexusPitMapUrl
+import com.thebluealliance.android.util.buildTbaPitMapUrl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+
+private enum class PitMapAvailability {
+    AVAILABLE,
+    NOT_FOUND,
+    UNKNOWN,
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PitMapScreen(
+    onNavigateUp: () -> Unit,
+    viewModel: PitMapViewModel,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val pitMapUrl = remember(viewModel.eventKey, viewModel.highlightedTeamKeys) {
+        buildTbaPitMapUrl(viewModel.eventKey, viewModel.highlightedTeamKeys)
+    }
+
+    val availability by produceState<PitMapAvailability>(initialValue = PitMapAvailability.UNKNOWN, pitMapUrl) {
+        value = withContext(Dispatchers.IO) { fetchPitMapAvailability(pitMapUrl) }
+    }
+
+    // When TBA has no pit map, fall back to the Nexus map. Nexus event codes are case-insensitive,
+    // so the lowercase nexusEventCode is fine. We defer until the event has loaded so we have the
+    // correct code (especially important for CMP divisions whose TBA key ≠ FIRST code).
+    val nexusPitMapUrl = remember(uiState.nexusEventCode, viewModel.highlightedTeamKeys) {
+        buildNexusPitMapUrl(uiState.nexusEventCode, viewModel.highlightedTeamKeys.firstOrNull())
+    }
+
+    // CSS selector for the SVG element to center on after load.
+    // TBA SVG uses data-team-key on pit <g> elements and data-label-key on division labels.
+    // Nexus is a JS SPA — onPageFinished fires before content renders, so skip centering there.
+    val tbaCenterSelector = remember(viewModel.eventKey, viewModel.highlightedTeamKeys) {
+        if (viewModel.highlightedTeamKeys.isNotEmpty()) {
+            "[data-team-key=\"${viewModel.highlightedTeamKeys.first()}\"]"
+        } else {
+            "[data-label-key=\"${viewModel.eventKey}\"]"
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TBATopAppBar(
+                title = {
+                    Text(
+                        if (uiState.eventTitle.isNotEmpty()) "${uiState.eventTitle} Pit Map"
+                        else "Pit Map"
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val showingFallback = availability == PitMapAvailability.NOT_FOUND && uiState.isLoaded
+        when {
+            availability == PitMapAvailability.UNKNOWN ||
+                (availability == PitMapAvailability.NOT_FOUND && !uiState.isLoaded) -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            showingFallback -> {
+                PitMapWebView(
+                    pitMapUrl = nexusPitMapUrl,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    centerSelector = null, // Nexus is a JS SPA; content renders after onPageFinished
+                )
+            }
+            else -> {
+                PitMapWebView(
+                    pitMapUrl = pitMapUrl,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    centerSelector = tbaCenterSelector,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * @param pitMapUrl URL to load in the WebView.
+ * @param centerSelector Optional CSS selector for the element to center the viewport on after
+ *   the page loads. For TBA SVGs this is either `[data-team-key="frcXXX"]` (team pit) or
+ *   `[data-label-key="eventKey"]` (division label). Null skips centering.
+ */
+@Composable
+private fun PitMapWebView(
+    pitMapUrl: String,
+    modifier: Modifier = Modifier,
+    centerSelector: String? = null,
+) {
+    // Array refs so the static WebViewClient can always read the latest values without the
+    // AndroidView being recreated (which would flash and reset scroll position).
+    val latestSelector = remember { arrayOf(centerSelector) }
+    latestSelector[0] = centerSelector
+    val webViewRef = remember { arrayOf<WebView?>(null) }
+    // Track the current page scale via onScaleChanged (avoids deprecated WebView.scale).
+    val currentScale = remember { floatArrayOf(1f) }
+
+    AndroidView(
+        factory = { context ->
+            WebView(context).apply {
+                webViewRef[0] = this
+                // Hide until centering is done to avoid showing the map at the wrong position.
+                alpha = 0f
+
+                webViewClient = object : WebViewClient() {
+                    override fun onScaleChanged(view: WebView?, oldScale: Float, newScale: Float) {
+                        currentScale[0] = newScale
+                    }
+
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        val wv = webViewRef[0] ?: run { showWebView(view); return }
+                        val selector = latestSelector[0] ?: run { showWebView(wv); return }
+
+                        // Mirror the iOS implementation: wait 400 ms for layout to settle,
+                        // then ask JS for the element's document-space centre coordinates,
+                        // scale by the current zoom and scroll natively — identical math to
+                        // https://github.com/the-blue-alliance/the-blue-alliance-ios/pull/1094
+                        wv.postDelayed({
+                            // Single-quoted JS string so selector's double-quotes are safe.
+                            val js = """
+                                (() => {
+                                  const el = document.querySelector('$selector');
+                                  if (!el) return null;
+                                  const rect = el.getBoundingClientRect();
+                                  return [
+                                    rect.left + window.scrollX + rect.width  / 2,
+                                    rect.top  + window.scrollY + rect.height / 2,
+                                  ];
+                                })()
+                            """.trimIndent()
+                            wv.evaluateJavascript(js) { result ->
+                                try {
+                                    if (result != null && result != "null") {
+                                        // result arrives as a JSON array string, e.g. "[1234.5,678.9]"
+                                        val coords = result.trim('[', ']')
+                                            .split(',')
+                                            .map { it.trim().toDouble() }
+                                        if (coords.size >= 2) {
+                                            val zoom = currentScale[0]
+                                            val targetX = (coords[0] * zoom - wv.width  / 2)
+                                                .toInt().coerceAtLeast(0)
+                                            val targetY = (coords[1] * zoom - wv.height / 2)
+                                                .toInt().coerceAtLeast(0)
+                                            wv.scrollTo(targetX, targetY)
+                                        }
+                                    }
+                                } catch (_: Exception) {
+                                    // Ignore parse errors; the map is still usable without centering.
+                                } finally {
+                                    showWebView(wv)
+                                }
+                            }
+                        }, 400L)
+                    }
+
+                    override fun onReceivedError(
+                        view: WebView?,
+                        request: WebResourceRequest?,
+                        error: WebResourceError?,
+                    ) {
+                        // Silently ignore sub-resource errors; the SVG is self-contained.
+                        // Also ensure WebView becomes visible if we never reach a page finish.
+                        showWebView(view)
+                    }
+                }
+                settings.apply {
+                    // JavaScript is required for evaluateJavascript centering injection.
+                    // This WebView only loads trusted TBA and Nexus URLs.
+                    @Suppress("SetJavaScriptEnabled")
+                    javaScriptEnabled = true
+                    useWideViewPort = true
+                    loadWithOverviewMode = true
+                    builtInZoomControls = true
+                    displayZoomControls = false
+                    setSupportZoom(true)
+                }
+                loadUrl(pitMapUrl)
+            }
+        },
+        update = { webView ->
+            webViewRef[0] = webView
+            if (webView.url != pitMapUrl) {
+                webView.alpha = 0f
+                webView.loadUrl(pitMapUrl)
+            }
+        },
+        modifier = modifier,
+    )
+}
+
+/** Fades the WebView in, matching the iOS 150 ms fade from the same PR. */
+private fun showWebView(view: WebView?) {
+    view?.animate()?.alpha(1f)?.setDuration(150)?.start()
+}
+
+private fun fetchPitMapAvailability(url: String): PitMapAvailability {
+    return try {
+        val connection = URL(url).openConnection() as HttpURLConnection
+        connection.requestMethod = "HEAD"
+        connection.instanceFollowRedirects = true
+        connection.connectTimeout = 8000
+        connection.readTimeout = 8000
+        connection.connect()
+
+        val responseCode = connection.responseCode
+        connection.disconnect()
+
+        if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+            PitMapAvailability.NOT_FOUND
+        } else {
+            PitMapAvailability.AVAILABLE
+        }
+    } catch (_: Exception) {
+        PitMapAvailability.UNKNOWN
+    }
+}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapViewModel.kt
@@ -1,0 +1,64 @@
+package com.thebluealliance.android.ui.events.detail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.thebluealliance.android.data.repository.EventRepository
+import com.thebluealliance.android.navigation.Screen
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+data class PitMapUiState(
+    /** Screen title, formatted as "2026 EventShort" once loaded. Empty until event loads. */
+    val eventTitle: String = "",
+    /** Pre-formatted Nexus event code, e.g. "2026MIKET". Empty string until event loads. */
+    val nexusEventCode: String = "",
+    val isLoaded: Boolean = false,
+)
+
+@HiltViewModel(assistedFactory = PitMapViewModel.Factory::class)
+class PitMapViewModel
+    @AssistedInject
+    constructor(
+        @Assisted val navKey: Screen.PitMap,
+        private val eventRepository: EventRepository,
+    ) : ViewModel() {
+        val eventKey: String = navKey.eventKey
+        val highlightedTeamKeys: List<String> = navKey.highlightedTeamKeys
+
+        val uiState: StateFlow<PitMapUiState> =
+            eventRepository
+                .observeEvent(eventKey)
+                .map { event ->
+                    if (event == null) {
+                        PitMapUiState()
+                    } else {
+                        val nexusCode =
+                            if (!event.firstEventCode.isNullOrBlank()) {
+                                "${event.year}${event.firstEventCode.uppercase()}"
+                            } else {
+                                "${event.year}${eventKey.drop(4).uppercase()}"
+                            }
+                        PitMapUiState(
+                            eventTitle = "${event.year} ${event.shortName ?: event.name}",
+                            nexusEventCode = nexusCode,
+                            isLoaded = true,
+                        )
+                    }
+                }.stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(5_000),
+                    initialValue = PitMapUiState(),
+                )
+
+        @AssistedFactory
+        interface Factory {
+            fun create(navKey: Screen.PitMap): PitMapViewModel
+        }
+    }
+

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapViewModel.kt
@@ -4,19 +4,27 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.thebluealliance.android.data.repository.EventRepository
 import com.thebluealliance.android.navigation.Screen
+import com.thebluealliance.android.util.buildNexusEventCode
+import com.thebluealliance.android.util.buildTbaPitMapUrl
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.net.HttpURLConnection
+import java.net.URL
 
 data class PitMapUiState(
-    /** Screen title, formatted as "2026 EventShort" once loaded. Empty until event loads. */
+    /** Screen title, formatted as "2026 EventShort" once the event loads. Empty until then. */
     val eventTitle: String = "",
-    /** Pre-formatted Nexus event code, e.g. "2026MIKET". Empty string until event loads. */
+    /** Pre-formatted Nexus event code, e.g. "2026MIKET". Empty until event loads. */
     val nexusEventCode: String = "",
     val isLoaded: Boolean = false,
 )
@@ -25,11 +33,21 @@ data class PitMapUiState(
 class PitMapViewModel
     @AssistedInject
     constructor(
-        @Assisted val navKey: Screen.PitMap,
+        @Assisted private val navKey: Screen.PitMap,
         private val eventRepository: EventRepository,
     ) : ViewModel() {
         val eventKey: String = navKey.eventKey
         val highlightedTeamKeys: List<String> = navKey.highlightedTeamKeys
+
+        private val _tbaMapAvailable = MutableStateFlow<Boolean?>(null)
+
+        /**
+         * Whether the TBA pit map exists for this event.
+         * - `null`  = HEAD check in progress
+         * - `true`  = TBA map available; load it in the WebView
+         * - `false` = Not found; fall back to Nexus
+         */
+        val tbaMapAvailable: StateFlow<Boolean?> = _tbaMapAvailable.asStateFlow()
 
         val uiState: StateFlow<PitMapUiState> =
             eventRepository
@@ -38,15 +56,9 @@ class PitMapViewModel
                     if (event == null) {
                         PitMapUiState()
                     } else {
-                        val nexusCode =
-                            if (!event.firstEventCode.isNullOrBlank()) {
-                                "${event.year}${event.firstEventCode.uppercase()}"
-                            } else {
-                                "${event.year}${eventKey.drop(4).uppercase()}"
-                            }
                         PitMapUiState(
                             eventTitle = "${event.year} ${event.shortName ?: event.name}",
-                            nexusEventCode = nexusCode,
+                            nexusEventCode = buildNexusEventCode(eventKey, event.year, event.firstEventCode),
                             isLoaded = true,
                         )
                     }
@@ -56,9 +68,39 @@ class PitMapViewModel
                     initialValue = PitMapUiState(),
                 )
 
+        init {
+            // Run the availability HEAD check on IO so the UI layer stays free of network calls.
+            viewModelScope.launch(Dispatchers.IO) {
+                _tbaMapAvailable.value = checkTbaPitMapAvailable(
+                    buildTbaPitMapUrl(eventKey, highlightedTeamKeys),
+                )
+            }
+        }
+
         @AssistedFactory
         interface Factory {
             fun create(navKey: Screen.PitMap): PitMapViewModel
         }
     }
 
+/**
+ * Returns `true` if the TBA pit map endpoint responds with anything other than HTTP 404.
+ * On any network failure we return `true` optimistically and let the WebView handle errors
+ * rather than leaving the UI stuck on a spinner indefinitely.
+ */
+private fun checkTbaPitMapAvailable(url: String): Boolean =
+    try {
+        val connection = URL(url).openConnection() as HttpURLConnection
+        connection.requestMethod = "HEAD"
+        connection.instanceFollowRedirects = true
+        connection.connectTimeout = 8_000
+        connection.readTimeout = 8_000
+        connection.connect()
+        val responseCode = connection.responseCode
+        connection.disconnect()
+        responseCode != HttpURLConnection.HTTP_NOT_FOUND
+    } catch (_: Exception) {
+        // No connectivity or unexpected error — optimistically try TBA; WebView will surface any
+        // further errors natively.
+        true
+    }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/PitMapViewModel.kt
@@ -58,7 +58,12 @@ class PitMapViewModel
                     } else {
                         PitMapUiState(
                             eventTitle = "${event.year} ${event.shortName ?: event.name}",
-                            nexusEventCode = buildNexusEventCode(eventKey, event.year, event.firstEventCode),
+                            nexusEventCode =
+                                buildNexusEventCode(
+                                    eventKey,
+                                    event.year,
+                                    event.firstEventCode,
+                                ),
                             isLoaded = true,
                         )
                     }
@@ -71,9 +76,10 @@ class PitMapViewModel
         init {
             // Run the availability HEAD check on IO so the UI layer stays free of network calls.
             viewModelScope.launch(Dispatchers.IO) {
-                _tbaMapAvailable.value = checkTbaPitMapAvailable(
-                    buildTbaPitMapUrl(eventKey, highlightedTeamKeys),
-                )
+                _tbaMapAvailable.value =
+                    checkTbaPitMapAvailable(
+                        buildTbaPitMapUrl(eventKey, highlightedTeamKeys),
+                    )
             }
         }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -22,8 +22,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.thebluealliance.android.R
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.Webcast
 import com.thebluealliance.android.ui.common.LoadingBox
@@ -34,8 +37,11 @@ import com.thebluealliance.android.util.openUrl
 fun EventInfoTab(
     event: Event?,
     districtDisplayName: String? = null,
+    pitLocations: Map<String, String> = emptyMap(),
+    favoriteTeamKeys: List<String> = emptyList(),
     innerPadding: PaddingValues = PaddingValues.Zero,
     onNavigateToDistrict: (String) -> Unit = {},
+    onNavigateToPitMap: (eventKey: String, highlightedTeamKeys: List<String>) -> Unit = { _, _ -> },
 ) {
     if (event == null) {
         LoadingBox(
@@ -159,6 +165,34 @@ fun EventInfoTab(
                     Spacer(Modifier.width(8.dp))
                     Text(
                         text = event.website,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+
+        // Pit Map link (shown when any team has a pit location)
+        if (pitLocations.isNotEmpty()) {
+            item {
+                Row(
+                    modifier =
+                        Modifier
+                            .padding(top = 8.dp)
+                            .clickable {
+                                onNavigateToPitMap(event.key, favoriteTeamKeys)
+                            },
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_nexus_logo),
+                        contentDescription = "FRC Nexus",
+                        tint = Color.Unspecified,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = "Pit Map",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.primary,
                     )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
@@ -35,9 +37,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.thebluealliance.android.R
 import com.thebluealliance.android.domain.model.Alliance
 import com.thebluealliance.android.domain.model.Award
 import com.thebluealliance.android.domain.model.CmpAdvancement
@@ -81,6 +85,7 @@ fun TeamEventDetailScreen(
     onNavigateToTeam: (String) -> Unit,
     onNavigateToEvent: (eventKey: String, initialTab: EventDetailTab) -> Unit,
     onNavigateToSearch: () -> Unit,
+    onNavigateToPitMap: (eventKey: String, highlightedTeamKeys: List<String>) -> Unit = { _, _ -> },
     viewModel: TeamEventDetailViewModel,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -213,6 +218,7 @@ fun TeamEventDetailScreen(
                             onNavigateToEvent = onNavigateToEvent,
                             onNavigateToTeam = onNavigateToTeam,
                             onNavigateToMatch = onNavigateToMatch,
+                            onNavigateToPitMap = onNavigateToPitMap,
                             innerPadding = bottomPadding,
                         )
                     TeamEventDetailTabs.MATCHES -> {
@@ -303,6 +309,7 @@ private fun SummaryTab(
     onNavigateToEvent: (eventKey: String, initialTab: EventDetailTab) -> Unit,
     onNavigateToTeam: (String) -> Unit,
     onNavigateToMatch: (String) -> Unit,
+    onNavigateToPitMap: (eventKey: String, highlightedTeamKeys: List<String>) -> Unit = { _, _ -> },
     innerPadding: PaddingValues = PaddingValues.Zero,
 ) {
     LazyColumn(
@@ -403,14 +410,19 @@ private fun SummaryTab(
                 item(key = "summary_pit_location_divider") { HorizontalDivider() }
             }
             item(key = "summary_pit_location") {
-                val context = LocalContext.current
-                val teamNumber = teamKey.removePrefix("frc")
                 InfoRow(
                     label = "Pit Location",
-                    labelSuffix = "(via FRC Nexus)",
+                    labelLeadingIcon = {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_nexus_logo),
+                            contentDescription = "FRC Nexus",
+                            tint = Color.Unspecified,
+                            modifier = Modifier.size(16.dp),
+                        )
+                    },
                     value = pitLocation,
                     onClick = {
-                        context.openUrl("https://frc.nexus/en/event/$eventKey/team/$teamNumber/map")
+                        onNavigateToPitMap(eventKey, listOf(teamKey))
                     },
                 )
             }
@@ -546,7 +558,7 @@ private fun SummarySection(
 @Composable
 private fun InfoRow(
     label: String,
-    labelSuffix: String? = null,
+    labelLeadingIcon: (@Composable () -> Unit)? = null,
     value: String,
     onClick: () -> Unit,
 ) {
@@ -558,17 +570,18 @@ private fun InfoRow(
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(modifier = Modifier.weight(1f)) {
+        Row(
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (labelLeadingIcon != null) {
+                labelLeadingIcon()
+                Spacer(Modifier.width(6.dp))
+            }
             Text(
                 text = label,
                 style = MaterialTheme.typography.titleMedium,
             )
-            if (labelSuffix != null) {
-                Text(
-                    text = " $labelSuffix",
-                    style = MaterialTheme.typography.titleMedium,
-                )
-            }
         }
         Text(
             text = value,

--- a/app/src/main/kotlin/com/thebluealliance/android/util/PitMapUrls.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/util/PitMapUrls.kt
@@ -1,0 +1,31 @@
+package com.thebluealliance.android.util
+
+private const val TBA_EVENT_BASE_URL = "https://www.thebluealliance.com/event"
+private const val NEXUS_EVENT_BASE_URL = "https://frc.nexus/en/event"
+
+fun buildTbaPitMapUrl(
+    eventKey: String,
+    highlightedTeamKeys: List<String> = emptyList(),
+): String {
+    val normalizedKeys =
+        highlightedTeamKeys
+            .map { it.trim() }
+            .filter { it.startsWith("frc") }
+            .distinct()
+    val base = "$TBA_EVENT_BASE_URL/$eventKey/pitmap"
+    if (normalizedKeys.isEmpty()) return base
+    return "$base?teams=${normalizedKeys.joinToString(",")}"
+}
+
+fun buildNexusPitMapUrl(
+    eventKey: String,
+    highlightedTeamKey: String? = null,
+): String {
+    val teamNumber = highlightedTeamKey?.removePrefix("frc")?.takeIf { it.isNotBlank() }
+    return if (teamNumber == null) {
+        "$NEXUS_EVENT_BASE_URL/$eventKey/map"
+    } else {
+        "$NEXUS_EVENT_BASE_URL/$eventKey/team/$teamNumber/map"
+    }
+}
+

--- a/app/src/main/kotlin/com/thebluealliance/android/util/PitMapUrls.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/util/PitMapUrls.kt
@@ -29,3 +29,16 @@ fun buildNexusPitMapUrl(
     }
 }
 
+/**
+ * Builds the Nexus event code (e.g. `"2026MIKET"`) from TBA event data.
+ *
+ * For most events the code is just the year prepended to the event-key suffix. Championship
+ * divisions have a different FIRST API code (e.g. TBA key `2026cmptxcur` uses FIRST code `CUR`),
+ * which the API returns as [firstEventCode] and must be preferred when present.
+ */
+fun buildNexusEventCode(eventKey: String, year: Int, firstEventCode: String?): String =
+    if (!firstEventCode.isNullOrBlank()) {
+        "$year${firstEventCode.uppercase()}"
+    } else {
+        "$year${eventKey.drop(4).uppercase()}"
+    }

--- a/app/src/main/kotlin/com/thebluealliance/android/util/PitMapUrls.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/util/PitMapUrls.kt
@@ -36,7 +36,11 @@ fun buildNexusPitMapUrl(
  * divisions have a different FIRST API code (e.g. TBA key `2026cmptxcur` uses FIRST code `CUR`),
  * which the API returns as [firstEventCode] and must be preferred when present.
  */
-fun buildNexusEventCode(eventKey: String, year: Int, firstEventCode: String?): String =
+fun buildNexusEventCode(
+    eventKey: String,
+    year: Int,
+    firstEventCode: String?,
+): String =
     if (!firstEventCode.isNullOrBlank()) {
         "$year${firstEventCode.uppercase()}"
     } else {

--- a/app/src/main/res/drawable/ic_nexus_logo.xml
+++ b/app/src/main/res/drawable/ic_nexus_logo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  FRC Nexus star icon. Path and gradient reproduced verbatim from the official SVG at
+  https://frc.nexus/en/assets/images/icon.svg (viewBox 0 0 86 86).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="86"
+    android:viewportHeight="86">
+
+    <path
+        android:pathData="M41.0447 2.08864C41.4978 -0.0171729 44.5022 -0.0171749 44.9553 2.08864L49.4708 23.0783C49.765 24.4458 51.3362 25.0966 52.5112 24.3376L70.5461 12.6887C72.3555 11.52 74.48 13.6445 73.3113 15.4539L61.6624 33.4888C60.9034 34.6638 61.5542 36.235 62.9217 36.5292L83.9114 41.0447C86.0172 41.4978 86.0172 44.5022 83.9114 44.9553L62.9217 49.4708C61.5542 49.765 60.9034 51.3362 61.6624 52.5112L73.3113 70.5461C74.48 72.3555 72.3555 74.48 70.5461 73.3113L52.5112 61.6624C51.3362 60.9034 49.765 61.5542 49.4708 62.9217L44.9553 83.9114C44.5022 86.0172 41.4978 86.0172 41.0447 83.9114L36.5292 62.9217C36.235 61.5542 34.6638 60.9034 33.4888 61.6624L15.4539 73.3113C13.6445 74.48 11.52 72.3555 12.6887 70.5461L24.3376 52.5112C25.0966 51.3362 24.4458 49.765 23.0783 49.4708L2.08864 44.9553C-0.0171729 44.5022 -0.0171749 41.4978 2.08864 41.0447L23.0783 36.5292C24.4458 36.235 25.0966 34.6638 24.3376 33.4888L12.6887 15.4539C11.52 13.6445 13.6445 11.52 15.4539 12.6887L33.4888 24.3376C34.6638 25.0966 36.235 24.4458 36.5292 23.0783L41.0447 2.08864Z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:startX="35.6147"
+                android:startY="24.246"
+                android:endX="50.9101"
+                android:endY="61.9304"
+                android:type="linear">
+                <item android:offset="0" android:color="#FF0d6efd" />
+                <item android:offset="1" android:color="#FFdc3545" />
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>
+

--- a/app/src/test/kotlin/com/thebluealliance/android/navigation/DeeplinkMatcherTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/navigation/DeeplinkMatcherTest.kt
@@ -1,0 +1,38 @@
+package com.thebluealliance.android.navigation
+
+import android.net.Uri
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DeeplinkMatcherTest {
+    private val matcher = DeeplinkMatcher()
+
+    @Test
+    fun `event pitmap deeplink maps to pit map screen`() {
+        val uri = mockk<Uri>()
+        every { uri.pathSegments } returns listOf("event", "2026miket", "pitmap")
+        every { uri.getQueryParameter("teams") } returns "frc254,frc1678"
+
+        val result =
+            matcher.match(uri)
+
+        assertTrue(result is Screen.EventPitMap)
+        val pitMap = result as Screen.EventPitMap
+        assertEquals("2026miket", pitMap.eventKey)
+        assertEquals("frc254,frc1678", pitMap.teamsCsv)
+    }
+
+    @Test
+    fun `event detail deeplink remains unchanged`() {
+        val uri = mockk<Uri>()
+        every { uri.pathSegments } returns listOf("event", "2026miket")
+
+        val result = matcher.match(uri)
+
+        assertEquals(Screen.EventDetail("2026miket"), result)
+    }
+}
+

--- a/app/src/test/kotlin/com/thebluealliance/android/navigation/DeeplinkMatcherTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/navigation/DeeplinkMatcherTest.kt
@@ -35,4 +35,3 @@ class DeeplinkMatcherTest {
         assertEquals(Screen.EventDetail("2026miket"), result)
     }
 }
-

--- a/app/src/test/kotlin/com/thebluealliance/android/util/PitMapUrlsTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/util/PitMapUrlsTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class PitMapUrlsTest {
-
     // ── buildTbaPitMapUrl ────────────────────────────────────────────────────
 
     @Test

--- a/app/src/test/kotlin/com/thebluealliance/android/util/PitMapUrlsTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/util/PitMapUrlsTest.kt
@@ -1,0 +1,38 @@
+package com.thebluealliance.android.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PitMapUrlsTest {
+    @Test
+    fun `build tba pit map url with no teams`() {
+        assertEquals(
+            "https://www.thebluealliance.com/event/2026miket/pitmap",
+            buildTbaPitMapUrl("2026miket"),
+        )
+    }
+
+    @Test
+    fun `build tba pit map url with filtered teams`() {
+        assertEquals(
+            "https://www.thebluealliance.com/event/2026miket/pitmap?teams=frc33,frc67",
+            buildTbaPitMapUrl("2026miket", listOf(" frc33 ", "frc67", "67", "frc33")),
+        )
+    }
+
+    @Test
+    fun `build nexus pit map url for event`() {
+        assertEquals(
+            "https://frc.nexus/en/event/2026miket/map",
+            buildNexusPitMapUrl("2026miket"),
+        )
+    }
+
+    @Test
+    fun `build nexus pit map url for team highlight`() {
+        assertEquals(
+            "https://frc.nexus/en/event/2026miket/team/254/map",
+            buildNexusPitMapUrl("2026miket", "frc254"),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/thebluealliance/android/util/PitMapUrlsTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/util/PitMapUrlsTest.kt
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class PitMapUrlsTest {
+
+    // ── buildTbaPitMapUrl ────────────────────────────────────────────────────
+
     @Test
     fun `build tba pit map url with no teams`() {
         assertEquals(
@@ -20,6 +23,8 @@ class PitMapUrlsTest {
         )
     }
 
+    // ── buildNexusPitMapUrl ──────────────────────────────────────────────────
+
     @Test
     fun `build nexus pit map url for event`() {
         assertEquals(
@@ -34,5 +39,41 @@ class PitMapUrlsTest {
             "https://frc.nexus/en/event/2026miket/team/254/map",
             buildNexusPitMapUrl("2026miket", "frc254"),
         )
+    }
+
+    @Test
+    fun `build nexus pit map url ignores blank team key`() {
+        assertEquals(
+            "https://frc.nexus/en/event/2026miket/map",
+            buildNexusPitMapUrl("2026miket", "frc"),
+        )
+    }
+
+    // ── buildNexusEventCode ──────────────────────────────────────────────────
+
+    @Test
+    fun `build nexus event code falls back to event key suffix for regular event`() {
+        assertEquals("2026MIKET", buildNexusEventCode("2026miket", 2026, null))
+    }
+
+    @Test
+    fun `build nexus event code uses first_event_code for cmp division`() {
+        // TBA key "2026cmptxcur" maps to FIRST code "CUR" via firstEventCode
+        assertEquals("2026CUR", buildNexusEventCode("2026cmptxcur", 2026, "CUR"))
+    }
+
+    @Test
+    fun `build nexus event code uppercases first_event_code`() {
+        assertEquals("2026CUR", buildNexusEventCode("2026cmptxcur", 2026, "cur"))
+    }
+
+    @Test
+    fun `build nexus event code ignores blank first_event_code`() {
+        assertEquals("2026MIKET", buildNexusEventCode("2026miket", 2026, "   "))
+    }
+
+    @Test
+    fun `build nexus event code ignores empty first_event_code`() {
+        assertEquals("2026MIKET", buildNexusEventCode("2026miket", 2026, ""))
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Now that we can serve up rendered pit maps, let's show them in the app

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/d06ec632-1a9d-4a96-a91c-f91bcc224fc5" />


<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/0634814f-e7ec-4fbe-b339-ebaa26647951" />


<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/9598d103-8be3-425c-90eb-1653eed06313" />
