### PR TITLE
Sort event awards in TBA web's canonical display order

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
@@ -35,6 +35,7 @@ import com.thebluealliance.android.domain.model.EventOPRs
 import com.thebluealliance.android.domain.model.EventRankings
 import com.thebluealliance.android.domain.model.Ranking
 import com.thebluealliance.android.domain.model.RankingSortOrder
+import com.thebluealliance.android.domain.sortedForDisplay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -70,7 +71,9 @@ class EventRepository
         fun observeEvent(key: String): Flow<Event?> = eventDao.observe(key).map { it?.toDomain() }
 
         fun observeEventAwards(eventKey: String): Flow<List<Award>> =
-            awardDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
+            awardDao.observeByEvent(eventKey).map { list ->
+                list.map { it.toDomain() }.sortedForDisplay()
+            }
 
         fun observeEventRankings(eventKey: String): Flow<List<Ranking>> =
             rankingDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/AwardSort.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/AwardSort.kt
@@ -1,19 +1,30 @@
 package com.thebluealliance.android.domain
 
 import com.thebluealliance.android.domain.model.Award
+import com.thebluealliance.android.domain.model.AwardType
 import com.thebluealliance.android.util.teamNumber
 
-// TBA web's AWARD_SORT_ORDER (consts/award_type.py): Chairman's/Impact, Founders,
-// Engineering Inspiration, Rookie All Star, Woodie Flowers, Volunteer, Dean's List,
-// Winner, Finalist. The web sorts everything else after these in API order; we use
-// award type as a deterministic tiebreak instead.
-private val awardTypePriority: Map<Int, Int> =
-    listOf(0, 6, 9, 10, 3, 5, 4, 1, 2)
-        .withIndex()
-        .associate { (index, awardType) -> awardType to index }
+// TBA web's AWARD_SORT_ORDER (consts/award_type.py). The web sorts everything
+// else after these in API order; we use the award-type code as a deterministic
+// tiebreak instead.
+private val displayOrder =
+    listOf(
+        AwardType.CHAIRMANS,
+        AwardType.FOUNDERS,
+        AwardType.ENGINEERING_INSPIRATION,
+        AwardType.ROOKIE_ALL_STAR,
+        AwardType.WOODIE_FLOWERS,
+        AwardType.VOLUNTEER,
+        AwardType.DEANS_LIST,
+        AwardType.WINNER,
+        AwardType.FINALIST,
+    )
+
+private val priorityByCode: Map<Int, Int> =
+    displayOrder.withIndex().associate { (index, type) -> type.code to index }
 
 private val Award.displayPriority: Int
