### PR TITLE
fix(release): commit shared Play edit so phone + TV land in one release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -177,6 +177,10 @@ play {
     )
     track.set("alpha")
     defaultToAppBundles.set(true)
+    // Phone + TV publish into one shared Play edit on alpha so the release
+    // contains both AABs (Play routes by leanback uses-feature). Neither module
+    // commits its own edit; release.sh invokes :commitEditFor… last to flush it.
+    commit.set(false)
 }
 
 room {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -485,12 +485,14 @@ cmd_alpha() {
         :tv:bundleRelease :tv:assembleRelease
 
 
-    # :app and :tv must publish in the same gradlew invocation so they share one Play
-    # edit on the alpha track. They piggyback (Play routes the right AAB to each device
-    # via the leanback uses-feature declaration), and a separate invocation would start
-    # a new edit that overwrites the prior AAB on the track.
+    # :app and :tv share one Play edit on the alpha track so the release contains both
+    # AABs (Play routes to each device via the leanback uses-feature declaration). Both
+    # modules set commit.set(false); the :commitEditFor… task explicitly commits the
+    # shared edit at the end. Without that final task neither AAB ends up in a release.
+    # Without commit=false on both, the first publish closes the edit and the second
+    # opens a new one, replacing the prior AAB. All three must run in one invocation.
     info "Publishing phone + TV apps to alpha..."
-    run ./gradlew :app:publishReleaseBundle :tv:publishReleaseBundle
+    run ./gradlew :app:publishReleaseBundle :tv:publishReleaseBundle :commitEditForComDotTheblueallianceDotAndroidclient
     info "Publishing wear app to wear:alpha..."
     run ./gradlew :wear:publishReleaseBundle
 
@@ -543,11 +545,13 @@ cmd_beta() {
     info "Checking out ${tag}..."
     run git checkout "$tag"
 
-    # :app and :tv promote together in one invocation (shared alpha → beta Play edit).
+    # :app and :tv promote together in one invocation; commit.set(false) on both
+    # modules means the explicit :commitEditFor… task is what flushes the edit.
     info "Promoting phone + TV apps alpha → beta..."
     run ./gradlew \
         :app:promoteReleaseArtifact \
         :tv:promoteReleaseArtifact \
+        :commitEditForComDotTheblueallianceDotAndroidclient \
         --from-track alpha --promote-track beta
     info "Promoting wear app wear:alpha → wear:beta..."
     run ./gradlew :wear:promoteReleaseArtifact --from-track "wear:alpha" --promote-track "wear:beta"
@@ -613,11 +617,13 @@ cmd_production() {
     info "Checking out ${tag}..."
     run git checkout "$tag"
 
-    # :app and :tv promote together in one invocation (shared beta → production Play edit).
+    # :app and :tv promote together in one invocation; commit.set(false) on both
+    # modules means the explicit :commitEditFor… task is what flushes the edit.
     info "Promoting phone + TV apps beta → production..."
     run ./gradlew \
         :app:promoteReleaseArtifact \
         :tv:promoteReleaseArtifact \
+        :commitEditForComDotTheblueallianceDotAndroidclient \
         --from-track beta --promote-track production
     info "Promoting wear app wear:beta → wear:production..."
     run ./gradlew :wear:promoteReleaseArtifact --from-track "wear:beta" --promote-track "wear:production"

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -160,6 +160,10 @@ play {
     // get :tv from a single release.
     track.set("alpha")
     defaultToAppBundles.set(true)
+    // Phone + TV publish into one shared Play edit on alpha so the release
+    // contains both AABs (Play routes by leanback uses-feature). Neither module
+    // commits its own edit; release.sh invokes :commitEditFor… last to flush it.
+    commit.set(false)
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

v11.9.0 alpha shipped phone-only because `:app:publishReleaseBundle` and `:tv:publishReleaseBundle` each commit their own Play edit by default: the first publish closes the edit with one AAB, the second opens a fresh edit that overwrites it. The TV AAB (`211090000`) was uploaded to the bundle library but never attached to the release.

Use GPP's documented multi-module pattern, mirroring [phansier/Coffeegram's phone+wear setup](https://github.com/phansier/Coffeegram/blob/develop/.github/workflows/android-publish.yaml) (`commit.set(false)` on each module + an explicit `commitEditFor<applicationId>` task at the end of the shared invocation).

- `app/build.gradle.kts` + `tv/build.gradle.kts`: `commit.set(false)` on the play extension
- `scripts/release.sh`: append `:commitEditForComDotTheblueallianceDotAndroidclient` to the alpha publish, beta promote, and production promote invocations
- `:wear` unaffected — separate `wear:*` tracks, separate edit lifecycle

Task name discovered with `./gradlew tasks --all | grep commitEdit` after adding `commit.set(false)`.

## Test plan
- [ ] Cut v11.9.1 via `./scripts/release.sh alpha`
- [ ] Confirm Play Console alpha release shows BOTH `11090100` and `211090100` under "New app bundles"
- [ ] Confirm `tv-release.aab` is no longer orphaned in the bundle library after the release
- [ ] Confirm `:wear` still publishes cleanly to `wear:alpha` (separate invocation, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)