### PR TITLE
fix: auto-scroll events list to Championship section

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/Event.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/Event.kt
@@ -1,5 +1,20 @@
 package com.thebluealliance.android.domain.model
 
+/** TBA API event type constants. */
+object EventType {
+    const val REGIONAL = 0
+    const val DISTRICT = 1
+    const val DISTRICT_CHAMPIONSHIP = 2
+    const val CHAMPIONSHIP_DIVISION = 3
+    const val CHAMPIONSHIP_FINALS = 4
+    const val DISTRICT_CHAMPIONSHIP_DIVISION = 5
+    const val OFFSEASON = 99
+    const val PRESEASON = 100
+
+    /** Championship division or finals. */
+    val CHAMPIONSHIP_TYPES = listOf(CHAMPIONSHIP_DIVISION, CHAMPIONSHIP_FINALS)
+}
+
 data class Event(
     val key: String,
     val name: String,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.Event
+import com.thebluealliance.android.domain.model.EventType
 import com.thebluealliance.android.ui.components.EventRow
 import com.thebluealliance.android.ui.components.FastScrollbar
 import com.thebluealliance.android.ui.components.TBATopAppBar
@@ -534,7 +535,7 @@ private fun currentWeekChipLabel(
     // Check for active championship events (types 3/4 have week == null)
     val championshipActive =
         allEvents.any { event ->
-            event.type in listOf(3, 4) &&
+            event.type in EventType.CHAMPIONSHIP_TYPES &&
                 event.startDate?.let { !today.isBefore(LocalDate.parse(it)) } == true &&
                 event.endDate?.let { !today.isAfter(LocalDate.parse(it)) } == true
         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -521,13 +521,24 @@ private fun SubSectionHeader(label: String) {
     }
 }
 
-/** Returns the chip label for the current competition week, or null. */
+/** Returns the chip label for the current competition week or championship, or null. */
 private fun currentWeekChipLabel(
     allEvents: List<Event>,
     today: LocalDate,
     selectedYear: Int,
 ): String? {
     if (selectedYear != today.year) return null
-    val week = findCurrentCompetitionWeek(allEvents, today) ?: return null
-    return "Week ${week + 1}"
+    val week = findCurrentCompetitionWeek(allEvents, today)
+    if (week != null) return "Week ${week + 1}"
+
+    // Check for active championship events (types 3/4 have week == null)
+    val championshipActive =
+        allEvents.any { event ->
+            event.type in listOf(3, 4) &&
+                event.startDate?.let { !today.isBefore(LocalDate.parse(it)) } == true &&
+                event.endDate?.let { !today.isAfter(LocalDate.parse(it)) } == true
+        }
+    if (championshipActive) return "Championship"
+
+    return null
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
@@ -1,6 +1,7 @@
 package com.thebluealliance.android.ui.events
 
 import com.thebluealliance.android.domain.model.Event
+import com.thebluealliance.android.domain.model.EventType
 import com.thebluealliance.android.ui.components.SectionHeaderInfo
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -42,13 +43,17 @@ private fun eventSectionKey(
     preseasonOver: Boolean,
 ): SectionKey {
     return when (event.type) {
-        100 -> if (preseasonOver) SectionKey(1500, "Preseason") else SectionKey(-1, "Preseason")
-        0, 1, 2, 5 -> {
+        EventType.PRESEASON ->
+            if (preseasonOver) SectionKey(1500, "Preseason") else SectionKey(-1, "Preseason")
+        EventType.REGIONAL, EventType.DISTRICT, EventType.DISTRICT_CHAMPIONSHIP,
+        EventType.DISTRICT_CHAMPIONSHIP_DIVISION,
+        -> {
             val week = event.week ?: return SectionKey(9999, "Other events")
             SectionKey(week, "Week ${week + 1}")
         }
-        3, 4 -> SectionKey(1000, "Championship")
-        99 -> SectionKey(2000, "Offseason")
+        EventType.CHAMPIONSHIP_DIVISION, EventType.CHAMPIONSHIP_FINALS ->
+            SectionKey(1000, "Championship")
+        EventType.OFFSEASON -> SectionKey(2000, "Offseason")
         else -> {
             // Unknown type but has a week — group with regular weeks
             if (event.week != null) {
@@ -70,7 +75,7 @@ fun buildEventSections(
 ): List<EventSection> {
     val lastPreseasonEnd =
         events
-            .filter { it.type == 100 }
+            .filter { it.type == EventType.PRESEASON }
             .mapNotNull { it.endDate?.let { d -> runCatching { LocalDate.parse(d) }.getOrNull() } }
             .maxOrNull()
     val preseasonOver = lastPreseasonEnd != null && today.isAfter(lastPreseasonEnd)
@@ -93,16 +98,16 @@ private fun buildSubSections(
     buildList {
         val regionals =
             events
-                .filter { it.district == null && it.type == 0 }
+                .filter { it.district == null && it.type == EventType.REGIONAL }
                 .sortedBy { it.name }
         if (regionals.isNotEmpty()) {
             add(EventSubSection("Regional Events", regionals))
         }
 
-        val others = events.filter { it.district == null && it.type != 0 }
+        val others = events.filter { it.district == null && it.type != EventType.REGIONAL }
         if (others.isNotEmpty()) {
-            val offseasons = others.filter { it.type == 99 }
-            val nonOffseasonOthers = others.filter { it.type != 99 }
+            val offseasons = others.filter { it.type == EventType.OFFSEASON }
+            val nonOffseasonOthers = others.filter { it.type != EventType.OFFSEASON }
 
             if (offseasons.isNotEmpty()) {
                 offseasons
@@ -225,7 +230,7 @@ fun computeThisWeekEvents(
         val championshipEvents =
             if (weekStartDate != null && weekEndDate != null) {
                 allEvents.filter { event ->
-                    event.type in listOf(3, 4) &&
+                    event.type in EventType.CHAMPIONSHIP_TYPES &&
                         event.week == null &&
                         datesOverlap(event, weekStartDate, weekEndDate)
                 }

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
@@ -1,6 +1,7 @@
 package com.thebluealliance.android.ui.events
 
 import com.thebluealliance.android.domain.model.Event
+import com.thebluealliance.android.domain.model.EventType
 import com.thebluealliance.android.domain.model.PlayoffType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -13,7 +14,7 @@ class EventsUiStateTest {
         key: String = "2026test",
         name: String = "Test Event",
         year: Int = 2026,
-        type: Int? = 0,
+        type: Int? = EventType.REGIONAL,
         week: Int? = null,
         startDate: String? = null,
         endDate: String? = null,
@@ -171,7 +172,7 @@ class EventsUiStateTest {
     fun `regional events have Regional Events sub-section label`() {
         val events =
             listOf(
-                makeEvent(name = "Regional 1", type = 0, week = 0),
+                makeEvent(name = "Regional 1", type = EventType.REGIONAL, week = 0),
             )
         val sections = buildEventSections(events)
         val week1 = sections.first { it.label == "Week 1" }
@@ -184,7 +185,7 @@ class EventsUiStateTest {
     fun `championship events have empty sub-section label`() {
         val events =
             listOf(
-                makeEvent(name = "CMP", type = 3, week = null),
+                makeEvent(name = "CMP", type = EventType.CHAMPIONSHIP_DIVISION, week = null),
             )
         val sections = buildEventSections(events)
         val cmp = sections.first { it.label == "Championship" }
@@ -197,7 +198,12 @@ class EventsUiStateTest {
     fun `district events use district name or fallback`() {
         val events =
             listOf(
-                makeEvent(name = "District Event", type = 1, week = 0, district = "2026ne"),
+                makeEvent(
+                    name = "District Event",
+                    type = EventType.DISTRICT,
+                    week = 0,
+                    district = "2026ne",
+                ),
             )
         val sections = buildEventSections(events, districtNames = mapOf("2026ne" to "New England"))
         val week1 = sections.first { it.label == "Week 1" }
@@ -215,20 +221,20 @@ class EventsUiStateTest {
             listOf(
                 makeEvent(
                     key = "2026pre1",
-                    type = 100,
+                    type = EventType.PRESEASON,
                     startDate = "2026-02-14",
                     endDate = "2026-02-21",
                 ),
                 makeEvent(
                     key = "2026wk1",
-                    type = 0,
+                    type = EventType.REGIONAL,
                     week = 0,
                     startDate = "2026-03-04",
                     endDate = "2026-03-07",
                 ),
                 makeEvent(
                     key = "2026cmp",
-                    type = 3,
+                    type = EventType.CHAMPIONSHIP_DIVISION,
                     startDate = "2026-04-15",
                     endDate = "2026-04-18",
                 ),
@@ -247,26 +253,26 @@ class EventsUiStateTest {
             listOf(
                 makeEvent(
                     key = "2026pre1",
-                    type = 100,
+                    type = EventType.PRESEASON,
                     startDate = "2026-02-14",
                     endDate = "2026-02-21",
                 ),
                 makeEvent(
                     key = "2026wk1",
-                    type = 0,
+                    type = EventType.REGIONAL,
                     week = 0,
                     startDate = "2026-03-04",
                     endDate = "2026-03-07",
                 ),
                 makeEvent(
                     key = "2026cmp",
-                    type = 3,
+                    type = EventType.CHAMPIONSHIP_DIVISION,
                     startDate = "2026-04-15",
                     endDate = "2026-04-18",
                 ),
                 makeEvent(
                     key = "2026off1",
-                    type = 99,
+                    type = EventType.OFFSEASON,
                     startDate = "2026-07-15",
                     endDate = "2026-07-17",
                 ),


### PR DESCRIPTION
## Summary
- `currentWeekChipLabel()` only checked `findCurrentCompetitionWeek()`, which filters to events with a non-null `week` field. Championship events (types 3/4) have `week == null`, so they were invisible to the auto-scroll logic.
- Now falls back to checking for active championship events when no regular-season week is current.
- Adds `EventType` constants to replace magic numbers across the events UI code and tests.

## Test plan
- [x] Verified on emulator with championship event running today (Apr 29 - May 2)
- [x] Championship chip correctly highlighted on load
- [x] All existing unit tests pass
- [x] Test with production data to verify scroll past weeks 1-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)