-    get() = awardTypePriority[awardType] ?: (awardTypePriority.size + awardType)
+    get() = priorityByCode[awardType] ?: (displayOrder.size + awardType)
 
 fun List<Award>.sortedForDisplay(): List<Award> =
     sortedWith(

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/AwardSort.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/AwardSort.kt
@@ -1,0 +1,25 @@
+package com.thebluealliance.android.domain
+
+import com.thebluealliance.android.domain.model.Award
+import com.thebluealliance.android.util.teamNumber
+
+// TBA web's AWARD_SORT_ORDER (consts/award_type.py): Chairman's/Impact, Founders,
+// Engineering Inspiration, Rookie All Star, Woodie Flowers, Volunteer, Dean's List,
+// Winner, Finalist. The web sorts everything else after these in API order; we use
+// award type as a deterministic tiebreak instead.
+private val awardTypePriority: Map<Int, Int> =
+    listOf(0, 6, 9, 10, 3, 5, 4, 1, 2)
+        .withIndex()
+        .associate { (index, awardType) -> awardType to index }
+
+private val Award.displayPriority: Int
+    get() = awardTypePriority[awardType] ?: (awardTypePriority.size + awardType)
+
+fun List<Award>.sortedForDisplay(): List<Award> =
+    sortedWith(
+        compareBy(
+            { it.displayPriority },
+            { it.teamKey.teamNumber.toIntOrNull() ?: Int.MAX_VALUE },
+            { it.awardee.orEmpty() },
+        ),
+    )

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/AwardType.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/AwardType.kt
@@ -1,0 +1,25 @@
+package com.thebluealliance.android.domain.model
+
+/**
+ * TBA award_type codes (web: consts/award_type.py) the app refers to by name.
+ * [Award.awardType] keeps the raw code since the full upstream enum has ~100 entries;
+ * codes without a named constant here are valid, just not individually significant.
+ */
+enum class AwardType(
+    val code: Int,
+) {
+    CHAIRMANS(0),
+    WINNER(1),
+    FINALIST(2),
+    WOODIE_FLOWERS(3),
+    DEANS_LIST(4),
+    VOLUNTEER(5),
+    FOUNDERS(6),
+    ENGINEERING_INSPIRATION(9),
+    ROOKIE_ALL_STAR(10),
+    ;
+
+    companion object {
+        fun fromCode(code: Int): AwardType? = entries.firstOrNull { it.code == code }
+    }
+}

--- a/app/src/test/kotlin/com/thebluealliance/android/domain/AwardSortTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/domain/AwardSortTest.kt
@@ -1,6 +1,7 @@
 package com.thebluealliance.android.domain
 
 import com.thebluealliance.android.domain.model.Award
+import com.thebluealliance.android.domain.model.AwardType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -9,54 +10,75 @@ class AwardSortTest {
         awardType: Int,
         teamKey: String = "frc254",
         awardee: String? = null,
-        name: String = "Award $awardType",
     ) = Award(
         eventKey = "2026casj",
         awardType = awardType,
         teamKey = teamKey,
         awardee = awardee,
-        name = name,
+        name = "Award $awardType",
         year = 2026,
     )
 
+    private fun award(
+        type: AwardType,
+        teamKey: String = "frc254",
+        awardee: String? = null,
+    ) = award(awardType = type.code, teamKey = teamKey, awardee = awardee)
+
     @Test
     fun `impact award sorts first, then web prestige order, then winner and finalist`() {
+        val highestRookieSeedCode = 14 // no named constant — stays a raw code
         val shuffled =
             listOf(
-                award(awardType = 2), // Finalist
-                award(awardType = 14), // Highest Rookie Seed
-                award(awardType = 1), // Winner
-                award(awardType = 9), // Engineering Inspiration
-                award(awardType = 0), // Chairman's/Impact
-                award(awardType = 3), // Woodie Flowers
+                award(AwardType.FINALIST),
+                award(awardType = highestRookieSeedCode),
+                award(AwardType.WINNER),
+                award(AwardType.ENGINEERING_INSPIRATION),
+                award(AwardType.CHAIRMANS),
+                award(AwardType.WOODIE_FLOWERS),
             )
 
         val sorted = shuffled.sortedForDisplay().map { it.awardType }
 
-        assertEquals(listOf(0, 9, 3, 1, 2, 14), sorted)
+        assertEquals(
+            listOf(
+                AwardType.CHAIRMANS.code,
+                AwardType.ENGINEERING_INSPIRATION.code,
+                AwardType.WOODIE_FLOWERS.code,
+                AwardType.WINNER.code,
+                AwardType.FINALIST.code,
+                highestRookieSeedCode,
+            ),
+            sorted,
+        )
     }
 
     @Test
-    fun `awards not in the priority list sort after listed ones by award type`() {
+    fun `awards without a named constant sort after listed ones by code`() {
+        val chairmansFinalistCode = 69
+        val industrialDesignCode = 11
         val shuffled =
             listOf(
-                award(awardType = 69), // Chairman's Finalist (unlisted)
-                award(awardType = 11), // Industrial Design (unlisted)
-                award(awardType = 2), // Finalist (listed, last priority)
+                award(awardType = chairmansFinalistCode),
+                award(awardType = industrialDesignCode),
+                award(AwardType.FINALIST),
             )
 
         val sorted = shuffled.sortedForDisplay().map { it.awardType }
 
-        assertEquals(listOf(2, 11, 69), sorted)
+        assertEquals(
+            listOf(AwardType.FINALIST.code, industrialDesignCode, chairmansFinalistCode),
+            sorted,
+        )
     }
 
     @Test
     fun `multi-recipient awards order by team number numerically`() {
         val shuffled =
             listOf(
-                award(awardType = 1, teamKey = "frc1114"),
-                award(awardType = 1, teamKey = "frc254"),
-                award(awardType = 1, teamKey = "frc33"),
+                award(AwardType.WINNER, teamKey = "frc1114"),
+                award(AwardType.WINNER, teamKey = "frc254"),
+                award(AwardType.WINNER, teamKey = "frc33"),
             )
 
         val sorted = shuffled.sortedForDisplay().map { it.teamKey }
@@ -68,9 +90,9 @@ class AwardSortTest {
     fun `awardee-only awards sort after team awards of the same type by awardee name`() {
         val shuffled =
             listOf(
-                award(awardType = 4, teamKey = "", awardee = "Zoe Zebra"),
-                award(awardType = 4, teamKey = "", awardee = "Amy Aardvark"),
-                award(awardType = 4, teamKey = "frc1678", awardee = "Casey Carrot"),
+                award(AwardType.DEANS_LIST, teamKey = "", awardee = "Zoe Zebra"),
+                award(AwardType.DEANS_LIST, teamKey = "", awardee = "Amy Aardvark"),
+                award(AwardType.DEANS_LIST, teamKey = "frc1678", awardee = "Casey Carrot"),
             )
 
         val sorted = shuffled.sortedForDisplay().map { it.awardee }

--- a/app/src/test/kotlin/com/thebluealliance/android/domain/AwardSortTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/domain/AwardSortTest.kt
@@ -1,0 +1,80 @@
+package com.thebluealliance.android.domain
+
+import com.thebluealliance.android.domain.model.Award
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AwardSortTest {
+    private fun award(
+        awardType: Int,
+        teamKey: String = "frc254",
+        awardee: String? = null,
+        name: String = "Award $awardType",
+    ) = Award(
+        eventKey = "2026casj",
+        awardType = awardType,
+        teamKey = teamKey,
+        awardee = awardee,
+        name = name,
+        year = 2026,
+    )
+
+    @Test
+    fun `impact award sorts first, then web prestige order, then winner and finalist`() {
+        val shuffled =
+            listOf(
+                award(awardType = 2), // Finalist
+                award(awardType = 14), // Highest Rookie Seed
+                award(awardType = 1), // Winner
+                award(awardType = 9), // Engineering Inspiration
+                award(awardType = 0), // Chairman's/Impact
+                award(awardType = 3), // Woodie Flowers
+            )
+
+        val sorted = shuffled.sortedForDisplay().map { it.awardType }
+
+        assertEquals(listOf(0, 9, 3, 1, 2, 14), sorted)
+    }
+
+    @Test
+    fun `awards not in the priority list sort after listed ones by award type`() {
+        val shuffled =
+            listOf(
+                award(awardType = 69), // Chairman's Finalist (unlisted)
+                award(awardType = 11), // Industrial Design (unlisted)
+                award(awardType = 2), // Finalist (listed, last priority)
+            )
+
+        val sorted = shuffled.sortedForDisplay().map { it.awardType }
+
+        assertEquals(listOf(2, 11, 69), sorted)
+    }
+
+    @Test
+    fun `multi-recipient awards order by team number numerically`() {
+        val shuffled =
+            listOf(
+                award(awardType = 1, teamKey = "frc1114"),
+                award(awardType = 1, teamKey = "frc254"),
+                award(awardType = 1, teamKey = "frc33"),
+            )
+
+        val sorted = shuffled.sortedForDisplay().map { it.teamKey }
+
+        assertEquals(listOf("frc33", "frc254", "frc1114"), sorted)
+    }
+
+    @Test
+    fun `awardee-only awards sort after team awards of the same type by awardee name`() {
+        val shuffled =
+            listOf(
+                award(awardType = 4, teamKey = "", awardee = "Zoe Zebra"),
+                award(awardType = 4, teamKey = "", awardee = "Amy Aardvark"),
+                award(awardType = 4, teamKey = "frc1678", awardee = "Casey Carrot"),
+            )
+
+        val sorted = shuffled.sortedForDisplay().map { it.awardee }
+
+        assertEquals(listOf("Casey Carrot", "Amy Aardvark", "Zoe Zebra"), sorted)
+    }
+}


### PR DESCRIPTION
## Summary
- Awards rendered in arbitrary Room order: `AwardDao` has no `ORDER BY` and neither the repository nor the composables sorted, so Impact/Chairman's and Winner could land mid-list below judged awards.
- Sort once in `EventRepository.observeEventAwards` using the web's `AWARD_SORT_ORDER` (Impact → Founders → Engineering Inspiration → Rookie All Star → Woodie Flowers → Volunteer → Dean's List → Winner → Finalist → everything else by award type), with numeric team-number and awardee tiebreaks. The team@event awards tab filters the same flow, so it's fixed for free.
- Unit tests pin the canonical order, the unlisted-type fallback, and multi-recipient ordering.

Fixes #832

## Panel notes
- **Designer:** "Award ordering IS the information design of that screen."
- **FRC Team Member:** matches how every other TBA surface presents awards — Impact first, then the banners.
- **Tech Lead:** one comparator at the single consumption point; no UI changes.

## Test plan
- [x] `:app:testDebugUnitTest` green (new `AwardSortTest`)
- [x] `:app:assembleDebug` green
- [ ] Before/after screenshots on an event with awards (PR comment to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)