### PR TITLE
feat(tv): fetch TBA API key from Firebase Remote Config

### DIFF
--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -70,11 +70,12 @@ android {
         versionCode = computedVersionCode
         versionName = computedVersionName
 
-        // Production defaults; the debug buildType overrides these below. The release
-        // build ships with no embedded key, so it serves the bundled sample events.
+        // Production defaults; the debug buildType overrides these below. Release builds
+        // ship with no embedded TBA key — ApiKeyProvider fetches the live key from
+        // Firebase Remote Config (apiv3_auth_key), mirroring :app and :wear.
         buildConfigField("String", "TBA_API_KEY", "\"\"")
         buildConfigField("String", "TBA_BASE_URL", "\"$tbaProdUrl\"")
-        buildConfigField("boolean", "USE_MOCK_DATA", "true")
+        buildConfigField("boolean", "USE_MOCK_DATA", "false")
     }
 
     signingConfigs {
@@ -187,11 +188,13 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
 
-    // Firebase — Crashlytics + Analytics, matching :app and :wear. Auto-initialized
-    // via the google-services plugin and the bundled google-services.json.
+    // Firebase — Crashlytics + Analytics auto-initialize via the google-services
+    // plugin and the bundled google-services.json. Remote Config fetches the TBA
+    // API key from apiv3_auth_key on release builds. All matching :app and :wear.
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.analytics)
+    implementation(libs.firebase.config)
 
     // Core library desugaring (java.time on minSdk 23)
     coreLibraryDesugaring(libs.desugar.jdk.libs)

--- a/tv/src/main/kotlin/com/thebluealliance/android/tv/TbaTvApplication.kt
+++ b/tv/src/main/kotlin/com/thebluealliance/android/tv/TbaTvApplication.kt
@@ -11,5 +11,6 @@ class TbaTvApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         container = DefaultAppContainer(this)
+        container.apiKeyProvider.init()
     }
 }

--- a/tv/src/main/kotlin/com/thebluealliance/android/tv/data/ApiKeyProvider.kt
+++ b/tv/src/main/kotlin/com/thebluealliance/android/tv/data/ApiKeyProvider.kt
@@ -1,0 +1,68 @@
+package com.thebluealliance.android.tv.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.core.content.edit
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.thebluealliance.android.tv.BuildConfig
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Resolves the TBA API key. Debug builds use the build-time key from local.properties;
+ * release builds fetch it from Firebase Remote Config (apiv3_auth_key) and cache the
+ * result in SharedPreferences. Mirrors :app.
+ */
+class ApiKeyProvider(
+    context: Context,
+    private val remoteConfig: FirebaseRemoteConfig,
+) {
+    private val prefs: SharedPreferences =
+        context.applicationContext.getSharedPreferences("api_config", Context.MODE_PRIVATE)
+
+    private val fetchComplete = CountDownLatch(1)
+
+    val apiKey: String
+        get() {
+            if (BuildConfig.DEBUG) return BuildConfig.TBA_API_KEY
+
+            val cached = prefs.getString(PREFS_KEY, null)
+            if (!cached.isNullOrEmpty()) return cached
+
+            // No cached key — wait for the in-flight Remote Config fetch so the first
+            // network call on a fresh install doesn't go out with an empty key.
+            fetchComplete.await(5, TimeUnit.SECONDS)
+
+            val remoteKey = remoteConfig.getString(REMOTE_CONFIG_KEY)
+            if (remoteKey.isNotEmpty()) return remoteKey
+
+            return BuildConfig.TBA_API_KEY
+        }
+
+    fun init() {
+        if (BuildConfig.DEBUG) {
+            fetchComplete.countDown()
+            return
+        }
+
+        remoteConfig.fetchAndActivate().addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                val key = remoteConfig.getString(REMOTE_CONFIG_KEY)
+                if (key.isNotEmpty()) {
+                    prefs.edit { putString(PREFS_KEY, key) }
+                    Log.d(TAG, "Updated API key from Remote Config")
+                }
+            } else {
+                Log.w(TAG, "Failed to fetch Remote Config", task.exception)
+            }
+            fetchComplete.countDown()
+        }
+    }
+
+    companion object {
+        private const val TAG = "ApiKeyProvider"
+        private const val REMOTE_CONFIG_KEY = "apiv3_auth_key"
+        private const val PREFS_KEY = "tba_api_key"
+    }
+}

