### PR TITLE
perf: add network constraints to Wear refresh workers

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ core-splashscreen = "1.2.0"
 
 junit = "6.1.0"
 turbine = "1.2.1"
-mockk = "1.14.9"
+mockk = "1.14.11"
 play-publisher = "4.0.0"
 lifecycle-process = "2.10.0"
 ktlint-gradle = "14.2.0"

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
@@ -5,9 +5,11 @@ import android.content.Context
 import android.util.Log
 import androidx.hilt.work.HiltWorker
 import androidx.wear.watchface.complications.datasource.ComplicationDataSourceUpdateRequester
+import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
@@ -44,11 +46,23 @@ class TeamTrackingComplicationWorker
 
             private val timeFormat = DateTimeFormatter.ofPattern("h:mm")
 
+            private val networkConstraints =
+                Constraints
+                    .Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+
             fun enqueuePeriodicRefresh(context: Context) {
                 val request =
                     PeriodicWorkRequestBuilder<TeamTrackingComplicationWorker>(
                         6,
                         TimeUnit.HOURS,
+                    ).setConstraints(
+                        Constraints
+                            .Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .setRequiresBatteryNotLow(true)
+                            .build(),
                     ).build()
                 WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                     WORK_NAME,
@@ -67,6 +81,7 @@ class TeamTrackingComplicationWorker
                 val request =
                     OneTimeWorkRequestBuilder<TeamTrackingComplicationWorker>()
                         .setInitialDelay(15, TimeUnit.MINUTES)
+                        .setConstraints(networkConstraints)
                         .build()
                 WorkManager.getInstance(context).enqueueUniqueWork(
                     FAST_WORK_NAME,
@@ -76,7 +91,10 @@ class TeamTrackingComplicationWorker
             }
 
             fun enqueueImmediateRefresh(context: Context) {
-                val request = OneTimeWorkRequestBuilder<TeamTrackingComplicationWorker>().build()
+                val request =
+                    OneTimeWorkRequestBuilder<TeamTrackingComplicationWorker>()
+                        .setConstraints(networkConstraints)
+                        .build()
                 WorkManager.getInstance(context).enqueueUniqueWork(
                     "complication_immediate_refresh",
                     ExistingWorkPolicy.REPLACE,


### PR DESCRIPTION
## Summary
- The periodic (6h), fast-follow (15min), and immediate complication-refresh `WorkRequest`s in `TeamTrackingComplicationWorker` had no `Constraints`, so they could wake the watch and attempt network calls with no connectivity, then back off and retry — wasted radio/CPU and battery.
- Adds `NetworkType.CONNECTED` to all three requests, and additionally `requiresBatteryNotLow(true)` on the periodic refresh. Mirrors the phone-side constraint change.

## Test plan
- [x] `./gradlew :wear:assembleDebug` passes
- [x] Verified on wear emulator (2026-05-29): the `TeamTrackingComplicationWorker` job shows `Required constraints: CONNECTIVITY` (INTERNET required) via `dumpsys jobscheduler`, with no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
