### PR TITLE
Display match times in the event's timezone

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/MatchList.kt
@@ -45,6 +45,7 @@ fun MatchList(
     matches: List<Match>?,
     playoffType: PlayoffType,
     onNavigateToMatch: (String) -> Unit,
+    eventTimezone: String? = null,
     headerContent: (LazyListScope.() -> Unit)? = null,
     headerItemCount: Int = 0,
     innerPadding: PaddingValues = PaddingValues.Zero,
@@ -157,6 +158,7 @@ fun MatchList(
                 MatchItem(
                     match = match,
                     playoffType = playoffType,
+                    eventTimezone = eventTimezone,
                     onClick = { onNavigateToMatch(match.key) },
                 )
                 HorizontalDivider()
@@ -170,6 +172,7 @@ fun MatchItem(
     match: Match,
     playoffType: PlayoffType,
     onClick: () -> Unit,
+    eventTimezone: String? = null,
 ) {
     val label = match.getShortLabel(playoffType)
     val isPlayed = match.redScore >= 0
@@ -341,7 +344,7 @@ fun MatchItem(
                         match.time != null &&
                         kotlin.math.abs(match.predictedTime - match.time) > 60
                 Text(
-                    text = formatMatchTime(displayTime),
+                    text = formatMatchTime(displayTime, eventTimezone),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -363,11 +366,18 @@ private val matchTimeFormat =
         java.util.Locale.US,
     )
 
-fun formatMatchTime(epochSeconds: Long?): String {
+/** Formats in the event's local time when [eventTimezone] is a valid zone ID, else device time. */
+fun formatMatchTime(
+    epochSeconds: Long?,
+    eventTimezone: String? = null,
+): String {
     if (epochSeconds == null) return "\u2014"
+    val zone =
+        eventTimezone?.let { runCatching { java.time.ZoneId.of(it) }.getOrNull() }
+            ?: java.time.ZoneId.systemDefault()
     val instant = java.time.Instant.ofEpochSecond(epochSeconds)
     return matchTimeFormat
-        .format(instant.atZone(java.time.ZoneId.systemDefault()))
+        .format(instant.atZone(zone))
         .replace("AM", "a")
         .replace("PM", "p")
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -377,6 +377,7 @@ fun EventDetailScreen(
                             matches = uiState.matches,
                             playoffType = uiState.event?.playoffType ?: PlayoffType.OTHER,
                             onNavigateToMatch = onNavigateToMatch,
+                            eventTimezone = uiState.event?.timezone,
                             innerPadding = bottomPadding,
                         )
                     EventDetailTab.ALLIANCES ->

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventMatchesTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventMatchesTab.kt
@@ -11,12 +11,14 @@ fun EventMatchesTab(
     matches: List<Match>?,
     playoffType: PlayoffType,
     onNavigateToMatch: (String) -> Unit,
+    eventTimezone: String? = null,
     innerPadding: PaddingValues = PaddingValues.Zero,
 ) {
     MatchList(
         matches = matches,
         playoffType = playoffType,
         onNavigateToMatch = onNavigateToMatch,
+        eventTimezone = eventTimezone,
         innerPadding = innerPadding,
     )
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailViewModel.kt
@@ -62,7 +62,7 @@ class MatchDetailViewModel
                         match.time != null &&
                         kotlin.math.abs(match.predictedTime - match.time) > 60
                 val formattedTime =
-                    formatMatchTime(timeToDisplay)?.let {
+                    formatMatchTime(timeToDisplay, event?.timezone)?.let {
                         if (isEstimate) "$it (est.)" else it
                     }
                 MatchDetailUiState(
@@ -95,10 +95,16 @@ class MatchDetailViewModel
             refreshing({ matchRepository.refreshMatch(matchKey) })
         }
 
-        private fun formatMatchTime(epochSeconds: Long?): String? {
+        private fun formatMatchTime(
+            epochSeconds: Long?,
+            eventTimezone: String?,
+        ): String? {
             if (epochSeconds == null) return null
+            val zone =
+                eventTimezone?.let { runCatching { ZoneId.of(it) }.getOrNull() }
+                    ?: ZoneId.systemDefault()
             val instant = Instant.ofEpochSecond(epochSeconds)
-            return timeFormatter.format(instant.atZone(ZoneId.systemDefault()))
+            return timeFormatter.format(instant.atZone(zone))
         }
 
         private fun parseVideos(jsonString: String): List<MatchVideo> {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -231,6 +231,7 @@ fun TeamEventDetailScreen(
                             matches = uiState.matches,
                             playoffType = evt?.playoffType ?: PlayoffType.OTHER,
                             onNavigateToMatch = onNavigateToMatch,
+                            eventTimezone = evt?.timezone,
                             headerItemCount = headerCount,
                             headerContent = {
                                 if (evt != null) {
@@ -503,6 +504,7 @@ private fun SummaryTab(
                         MatchItem(
                             match = lastPlayed,
                             playoffType = playoffType,
+                            eventTimezone = event?.timezone,
                             onClick = { onNavigateToMatch(lastPlayed.key) },
                         )
                     }
@@ -515,6 +517,7 @@ private fun SummaryTab(
                         MatchItem(
                             match = nextUnplayed,
                             playoffType = playoffType,
+                            eventTimezone = event?.timezone,
                             onClick = { onNavigateToMatch(nextUnplayed.key) },
                         )
                     }

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/components/MatchTimeFormatTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/components/MatchTimeFormatTest.kt
@@ -1,0 +1,26 @@
+package com.thebluealliance.android.ui.components
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MatchTimeFormatTest {
+    // 2026-01-01T00:00:00Z
+    private val newYearsUtc = 1767225600L
+
+    @Test
+    fun `formats in the event timezone when provided`() {
+        assertEquals("Wed 7:00p", formatMatchTime(newYearsUtc, "America/New_York"))
+        assertEquals("Thu 9:00a", formatMatchTime(newYearsUtc, "Asia/Tokyo"))
+    }
+
+    @Test
+    fun `falls back to device timezone when the zone id is invalid or missing`() {
+        val deviceLocal = formatMatchTime(newYearsUtc, null)
+        assertEquals(deviceLocal, formatMatchTime(newYearsUtc, "Not/AZone"))
+    }
+
+    @Test
+    fun `null time renders an em dash`() {
+        assertEquals("—", formatMatchTime(null, "America/New_York"))
+    }
+}


### PR DESCRIPTION
## Summary
- Match rows (`MatchList`) and the match detail header formatted times with `ZoneId.systemDefault()`, so anyone following a remote event saw times that disagreed with the venue schedule, TBA web, and FRC schedules — a parent in California saw "Sat 6:00a" for a 9:00 AM East Coast match.
- `Event.timezone` was already stored on the entity/domain model but unused by any UI. It now drives both formatters (match list rows, team@event summary rows, match detail header), falling back to device time when missing or invalid.
- The home-screen widget intentionally keeps device-local time for its at-event use case.

## Panel notes
- **PM:** "small fix with outsized trust impact during competition season" — their top quick win.
- **FRC Team Member:** FRC schedules speak venue-local; the app should too.

## Test plan
- [x] New `MatchTimeFormatTest` covers explicit zones (NY/Tokyo), invalid-zone fallback, and null time
- [x] `:app:assembleDebug` + `:app:testDebugUnitTest` green
- [ ] Before/after screenshots of a match list (PR comment to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)