### PR TITLE
chore: remove dead EventRepository.observeTeamEventKeys

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
@@ -102,9 +102,6 @@ class EventRepository
         fun observeEventAlliances(eventKey: String): Flow<List<Alliance>> =
             allianceDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
 
-        fun observeTeamEventKeys(teamKey: String): Flow<List<String>> =
-            eventTeamDao.observeByTeam(teamKey).map { list -> list.map { it.eventKey } }
-
         fun observeTeamEvents(
             teamKey: String,
             year: Int,


### PR DESCRIPTION
Split out from #1362 (being abandoned) so each cleanup is reviewable on its own.

`EventRepository.observeTeamEventKeys(teamKey)` has zero callers — deleted.

Pure dead-code removal, no behavior change.

### Testing
- `./gradlew :app:testDebugUnitTest` — green
- `./gradlew :app:ktlintCheck` — clean
- `./gradlew :app:assembleDebug` — builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)