### PR TITLE
chore: extend debug widget mock tooling for screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ firebase-debug.log
 
 # Screenshots
 screenshots/
+
+# Generated compliance reports / audit artifacts
+artifacts/

--- a/app/src/debug/kotlin/com/thebluealliance/android/widget/MockWidgetActivity.kt
+++ b/app/src/debug/kotlin/com/thebluealliance/android/widget/MockWidgetActivity.kt
@@ -33,6 +33,10 @@ import java.time.LocalDate
  * Presets:
  *   "at-event"  — Team 177 at NE District Event with last/next match (matches sampleData())
  *   "upcoming"  — Team 254 with 3 upcoming events, no current event
+ *   "empty"     — No team configured; widget shows the "Tap to set up" CTA
+ *
+ * Optionally force a responsive layout tier regardless of physical size:
+ *   --es size <1x1|2x1|2x2|4x1|4x2>
  */
 class MockWidgetActivity : ComponentActivity() {
     companion object {
@@ -44,9 +48,13 @@ class MockWidgetActivity : ComponentActivity() {
 
         val index = intent?.getIntExtra("index", -1) ?: -1
         val preset = intent?.getStringExtra("mock")
+        val forcedSize = intent?.getStringExtra("size")
 
         if (index < 0 || preset == null) {
-            Log.e(TAG, "Usage: --ei index <N> --es mock <at-event|upcoming>")
+            Log.e(
+                TAG,
+                "Usage: --ei index <N> --es mock <at-event|upcoming|empty> [--es size <1x1|2x1|2x2|4x1|4x2>]",
+            )
             finish()
             return
         }
@@ -73,13 +81,19 @@ class MockWidgetActivity : ComponentActivity() {
                     when (preset) {
                         "at-event" -> writeAtEventPreset(prefs)
                         "upcoming" -> writeUpcomingPreset(prefs)
+                        "empty" -> writeEmptyPreset(prefs)
                         else -> {
                             Log.e(
                                 TAG,
-                                "Unknown preset: $preset (expected 'at-event' or 'upcoming')",
+                                "Unknown preset: $preset (expected 'at-event', 'upcoming', or 'empty')",
                             )
                             return@updateAppWidgetState
                         }
+                    }
+                    if (forcedSize != null) {
+                        prefs[TeamTrackingWidgetKeys.DEBUG_FORCED_SIZE] = forcedSize
+                    } else {
+                        prefs.remove(TeamTrackingWidgetKeys.DEBUG_FORCED_SIZE)
                     }
                 }
 
@@ -159,6 +173,11 @@ class MockWidgetActivity : ComponentActivity() {
 
         // No upcoming events when at an event
         prefs.remove(TeamTrackingWidgetKeys.UPCOMING_EVENTS)
+    }
+
+    /** Clears all configured data so the widget renders its "Tap to set up" zero state. */
+    private fun writeEmptyPreset(prefs: androidx.datastore.preferences.core.MutablePreferences) {
+        prefs.clear()
     }
 
     private suspend fun writeUpcomingPreset(


### PR DESCRIPTION
## Summary
Debug-only tooling used to capture the widget quality-guideline screenshots. **No release impact** — everything is under `app/src/debug/` plus a `.gitignore` entry.

- **`MockWidgetActivity`**
  - Add an `"empty"` preset that clears configured data so the widget renders its **"Tap to set up"** zero state.
  - Add an optional `--es size <1x1|2x1|2x2|4x1|4x2>` flag to force a responsive layout tier regardless of the widget's physical cell size (via the existing `DEBUG_FORCED_SIZE` key).
- **`.gitignore`** — ignore `artifacts/` (local compliance reports and generated screenshots).

## Context
Part of a 4-PR Team Tracker **widget quality-guidelines** pass — this is the supporting dev-tooling tranche, kept separate from the three product PRs so reviews stay clean. Branches off `main`; independent of the others.

## Test plan
- [ ] `adb shell am start -n …/.widget.MockWidgetActivity --ei index <id> --es mock empty` → widget shows the zero state.
- [ ] Append `--es size 2x2` → widget renders the SQUARE tier in its current host.
- [ ] Confirm `artifacts/` is untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)