### PR TITLE
fix: auto-scroll events list to Offseason once season has ended

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/Event.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/Event.kt
@@ -13,6 +13,17 @@ object EventType {
 
     /** Championship division or finals. */
     val CHAMPIONSHIP_TYPES = listOf(CHAMPIONSHIP_DIVISION, CHAMPIONSHIP_FINALS)
+
+    /** Official-season event types — excludes preseason and offseason. */
+    val OFFICIAL_TYPES =
+        listOf(
+            REGIONAL,
+            DISTRICT,
+            DISTRICT_CHAMPIONSHIP,
+            CHAMPIONSHIP_DIVISION,
+            CHAMPIONSHIP_FINALS,
+            DISTRICT_CHAMPIONSHIP_DIVISION,
+        )
 }
 
 data class Event(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -53,8 +53,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.thebluealliance.android.domain.model.Event
-import com.thebluealliance.android.domain.model.EventType
 import com.thebluealliance.android.ui.components.EventRow
 import com.thebluealliance.android.ui.components.FastScrollbar
 import com.thebluealliance.android.ui.components.TBATopAppBar
@@ -520,26 +518,4 @@ private fun SubSectionHeader(label: String) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
-}
-
-/** Returns the chip label for the current competition week or championship, or null. */
-private fun currentWeekChipLabel(
-    allEvents: List<Event>,
-    today: LocalDate,
-    selectedYear: Int,
-): String? {
-    if (selectedYear != today.year) return null
-    val week = findCurrentCompetitionWeek(allEvents, today)
-    if (week != null) return "Week ${week + 1}"
-
-    // Check for active championship events (types 3/4 have week == null)
-    val championshipActive =
-        allEvents.any { event ->
-            event.type in EventType.CHAMPIONSHIP_TYPES &&
-                event.startDate?.let { !today.isBefore(LocalDate.parse(it)) } == true &&
-                event.endDate?.let { !today.isAfter(LocalDate.parse(it)) } == true
-        }
-    if (championshipActive) return "Championship"
-
-    return null
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
@@ -263,6 +263,37 @@ fun computeThisWeekEvents(
     return ThisWeekResult(label, subSections)
 }
 
+/** Returns the chip label for the current competition week, championship, or offseason. */
+internal fun currentWeekChipLabel(
+    allEvents: List<Event>,
+    today: LocalDate,
+    selectedYear: Int,
+): String? {
+    if (selectedYear != today.year) return null
+
+    val week = findCurrentCompetitionWeek(allEvents, today)
+    if (week != null) return "Week ${week + 1}"
+
+    // Championship events (types 3/4) have week == null, so check by date overlap.
+    val championshipActive =
+        allEvents.any { event ->
+            event.type in EventType.CHAMPIONSHIP_TYPES &&
+                parseDate(event.startDate)?.let { !today.isBefore(it) } == true &&
+                parseDate(event.endDate)?.let { !today.isAfter(it) } == true
+        }
+    if (championshipActive) return "Championship"
+
+    // Past the end of every official event → time for offseason.
+    val latestOfficialEnd =
+        allEvents
+            .filter { it.type in EventType.OFFICIAL_TYPES }
+            .mapNotNull { parseDate(it.endDate) }
+            .maxOrNull()
+    if (latestOfficialEnd != null && today.isAfter(latestOfficialEnd)) return "Offseason"
+
+    return null
+}
+
 internal fun findCurrentCompetitionWeek(
     allEvents: List<Event>,
     today: LocalDate,

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
@@ -386,4 +386,129 @@ class EventsUiStateTest {
 
         assertNull(week)
     }
+
+    // --- currentWeekChipLabel ---
+
+    @Test
+    fun `currentWeekChipLabel returns Week label during regular season`() {
+        val today = LocalDate.of(2026, 3, 11) // Wednesday of week 2
+        val events =
+            listOf(
+                makeEvent(
+                    type = EventType.REGIONAL,
+                    week = 1,
+                    startDate = "2026-03-09",
+                    endDate = "2026-03-14",
+                ),
+            )
+        assertEquals("Week 2", currentWeekChipLabel(events, today, selectedYear = 2026))
+    }
+
+    @Test
+    fun `currentWeekChipLabel returns Championship when championship is active`() {
+        val today = LocalDate.of(2026, 4, 16)
+        val events =
+            listOf(
+                makeEvent(
+                    type = EventType.REGIONAL,
+                    week = 1,
+                    startDate = "2026-03-09",
+                    endDate = "2026-03-14",
+                ),
+                makeEvent(
+                    key = "2026cmp",
+                    type = EventType.CHAMPIONSHIP_DIVISION,
+                    startDate = "2026-04-15",
+                    endDate = "2026-04-18",
+                ),
+            )
+        assertEquals("Championship", currentWeekChipLabel(events, today, selectedYear = 2026))
+    }
+
+    @Test
+    fun `currentWeekChipLabel returns Offseason after every official event has ended`() {
+        val today = LocalDate.of(2026, 5, 4)
+        val events =
+            listOf(
+                makeEvent(
+                    type = EventType.REGIONAL,
+                    week = 1,
+                    startDate = "2026-03-09",
+                    endDate = "2026-03-14",
+                ),
+                makeEvent(
+                    key = "2026cmp",
+                    type = EventType.CHAMPIONSHIP_DIVISION,
+                    startDate = "2026-04-15",
+                    endDate = "2026-04-18",
+                ),
+                makeEvent(
+                    key = "2026off1",
+                    type = EventType.OFFSEASON,
+                    startDate = "2026-07-15",
+                    endDate = "2026-07-17",
+                ),
+            )
+        assertEquals("Offseason", currentWeekChipLabel(events, today, selectedYear = 2026))
+    }
+
+    @Test
+    fun `currentWeekChipLabel returns null before season has ended`() {
+        val today = LocalDate.of(2026, 4, 1) // Between regionals and championship
+        val events =
+            listOf(
+                makeEvent(
+                    type = EventType.REGIONAL,
+                    week = 1,
+                    startDate = "2026-03-09",
+                    endDate = "2026-03-14",
+                ),
+                makeEvent(
+                    key = "2026cmp",
+                    type = EventType.CHAMPIONSHIP_DIVISION,
+                    startDate = "2026-04-15",
+                    endDate = "2026-04-18",
+                ),
+            )
+        assertNull(currentWeekChipLabel(events, today, selectedYear = 2026))
+    }
+
+    @Test
+    fun `currentWeekChipLabel ignores offseason events when checking season-end`() {
+        // Today falls between the championship end and the offseason event — but the championship
+        // is the latest official event, so we should still surface Offseason.
+        val today = LocalDate.of(2026, 6, 1)
+        val events =
+            listOf(
+                makeEvent(
+                    key = "2026cmp",
+                    type = EventType.CHAMPIONSHIP_DIVISION,
+                    startDate = "2026-04-15",
+                    endDate = "2026-04-18",
+                ),
+                makeEvent(
+                    key = "2026off1",
+                    type = EventType.OFFSEASON,
+                    startDate = "2026-07-15",
+                    endDate = "2026-07-17",
+                ),
+            )
+        assertEquals("Offseason", currentWeekChipLabel(events, today, selectedYear = 2026))
+    }
+
+    @Test
+    fun `currentWeekChipLabel returns null when viewing a non-current year`() {
+        val today = LocalDate.of(2026, 5, 4)
+        val events =
+            listOf(
+                makeEvent(
+                    year = 2025,
+                    type = EventType.REGIONAL,
+                    week = 1,
+                    startDate = "2025-03-09",
+                    endDate = "2025-03-14",
+                ),
+            )
+        assertNull(currentWeekChipLabel(events, today, selectedYear = 2025))
+    }
 }


### PR DESCRIPTION
## Summary
- During the offseason (today is after every official event's end date), the events list now auto-scrolls to the **Offseason** section instead of stopping at "Championship".
- Adds `EventType.OFFICIAL_TYPES` (regular + championship) and a fall-through in `currentWeekChipLabel` for the post-season case.
- Moves `currentWeekChipLabel` into `EventsUiState.kt` as `internal` so it sits next to `findCurrentCompetitionWeek` and is unit-testable.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests EventsUiStateTest` — six new cases cover Week / Championship / Offseason / mid-season-null / non-current-year / "championship is the latest official event".
- [x] Verified on emulator with today=2026-05-04: Offseason chip selected, list scrolled to Offseason header on first load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)