### PR TITLE
refactor: add String.teamNumber extension and replace open-coded sites

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -39,6 +39,7 @@ import com.thebluealliance.android.domain.model.Match
 import com.thebluealliance.android.domain.model.PlayoffType
 import com.thebluealliance.android.domain.model.displayTitleShort
 import com.thebluealliance.android.domain.rpBonuses
+import com.thebluealliance.android.util.teamNumber
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -223,7 +224,7 @@ fun MatchItem(
                     }
                 }
                 Text(
-                    text = match.redTeamKeys.joinToString(", ") { it.removePrefix("frc") },
+                    text = match.redTeamKeys.joinToString(", ") { it.teamNumber },
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight =
                         if (match.winningAlliance ==
@@ -269,7 +270,7 @@ fun MatchItem(
                     }
                 }
                 Text(
-                    text = match.blueTeamKeys.joinToString(", ") { it.removePrefix("frc") },
+                    text = match.blueTeamKeys.joinToString(", ") { it.teamNumber },
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight =
                         if (match.winningAlliance ==

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
@@ -50,6 +50,7 @@ import com.thebluealliance.android.ui.components.TopBarYearPicker
 import com.thebluealliance.android.ui.events.EventSection
 import com.thebluealliance.android.ui.events.computeThisWeekEvents
 import com.thebluealliance.android.ui.theme.TBAIndigo400
+import com.thebluealliance.android.util.teamNumber
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 
@@ -401,7 +402,7 @@ private fun RankingsTab(
                     modifier = Modifier.weight(0.10f),
                 )
                 Text(
-                    text = ranking.teamKey.removePrefix("frc"),
+                    text = ranking.teamKey.teamNumber,
                     style = MaterialTheme.typography.bodyLarge,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.weight(0.15f),

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
@@ -43,6 +43,7 @@ import com.thebluealliance.android.domain.model.Team
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.theme.TBAMotionTokens
+import com.thebluealliance.android.util.teamNumber
 
 internal fun advancementBreakdownRows(
     points: EventAdvancementPoints,
@@ -138,7 +139,7 @@ private fun AdvancementPointsItem(
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = points.teamKey.removePrefix("frc"),
+                    text = points.teamKey.teamNumber,
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.clickable { onTeamClick(points.teamKey) },

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
@@ -24,6 +24,7 @@ import com.thebluealliance.android.domain.model.displayTitle
 import com.thebluealliance.android.domain.model.playoffSummary
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
+import com.thebluealliance.android.util.teamNumber
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -86,7 +87,7 @@ fun EventAlliancesTab(
                     alliance.picks.forEachIndexed { index, teamKey ->
                         Text(
                             text =
-                                teamKey.removePrefix("frc") +
+                                teamKey.teamNumber +
                                     if (index < alliance.picks.lastIndex) "," else "",
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.primary,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAwardsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAwardsTab.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Award
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
+import com.thebluealliance.android.util.teamNumber
 
 @Composable
 fun EventAwardsTab(
@@ -64,9 +65,9 @@ fun EventAwardsTab(
                         if (award.awardee != null) append(award.awardee)
                         if (award.teamKey.isNotEmpty()) {
                             if (isNotEmpty()) {
-                                append(" (${award.teamKey.removePrefix("frc")})")
+                                append(" (${award.teamKey.teamNumber})")
                             } else {
-                                append(award.teamKey.removePrefix("frc"))
+                                append(award.teamKey.teamNumber)
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
@@ -44,6 +44,7 @@ import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.theme.TBAIndigo400
 import com.thebluealliance.android.util.openUrl
+import com.thebluealliance.android.util.teamNumber
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -538,8 +539,8 @@ private fun StandardOPRsView(
                 val result =
                     when (sortColumn) {
                         OprSortColumn.TEAM -> {
-                            val teamA = a.substring(3).toIntOrNull() ?: 0
-                            val teamB = b.substring(3).toIntOrNull() ?: 0
+                            val teamA = a.teamNumber.toIntOrNull() ?: 0
+                            val teamB = b.teamNumber.toIntOrNull() ?: 0
                             teamA.compareTo(teamB)
                         }
                         OprSortColumn.OPR -> (oprs.oprs[a] ?: 0.0).compareTo(oprs.oprs[b] ?: 0.0)
@@ -642,7 +643,7 @@ private fun StandardOPRsView(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = teamKey.substring(3),
+                        text = teamKey.teamNumber,
                         modifier = Modifier.weight(1.2f),
                         style = MaterialTheme.typography.bodyLarge,
                     )
@@ -701,8 +702,8 @@ private fun COPRView(
                 val result =
                     when (sortColumn) {
                         CoprSortColumn.TEAM -> {
-                            val teamA = a.substring(3).toIntOrNull() ?: 0
-                            val teamB = b.substring(3).toIntOrNull() ?: 0
+                            val teamA = a.teamNumber.toIntOrNull() ?: 0
+                            val teamB = b.teamNumber.toIntOrNull() ?: 0
                             teamA.compareTo(teamB)
                         }
                         CoprSortColumn.VALUE -> (coprData[a] ?: 0.0).compareTo(coprData[b] ?: 0.0)
@@ -775,7 +776,7 @@ private fun COPRView(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = teamKey.substring(3),
+                        text = teamKey.teamNumber,
                         modifier = Modifier.weight(1.2f),
                         style = MaterialTheme.typography.bodyLarge,
                     )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -44,6 +44,7 @@ import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.theme.TBAIndigo400
 import com.thebluealliance.android.ui.theme.TBAMotionTokens
+import com.thebluealliance.android.util.teamNumber
 import java.util.Locale
 
 enum class RankingSortColumn {
@@ -87,8 +88,8 @@ internal fun sortRankings(
         val result =
             when (sortState.column) {
                 RankingSortColumn.TEAM -> {
-                    val teamA = a.teamKey.removePrefix("frc").toIntOrNull() ?: 0
-                    val teamB = b.teamKey.removePrefix("frc").toIntOrNull() ?: 0
+                    val teamA = a.teamKey.teamNumber.toIntOrNull() ?: 0
+                    val teamB = b.teamKey.teamNumber.toIntOrNull() ?: 0
                     teamA.compareTo(teamB)
                 }
                 RankingSortColumn.PRIMARY -> {
@@ -280,7 +281,7 @@ private fun RankingItem(
                 modifier = Modifier.weight(0.12f),
             )
             Text(
-                text = ranking.teamKey.removePrefix("frc"),
+                text = ranking.teamKey.teamNumber,
                 style = MaterialTheme.typography.titleMedium,
                 modifier =
                     Modifier

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -56,6 +56,7 @@ import com.thebluealliance.android.ui.components.MediaGridItem
 import com.thebluealliance.android.ui.components.MediaGridRow
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.mediaUrl
+import com.thebluealliance.android.util.teamNumber
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -395,7 +396,7 @@ private fun AllianceTeams(
         ) {
             redTeamKeys.forEach { key ->
                 Text(
-                    text = key.removePrefix("frc"),
+                    text = key.teamNumber,
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.error,
                     modifier =
@@ -420,7 +421,7 @@ private fun AllianceTeams(
         ) {
             blueTeamKeys.forEach { key ->
                 Text(
-                    text = key.removePrefix("frc"),
+                    text = key.teamNumber,
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.primary,
                     modifier =

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
@@ -42,6 +42,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thebluealliance.android.domain.model.RegionalRanking
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.TopBarYearPicker
+import com.thebluealliance.android.util.teamNumber
 import kotlinx.coroutines.flow.Flow
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -229,7 +230,7 @@ private fun RegionalRankingRow(
                 modifier = Modifier.weight(0.12f),
             )
             Text(
-                text = ranking.teamKey.removePrefix("frc"),
+                text = ranking.teamKey.teamNumber,
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.weight(0.18f),
             )

--- a/app/src/main/kotlin/com/thebluealliance/android/util/PitMapUrls.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/util/PitMapUrls.kt
@@ -21,7 +21,7 @@ fun buildNexusPitMapUrl(
     eventKey: String,
     highlightedTeamKey: String? = null,
 ): String {
-    val teamNumber = highlightedTeamKey?.removePrefix("frc")?.takeIf { it.isNotBlank() }
+    val teamNumber = highlightedTeamKey?.teamNumber?.takeIf { it.isNotBlank() }
     return if (teamNumber == null) {
         "$NEXUS_EVENT_BASE_URL/$eventKey/map"
     } else {

--- a/app/src/main/kotlin/com/thebluealliance/android/util/TeamKey.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/util/TeamKey.kt
@@ -1,0 +1,5 @@
+package com.thebluealliance.android.util
+
+/** The team number portion of an FRC team key, e.g. "frc254" -> "254". */
+val String.teamNumber: String
+    get() = removePrefix("frc")

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidget.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidget.kt
@@ -47,6 +47,7 @@ import androidx.glance.text.TextDecoration
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.thebluealliance.android.R
+import com.thebluealliance.android.util.teamNumber
 
 /**
  * Glance Compose widget for team tracking.
@@ -510,13 +511,13 @@ class TeamTrackingWidget : GlanceAppWidget() {
                     // Alliance team rows in color
                     TeamNumbersRow(
                         data.nextRedTeams!!,
-                        data.teamKey.removePrefix("frc"),
+                        data.teamKey.teamNumber,
                         redColor,
                         false,
                     )
                     TeamNumbersRow(
                         data.nextBlueTeams!!,
-                        data.teamKey.removePrefix("frc"),
+                        data.teamKey.teamNumber,
                         blueColor,
                         false,
                     )
@@ -650,13 +651,13 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 }
                 TeamNumbersRow(
                     data.nextRedTeams!!,
-                    data.teamKey.removePrefix("frc"),
+                    data.teamKey.teamNumber,
                     redColor,
                     false,
                 )
                 TeamNumbersRow(
                     data.nextBlueTeams!!,
-                    data.teamKey.removePrefix("frc"),
+                    data.teamKey.teamNumber,
                     blueColor,
                     false,
                 )
@@ -1000,7 +1001,7 @@ class TeamTrackingWidget : GlanceAppWidget() {
         val blueColor = ColorProvider(R.color.widget_blue_text)
         val rpInactiveColor = ColorProvider(R.color.widget_rp_inactive)
 
-        val teamNumber = teamKey.removePrefix("frc")
+        val teamNumber = teamKey.teamNumber
         val isPlayed = redScore != null && blueScore != null
 
         Row(

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWorker.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWorker.kt
@@ -26,6 +26,7 @@ import com.thebluealliance.android.domain.model.Match
 import com.thebluealliance.android.domain.model.Media
 import com.thebluealliance.android.domain.model.PlayoffType
 import com.thebluealliance.android.domain.rpBonuses
+import com.thebluealliance.android.util.teamNumber
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.firstOrNull
@@ -109,7 +110,7 @@ class TeamTrackingWorker
                                 glanceId,
                             )
                         val teamKey = state[TeamTrackingWidgetKeys.TEAM_KEY] ?: continue
-                        val teamNumber = teamKey.removePrefix("frc")
+                        val teamNumber = teamKey.teamNumber
 
                         val hasActiveEvent = updateWidgetForTeam(teamKey, teamNumber, glanceId)
                         if (hasActiveEvent) anyActiveEvent = true
@@ -280,9 +281,9 @@ class TeamTrackingWorker
                     prefs[TeamTrackingWidgetKeys.LAST_MATCH_LABEL] =
                         lastMatch.getShortLabel(playoffType)
                     prefs[TeamTrackingWidgetKeys.LAST_MATCH_RED_TEAMS] =
-                        lastMatch.redTeamKeys.joinToString(",") { it.removePrefix("frc") }
+                        lastMatch.redTeamKeys.joinToString(",") { it.teamNumber }
                     prefs[TeamTrackingWidgetKeys.LAST_MATCH_BLUE_TEAMS] =
-                        lastMatch.blueTeamKeys.joinToString(",") { it.removePrefix("frc") }
+                        lastMatch.blueTeamKeys.joinToString(",") { it.teamNumber }
                     prefs[TeamTrackingWidgetKeys.LAST_MATCH_RED_SCORE] =
                         lastMatch.redScore.toString()
                     prefs[TeamTrackingWidgetKeys.LAST_MATCH_BLUE_SCORE] =
@@ -305,9 +306,9 @@ class TeamTrackingWorker
                     prefs[TeamTrackingWidgetKeys.NEXT_MATCH_LABEL] =
                         nextMatch.getShortLabel(playoffType)
                     prefs[TeamTrackingWidgetKeys.NEXT_MATCH_RED_TEAMS] =
-                        nextMatch.redTeamKeys.joinToString(",") { it.removePrefix("frc") }
+                        nextMatch.redTeamKeys.joinToString(",") { it.teamNumber }
                     prefs[TeamTrackingWidgetKeys.NEXT_MATCH_BLUE_TEAMS] =
-                        nextMatch.blueTeamKeys.joinToString(",") { it.removePrefix("frc") }
+                        nextMatch.blueTeamKeys.joinToString(",") { it.teamNumber }
                     prefs[TeamTrackingWidgetKeys.NEXT_MATCH_TIME] = formatMatchTime(nextMatch)
                     prefs[TeamTrackingWidgetKeys.NEXT_MATCH_TIME_IS_ESTIMATE] =
                         isUsingPredictedTime(nextMatch).toString()


### PR DESCRIPTION
Split out from #1362 (being abandoned) so each cleanup is reviewable on its own.

The transform "FRC team key → team number" (`"frc254" → "254"`) was open-coded ~30 times as either `removePrefix("frc")` or, inconsistently, `substring(3)`. Replace every site with one named extension in `util/TeamKey.kt`:

```kotlin
val String.teamNumber: String get() = removePrefix("frc")
```

Swept across 12 files: event tabs (rankings/insights/alliances/awards/advancement), match list + detail, district + regional screens, the home-screen widget + worker, and pit-map URLs. Folding the positional `substring(3)` sites in also makes them robust to keys that don't begin with `frc`.

No behavior change.

### Testing
- `./gradlew :app:testDebugUnitTest` — green
- `./gradlew :app:ktlintCheck` — clean
- `./gradlew :app:assembleDebug` — builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)