### PR TITLE
Show 1-indexed week on the Event Info tab

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
@@ -30,6 +30,9 @@ private data class SectionKey(
     val label: String,
 )
 
+/** The API's week field is 0-indexed; humans say "Week 1". */
+fun weekLabel(week: Int): String = "Week ${week + 1}"
+
 private fun eventSectionKey(
     event: Event,
     preseasonOver: Boolean,
@@ -41,7 +44,7 @@ private fun eventSectionKey(
         EventType.DISTRICT_CHAMPIONSHIP_DIVISION,
         -> {
             val week = event.week ?: return SectionKey(9999, "Other events")
-            SectionKey(week, "Week ${week + 1}")
+            SectionKey(week, weekLabel(week))
         }
         EventType.CHAMPIONSHIP_DIVISION, EventType.CHAMPIONSHIP_FINALS ->
             SectionKey(1000, "Championship")
@@ -49,7 +52,7 @@ private fun eventSectionKey(
         else -> {
             // Unknown type but has a week — group with regular weeks
             if (event.week != null) {
-                SectionKey(event.week, "Week ${event.week + 1}")
+                SectionKey(event.week, weekLabel(event.week))
             } else {
                 SectionKey(9999, "Other events")
             }
@@ -231,7 +234,7 @@ fun computeThisWeekEvents(
             }
 
         rawEvents = (weekEvents + championshipEvents).distinctBy { it.key }
-        label = "Upcoming This Week \u2014 Week ${currentWeek + 1}"
+        label = "Upcoming This Week \u2014 ${weekLabel(currentWeek)}"
     } else {
         // Offseason fallback: calendar week overlap (Monday-Sunday)
         val monday = today.with(DayOfWeek.MONDAY)
@@ -264,7 +267,7 @@ internal fun currentWeekChipLabel(
     if (selectedYear != today.year) return null
 
     val week = findCurrentCompetitionWeek(allEvents, today)
-    if (week != null) return "Week ${week + 1}"
+    if (week != null) return weekLabel(week)
 
     // Championship events (types 3/4) have week == null, so check by date overlap.
     val championshipActive =

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
@@ -30,8 +30,23 @@ private data class SectionKey(
     val label: String,
 )
 
-/** The API's week field is 0-indexed; humans say "Week 1". */
-fun weekLabel(week: Int): String = "Week ${week + 1}"
+/** The API's week field is 0-indexed; humans say "Week 1", except for special years. */
+fun weekLabel(
+    year: Int,
+    week: Int,
+): String =
+    when (year) {
+        2016 -> "Week ${if (week == 0) "0.5" else week.toString()}"
+        2021 ->
+            when (week) {
+                0 -> "Participation"
+                6 -> "FIRST Innovation Challenge"
+                7 -> "INFINITE RECHARGE At Home Challenge"
+                8 -> "Game Design Challenge"
+                else -> "Awards"
+            }
+        else -> "Week ${week + 1}"
+    }
 
 private fun eventSectionKey(
     event: Event,
@@ -44,7 +59,7 @@ private fun eventSectionKey(
         EventType.DISTRICT_CHAMPIONSHIP_DIVISION,
         -> {
             val week = event.week ?: return SectionKey(9999, "Other events")
-            SectionKey(week, weekLabel(week))
+            SectionKey(week, weekLabel(event.year, week))
         }
         EventType.CHAMPIONSHIP_DIVISION, EventType.CHAMPIONSHIP_FINALS ->
             SectionKey(1000, "Championship")
@@ -52,7 +67,7 @@ private fun eventSectionKey(
         else -> {
             // Unknown type but has a week — group with regular weeks
             if (event.week != null) {
-                SectionKey(event.week, weekLabel(event.week))
+                SectionKey(event.week, weekLabel(event.year, event.week))
             } else {
                 SectionKey(9999, "Other events")
             }
@@ -234,7 +249,7 @@ fun computeThisWeekEvents(
             }
 
         rawEvents = (weekEvents + championshipEvents).distinctBy { it.key }
-        label = "Upcoming This Week \u2014 ${weekLabel(currentWeek)}"
+        label = "Upcoming This Week \u2014 ${weekLabel(selectedYear, currentWeek)}"
     } else {
         // Offseason fallback: calendar week overlap (Monday-Sunday)
         val monday = today.with(DayOfWeek.MONDAY)
@@ -267,7 +282,7 @@ internal fun currentWeekChipLabel(
     if (selectedYear != today.year) return null
 
     val week = findCurrentCompetitionWeek(allEvents, today)
-    if (week != null) return weekLabel(week)
+    if (week != null) return weekLabel(selectedYear, week)
 
     // Championship events (types 3/4) have week == null, so check by date overlap.
     val championshipActive =

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -85,7 +85,7 @@ fun EventInfoTab(
         if (week != null) {
             item {
                 Text(
-                    text = weekLabel(week),
+                    text = weekLabel(event.year, week),
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(top = 4.dp),
                 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -31,6 +31,7 @@ import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.Webcast
 import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.components.formatEventDateRange
+import com.thebluealliance.android.ui.events.weekLabel
 import com.thebluealliance.android.util.openUrl
 
 @Composable
@@ -80,10 +81,11 @@ fun EventInfoTab(
                 )
             }
         }
-        if (event.week != null) {
+        val week = event.week
+        if (week != null) {
             item {
                 Text(
-                    text = "Week ${event.week}",
+                    text = weekLabel(week),
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(top = 4.dp),
                 )

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
@@ -46,8 +46,24 @@ class EventsUiStateTest {
 
     @Test
     fun `weekLabel converts the zero-indexed api week to the one-indexed display label`() {
-        assertEquals("Week 1", weekLabel(0))
-        assertEquals("Week 6", weekLabel(5))
+        assertEquals("Week 1", weekLabel(2026, 0))
+        assertEquals("Week 6", weekLabel(2026, 5))
+    }
+
+    @Test
+    fun `weekLabel formats 2016 week 0 as week zero point five`() {
+        assertEquals("Week 0.5", weekLabel(2016, 0))
+        assertEquals("Week 1", weekLabel(2016, 1))
+        assertEquals("Week 6", weekLabel(2016, 6))
+    }
+
+    @Test
+    fun `weekLabel uses custom labels for 2021 events`() {
+        assertEquals("Participation", weekLabel(2021, 0))
+        assertEquals("Awards", weekLabel(2021, 1))
+        assertEquals("FIRST Innovation Challenge", weekLabel(2021, 6))
+        assertEquals("INFINITE RECHARGE At Home Challenge", weekLabel(2021, 7))
+        assertEquals("Game Design Challenge", weekLabel(2021, 8))
     }
 
     // --- buildHeaderInfos: index calculation ---

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
@@ -42,6 +42,14 @@ class EventsUiStateTest {
         playoffType = PlayoffType.BRACKET_8_TEAM,
     )
 
+    // --- weekLabel ---
+
+    @Test
+    fun `weekLabel converts the zero-indexed api week to the one-indexed display label`() {
+        assertEquals("Week 1", weekLabel(0))
+        assertEquals("Week 6", weekLabel(5))
+    }
+
     // --- buildHeaderInfos: index calculation ---
 
     @Test


### PR DESCRIPTION
## Summary
- The events list, week chips, and "Upcoming This Week" header all render `week + 1`, but the Event Info tab printed the raw 0-indexed API value — the same event appeared under "Week 5" in the list and said "Week 4" on its own page, and week-1 events said "Week 0".
- All five week-label call sites now share a single `weekLabel()` so they can't diverge again; unit test pins `0 -> "Week 1"`.

Fixes #1343

## Panel notes
- **PM / FRC Team Member:** people cross-reference week numbers for travel and scouting; a self-contradicting app loses trust fast.

## Test plan
- [x] `:app:testDebugUnitTest` green (weekLabel test added to `EventsUiStateTest`)
- [x] `:app:assembleDebug` green
- [ ] Before/after screenshots of an event info tab (PR comment to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)