### PR TITLE
perf: add OkHttp disk cache for TBA and GitHub clients

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/di/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.thebluealliance.android.di
 
+import android.content.Context
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.thebluealliance.android.BuildConfig
 import com.thebluealliance.android.data.remote.AuthTokenInterceptor
@@ -10,8 +11,10 @@ import com.thebluealliance.android.data.remote.TbaApiKeyInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
+import okhttp3.Cache
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -23,6 +26,8 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
+    private const val HTTP_CACHE_SIZE_BYTES = 20L * 1024 * 1024
+
     @Provides
     @Singleton
     fun provideJson(): Json =
@@ -33,9 +38,13 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(apiKeyInterceptor: TbaApiKeyInterceptor): OkHttpClient =
+    fun provideOkHttpClient(
+        @ApplicationContext context: Context,
+        apiKeyInterceptor: TbaApiKeyInterceptor,
+    ): OkHttpClient =
         OkHttpClient
             .Builder()
+            .cache(Cache(context.cacheDir.resolve("http_cache"), HTTP_CACHE_SIZE_BYTES))
             .addInterceptor(apiKeyInterceptor)
             .addInterceptor(
                 HttpLoggingInterceptor().apply {
@@ -87,14 +96,19 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideGitHubApi(json: Json): GitHubApi =
+    fun provideGitHubApi(
+        @ApplicationContext context: Context,
+        json: Json,
+    ): GitHubApi =
         Retrofit
             .Builder()
             .baseUrl("https://api.github.com/")
             .client(
                 OkHttpClient
                     .Builder()
-                    .addInterceptor(
+                    .cache(
+                        Cache(context.cacheDir.resolve("github_http_cache"), HTTP_CACHE_SIZE_BYTES),
+                    ).addInterceptor(
                         HttpLoggingInterceptor().apply {
                             level =
                                 if (BuildConfig.DEBUG) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ core-splashscreen = "1.2.0"
 
 junit = "6.1.0"
 turbine = "1.2.1"
-mockk = "1.14.9"
+mockk = "1.14.11"
 play-publisher = "4.0.0"
 lifecycle-process = "2.10.0"
 ktlint-gradle = "14.2.0"


### PR DESCRIPTION
## Summary
- The read-only `OkHttpClient` was built with no HTTP cache, so every screen revisit re-downloaded full JSON despite the TBA v3 API serving `Cache-Control: max-age` and supporting conditional requests.
- Adds a 20 MB disk cache to the TBA and GitHub clients (`NetworkModule`), letting OkHttp serve cached responses and revalidate transparently — a meaningful network/battery win.
- The authenticated (personalized) client is intentionally left uncached.

## Test plan
- [x] `./gradlew :app:assembleDebug` passes
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] Verified on emulator (2026-05-29): after browsing events, the app's `http_cache` dir is populated with OkHttp header/body/`journal` files; screens render with no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
