### PR TITLE
feat: declare widget resize bounds and reconfigurable feature

### DIFF
--- a/app/src/main/res/xml-v31/team_tracking_widget_info.xml
+++ b/app/src/main/res/xml-v31/team_tracking_widget_info.xml
@@ -7,8 +7,11 @@
     android:minHeight="40dp"
     android:targetCellWidth="4"
     android:targetCellHeight="2"
+    android:maxResizeWidth="250dp"
+    android:maxResizeHeight="110dp"
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
+    android:widgetFeatures="reconfigurable"
     android:initialLayout="@layout/widget_loading"
     android:previewLayout="@layout/widget_preview"
     android:updatePeriodMillis="0" />


### PR DESCRIPTION
## Summary
On **API 31+**, declare the Team Tracker widget's resize limits and advertise reconfiguration:

- `android:maxResizeWidth="250dp"` / `android:maxResizeHeight="110dp"` — caps the host's resize handles at the widget's largest declared layout. These match the widest responsive breakpoint in `TeamTrackingWidget.kt` (`FULL = DpSize(250.dp, 110.dp)`, the 4×2 layout); no layout uses space beyond that, and Android's canonical 4×2 example declares the same values.
- `android:widgetFeatures="reconfigurable"` — exposes the system reconfigure affordance (the widget already ships a configuration Activity, so this just surfaces it).

Metadata-only; affects the `xml-v31/` provider info. (`targetCellWidth/Height` and `previewLayout` already existed — unchanged here.)

## Context
Part of a 4-PR Team Tracker **widget quality-guidelines** pass (criteria WL-4.1 / WS-4). Branches off `main`; independent of the other three.

## Test plan
- [ ] On an API 31+ device, resize the widget → handles stop at the declared max bounds.
- [ ] Long-press the widget → a "Reconfigure" option is available and reopens the config flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)