### PR TITLE
refactor: consolidate duplicate RpDots composable

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -1,6 +1,5 @@
 package com.thebluealliance.android.ui.components
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -29,8 +28,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.getGroup
@@ -289,8 +286,16 @@ fun MatchItem(
                     horizontalAlignment = Alignment.End,
                     verticalArrangement = Arrangement.spacedBy(3.dp),
                 ) {
-                    RpDots(rpBonuses.red, MaterialTheme.colorScheme.error)
-                    RpDots(rpBonuses.blue, MaterialTheme.colorScheme.primary)
+                    RpDots(
+                        rpBonuses.red,
+                        MaterialTheme.colorScheme.error,
+                        Modifier.padding(end = 3.dp),
+                    )
+                    RpDots(
+                        rpBonuses.blue,
+                        MaterialTheme.colorScheme.primary,
+                        Modifier.padding(end = 3.dp),
+                    )
                 }
             }
             Column(
@@ -364,33 +369,4 @@ fun formatMatchTime(epochSeconds: Long?): String {
         .format(instant.atZone(java.time.ZoneId.systemDefault()))
         .replace("AM", "a")
         .replace("PM", "p")
-}
-
-@Composable
-private fun RpDots(
-    bonuses: List<Boolean>,
-    achievedColor: Color,
-) {
-    Row(
-        modifier = Modifier.padding(end = 3.dp),
-        horizontalArrangement = Arrangement.spacedBy(2.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        bonuses.forEach { achieved ->
-            Canvas(modifier = Modifier.size(6.dp)) {
-                if (achieved) {
-                    drawCircle(
-                        color = achievedColor,
-                        radius = size.minDimension / 2,
-                    )
-                } else {
-                    drawCircle(
-                        color = Color(0xFF9CA3AF),
-                        radius = size.minDimension / 2 - 1.dp.toPx(),
-                        style = Stroke(width = 1.dp.toPx()),
-                    )
-                }
-            }
-        }
-    }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/RpDots.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/RpDots.kt
@@ -1,0 +1,46 @@
+package com.thebluealliance.android.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/** Row of ranking-point bonus indicators: filled when achieved, hollow when not. */
+@Composable
+fun RpDots(
+    bonuses: List<Boolean>,
+    achievedColor: Color,
+    modifier: Modifier = Modifier,
+    dotSize: Dp = 6.dp,
+    gap: Dp = 2.dp,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(gap),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        bonuses.forEach { achieved ->
+            Canvas(modifier = Modifier.size(dotSize)) {
+                if (achieved) {
+                    drawCircle(
+                        color = achievedColor,
+                        radius = size.minDimension / 2,
+                    )
+                } else {
+                    drawCircle(
+                        color = Color(0xFF9CA3AF),
+                        radius = size.minDimension / 2 - 1.dp.toPx(),
+                        style = Stroke(width = 1.dp.toPx()),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -1,9 +1,7 @@
 package com.thebluealliance.android.ui.matches
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -33,7 +30,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -54,6 +50,7 @@ import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.common.shareTbaUrl
 import com.thebluealliance.android.ui.components.MediaGridItem
 import com.thebluealliance.android.ui.components.MediaGridRow
+import com.thebluealliance.android.ui.components.RpDots
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.mediaUrl
 
@@ -311,7 +308,7 @@ private fun RowScope.AllianceScoreSummaryCol(
             color = mainColor,
         )
         rpBonus?.let {
-            RpDots(it, mainColor)
+            RpDots(it, mainColor, Modifier.padding(top = 4.dp), dotSize = 8.dp, gap = 4.dp)
         }
         advancementMsg?.let {
             Box(
@@ -466,35 +463,6 @@ private fun BreakdownRow(
             modifier = Modifier.weight(0.2f),
             textAlign = TextAlign.Center,
         )
-    }
-}
-
-@Composable
-private fun RpDots(
-    bonuses: List<Boolean>,
-    achievedColor: Color,
-) {
-    Row(
-        modifier = Modifier.padding(top = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        bonuses.forEach { achieved ->
-            Canvas(modifier = Modifier.size(8.dp)) {
-                if (achieved) {
-                    drawCircle(
-                        color = achievedColor,
-                        radius = size.minDimension / 2,
-                    )
-                } else {
-                    drawCircle(
-                        color = Color(0xFF9CA3AF),
-                        radius = size.minDimension / 2 - 1.dp.toPx(),
-                        style = Stroke(width = 1.dp.toPx()),
-                    )
-                }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Split out from #1362 (being abandoned) so each cleanup is reviewable on its own.

The ranking-point bonus-dots composable was duplicated as near-identical ~28-line copies in `MatchDetailScreen` and `MatchList`, differing only in dot size / spacing / padding. Extract one parameterized `ui/components/RpDots.kt`:

```kotlin
@Composable
fun RpDots(
    bonuses: List<Boolean>,
    achievedColor: Color,
    modifier: Modifier = Modifier,
    dotSize: Dp = 6.dp,
    gap: Dp = 2.dp,
)
```

The two call sites pass their own sizes via params + modifier, so the rendering is byte-for-byte unchanged. No behavior change.

### Testing
- `./gradlew :app:testDebugUnitTest` — green
- `./gradlew :app:ktlintCheck` — clean
- `./gradlew :app:assembleDebug` — builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)