--- a/tv/src/main/kotlin/com/thebluealliance/android/tv/data/AppContainer.kt
+++ b/tv/src/main/kotlin/com/thebluealliance/android/tv/data/AppContainer.kt
@@ -1,6 +1,7 @@
 package com.thebluealliance.android.tv.data
 
 import android.content.Context
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.thebluealliance.android.tv.BuildConfig
 import com.thebluealliance.android.tv.data.api.GitHubApiFactory
 import com.thebluealliance.android.tv.data.api.TbaApiFactory
@@ -14,6 +15,7 @@ import com.thebluealliance.android.tv.data.repository.NetworkEventRepository
 interface AppContainer {
     val eventRepository: EventRepository
     val contributorRepository: ContributorRepository
+    val apiKeyProvider: ApiKeyProvider
     val usingMockData: Boolean
 }
 
@@ -24,6 +26,10 @@ class DefaultAppContainer(
 
     override val usingMockData: Boolean = BuildConfig.USE_MOCK_DATA
 
+    override val apiKeyProvider: ApiKeyProvider by lazy {
+        ApiKeyProvider(appContext, FirebaseRemoteConfig.getInstance())
+    }
+
     override val eventRepository: EventRepository by lazy {
         if (usingMockData) {
             AssetEventRepository(appContext)
@@ -32,7 +38,7 @@ class DefaultAppContainer(
                 TbaApiFactory.create(
                     context = appContext,
                     baseUrl = BuildConfig.TBA_BASE_URL,
-                    apiKey = BuildConfig.TBA_API_KEY,
+                    apiKey = { apiKeyProvider.apiKey },
                 ),
             )
         }

--- a/tv/src/main/kotlin/com/thebluealliance/android/tv/data/api/TbaApi.kt
+++ b/tv/src/main/kotlin/com/thebluealliance/android/tv/data/api/TbaApi.kt
@@ -31,7 +31,7 @@ object TbaApiFactory {
     fun create(
         context: Context,
         baseUrl: String,
-        apiKey: String,
+        apiKey: () -> String,
     ): TbaApi {
         val client =
             OkHttpClient
@@ -45,7 +45,7 @@ object TbaApiFactory {
                         chain
                             .request()
                             .newBuilder()
-                            .addHeader("X-TBA-Auth-Key", apiKey)
+                            .addHeader("X-TBA-Auth-Key", apiKey())
                             .addHeader("Accept", "application/json")
                             .build()
                     chain.proceed(request)


### PR DESCRIPTION
## Summary

- :tv release builds now pull the TBA API key from Firebase Remote Config (`apiv3_auth_key`), mirroring :app — instead of shipping an empty build-time key and falling back to bundled mock data.
- New `ApiKeyProvider` caches the fetched key in SharedPreferences (`api_config` → `tba_api_key`) and uses a `CountDownLatch(1)` with a 5s timeout so the first network call on a fresh install waits for the in-flight fetch (catches a race agy flagged in review).
- `TbaApiFactory.create` now takes `apiKey: () -> String` so the OkHttp interceptor reads the live value on every request; `DefaultAppContainer` wires it up and `TbaTvApplication` calls `init()` from `onCreate`.
- CI: `ci-tv.yaml` gets the standard placeholder `google-services.json` bootstrap on both jobs (the file is `.gitignored` like :app/:wear); `ci-lint.yaml` adds :tv debug/release entries to the existing loop so `:tv:lintDebug` still has a manifest.
- Release `USE_MOCK_DATA` flips from `true` → `false` now that the key resolves at runtime.

## Test plan

- [x] `./gradlew :tv:assembleRelease` — green
- [x] `./gradlew :tv:testDebugUnitTest` — green
- [x] `./gradlew :tv:ktlintCheck :tv:lintRelease` — green
- [x] On `Television_4K` emulator with the prod signing keystore, logcat shows: `Firebase-Installations: …, tbatv-prod-hrd, 1:836511118694:android:…` → `ApiKeyProvider: Updated API key from Remote Config` → `OkHttp --> GET https://www.thebluealliance.com/api/v3/events/2026 <-- 200`
- [x] First-run latch verified: with the latch, `Updated API key from Remote Config` and `--> GET` line up at the same millisecond (`.213`), then a real 250ms network 200. Without the latch they were 446ms apart and the first request fired unauthenticated.
- [x] Screenshot (`screenshots/1378_tv_firebase_latch.png`) shows real off-season events ("BattleCry (May)", "Arizona Robotics League Qualifier 1") — none of which are in `events_fixture.json`. Confirms live prod data, not the bundled fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)