### PR TITLE
perf: only schedule Wear periodic refresh when a team is tracked

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ core-splashscreen = "1.2.0"
 
 junit = "6.1.0"
 turbine = "1.2.1"
-mockk = "1.14.9"
+mockk = "1.14.11"
 play-publisher = "4.0.0"
 lifecycle-process = "2.10.0"
 ktlint-gradle = "14.2.0"

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/WearApplication.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/WearApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import com.thebluealliance.android.wear.data.ApiKeyProvider
+import com.thebluealliance.android.wear.tracker.TeamTrackerPreferences
 import com.thebluealliance.android.wear.worker.TeamTrackingComplicationWorker
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
@@ -26,6 +27,11 @@ class WearApplication :
     override fun onCreate() {
         super.onCreate()
         apiKeyProvider.init()
-        TeamTrackingComplicationWorker.enqueuePeriodicRefresh(this)
+        // Only schedule the periodic refresh when a team is actually tracked;
+        // otherwise the worker wakes every 6h to do nothing. Setting a team
+        // schedules it from the tracker/config activities.
+        if (TeamTrackerPreferences(this).teamNumber.isNotBlank()) {
+            TeamTrackingComplicationWorker.enqueuePeriodicRefresh(this)
+        }
     }
 }

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationConfigActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationConfigActivity.kt
@@ -83,6 +83,7 @@ class TeamTrackingComplicationConfigActivity : ComponentActivity() {
             }
 
             TeamTrackingComplicationWorker.enqueueImmediateRefresh(this)
+            TeamTrackingComplicationWorker.enqueuePeriodicRefresh(this)
 
             ComplicationDataSourceUpdateRequester
                 .create(

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -75,6 +75,9 @@ class TeamTrackerActivity : ComponentActivity() {
 
         // Trigger refresh to get latest data
         TeamTrackingComplicationWorker.enqueueImmediateRefresh(this)
+        if (trackerPrefs.teamNumber.isNotBlank()) {
+            TeamTrackingComplicationWorker.enqueuePeriodicRefresh(this)
+        }
 
         setContent {
             MaterialTheme {

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
@@ -129,6 +129,11 @@ class TeamTrackingComplicationWorker
                     } catch (e: Exception) {
                         Log.e(TAG, "Failed to update app tracker", e)
                     }
+                } else {
+                    // No team is tracked anymore — cancel the periodic refresh so the
+                    // worker stops waking every 6h to do nothing. It gets re-enqueued
+                    // when a team is set again.
+                    cancelPeriodicRefresh(applicationContext)
                 }
 
                 if (anyActiveEvent) {


### PR DESCRIPTION
## Summary
- `WearApplication.onCreate` unconditionally enqueued the 6-hour periodic complication refresh, so the worker woke every 6h even with no team configured and no complication present — needless wakeups/battery.
- Gates the enqueue on a non-blank tracked team, and (re)schedules the periodic refresh from `TeamTrackerActivity` and `TeamTrackingComplicationConfigActivity` when a team is set, so it still starts as soon as a team is chosen.
- Per Bryan's review: the worker now also cancels the periodic refresh in its `doWork()` `else` branch when it runs and finds no tracked team, so it stops the 6h wakeups (re-enqueued when a team is set again).
- `enqueueUniquePeriodicWork` uses `KEEP`, so the repeated calls are idempotent.

## Test plan
- [x] `./gradlew :wear:assembleDebug` passes
- [x] Verified on wear emulator (2026-05-29) via the WorkManager diagnostics broadcast: setting a team takes the periodic job count 0→1; relaunching with a blank team shows `complication_refresh` → **CANCELLED** and `complication_immediate_refresh` → **SUCCEEDED**, confirming the worker cancels the periodic work when no team is tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
