### PR TITLE
perf: require network connectivity for widget refresh workers

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWorker.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWorker.kt
@@ -8,9 +8,11 @@ import androidx.glance.appwidget.state.getAppWidgetState
 import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.glance.state.PreferencesGlanceStateDefinition
 import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
@@ -55,12 +57,19 @@ class TeamTrackingWorker
                 wm.cancelUniqueWork(FAST_WORK_NAME)
             }
 
+            private val networkConstraints =
+                Constraints
+                    .Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+
             fun enqueuePeriodicRefresh(context: Context) {
                 val request =
                     PeriodicWorkRequestBuilder<TeamTrackingWorker>(
                         6,
                         TimeUnit.HOURS,
-                    ).build()
+                    ).setConstraints(networkConstraints)
+                        .build()
                 WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                     WORK_NAME,
                     ExistingPeriodicWorkPolicy.KEEP,
@@ -72,6 +81,7 @@ class TeamTrackingWorker
                 val request =
                     OneTimeWorkRequestBuilder<TeamTrackingWorker>()
                         .setInitialDelay(15, TimeUnit.MINUTES)
+                        .setConstraints(networkConstraints)
                         .build()
                 WorkManager.getInstance(context).enqueueUniqueWork(
                     FAST_WORK_NAME,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ core-splashscreen = "1.2.0"
 
 junit = "6.1.0"
 turbine = "1.2.1"
-mockk = "1.14.9"
+mockk = "1.14.11"
 play-publisher = "4.0.0"
 lifecycle-process = "2.10.0"
 ktlint-gradle = "14.2.0"


### PR DESCRIPTION
## Summary
- The periodic (6-hour) and fast-follow `TeamTrackingWorker` requests had no `Constraints`, so they could wake the device and attempt network refreshes with no connectivity — wasting the wakeup and returning `Result.retry()`.
- Adds a `NetworkType.CONNECTED` constraint to both requests, matching the pattern already used by `DeviceRegistrationManager`.

## Test plan
- [x] `./gradlew :app:assembleDebug` passes
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] Verified on emulator (2026-05-29): app and widget-config activity launch clean with no crash. (Live job constraint isn't observable without a placed widget; verified at the app level.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
