### PR TITLE
Fix double-elim advancement routing; hide it for unplayed matches

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/domain/MatchAdvancementMsgs.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/MatchAdvancementMsgs.kt
@@ -16,22 +16,26 @@ data class MatchAdvancementMsgs(
  */
 fun Match.getAdvancement(playoffType: PlayoffType?): MatchAdvancementMsgs? {
     if (this.compLevel !in PLAYOFF_COMP_LEVELS || this.compLevel == CompLevel.FINAL) return null
+    // Unplayed match: nobody has advanced or been eliminated yet.
+    if (this.winningAlliance.isNullOrEmpty() || this.redScore < 0) return null
 
     val (winAdvancement, loseAdvancement) =
         when (playoffType) {
-            // 2023+
+            // 2023+ bracket (FIRST Game Manual Table 11-3): M11 is the upper-bracket
+            // final (W7 vs W8, winner to Finals, loser to M13); M12 is lower bracket
+            // (W9 vs W10, winner to M13, loser out).
             PlayoffType.DOUBLE_ELIM_8_TEAM ->
                 when (this.setNumber) {
                     1, 2 -> "Advances to Upper Bracket - R2-7" to "Advances to Lower Bracket - R2-5"
                     3, 4 -> "Advances to Upper Bracket - R2-8" to "Advances to Lower Bracket - R2-6"
                     5 -> "Advances to Lower Bracket - R3-10" to "Eliminated"
                     6 -> "Advances to Lower Bracket - R3-9" to "Eliminated"
-                    7 -> "Advances to Upper Bracket - R4-12" to "Advances to Lower Bracket - R3-9"
-                    8 -> "Advances to Upper Bracket - R4-12" to "Advances to Lower Bracket - R3-10"
-                    9 -> "Advances to Lower Bracket - R4-11" to "Eliminated"
-                    10 -> "Advances to Lower Bracket - R4-11" to "Eliminated"
-                    11 -> "Advances to Lower Bracket - R5-13" to "Eliminated"
-                    12 -> "Advances to Finals" to "Advances to Lower Bracket - R5-13"
+                    7 -> "Advances to Upper Bracket - R4-11" to "Advances to Lower Bracket - R3-9"
+                    8 -> "Advances to Upper Bracket - R4-11" to "Advances to Lower Bracket - R3-10"
+                    9 -> "Advances to Lower Bracket - R4-12" to "Eliminated"
+                    10 -> "Advances to Lower Bracket - R4-12" to "Eliminated"
+                    11 -> "Advances to Finals" to "Advances to Lower Bracket - R5-13"
+                    12 -> "Advances to Lower Bracket - R5-13" to "Eliminated"
                     13 -> "Advances to Finals" to "Eliminated"
                     else -> null
                 }

--- a/app/src/test/kotlin/com/thebluealliance/android/domain/MatchAdvancementMsgsTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/domain/MatchAdvancementMsgsTest.kt
@@ -1,0 +1,108 @@
+package com.thebluealliance.android.domain
+
+import com.thebluealliance.android.domain.model.CompLevel
+import com.thebluealliance.android.domain.model.Match
+import com.thebluealliance.android.domain.model.PlayoffType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class MatchAdvancementMsgsTest {
+    private fun match(
+        setNumber: Int,
+        compLevel: CompLevel = CompLevel.SEMIFINAL,
+        winningAlliance: String? = "red",
+        redScore: Int = 100,
+        blueScore: Int = 80,
+    ) = Match(
+        key = "2026test_sf${setNumber}m1",
+        eventKey = "2026test",
+        compLevel = compLevel,
+        matchNumber = 1,
+        setNumber = setNumber,
+        time = null,
+        predictedTime = null,
+        actualTime = null,
+        redTeamKeys = listOf("frc1", "frc2", "frc3"),
+        redScore = redScore,
+        blueTeamKeys = listOf("frc4", "frc5", "frc6"),
+        blueScore = blueScore,
+        winningAlliance = winningAlliance,
+    )
+
+    // FIRST Game Manual Table 11-3 (2023+ double elim):
+    // M11 = upper final (winner -> Finals, loser -> M13); M12 = lower R4
+    // (winner -> M13, loser out); M13 = lower final (winner -> Finals).
+    @Test
+    fun `eight team bracket routes every set per the official table`() {
+        val expected =
+            mapOf(
+                1 to ("Advances to Upper Bracket - R2-7" to "Advances to Lower Bracket - R2-5"),
+                2 to ("Advances to Upper Bracket - R2-7" to "Advances to Lower Bracket - R2-5"),
+                3 to ("Advances to Upper Bracket - R2-8" to "Advances to Lower Bracket - R2-6"),
+                4 to ("Advances to Upper Bracket - R2-8" to "Advances to Lower Bracket - R2-6"),
+                5 to ("Advances to Lower Bracket - R3-10" to "Eliminated"),
+                6 to ("Advances to Lower Bracket - R3-9" to "Eliminated"),
+                7 to ("Advances to Upper Bracket - R4-11" to "Advances to Lower Bracket - R3-9"),
+                8 to ("Advances to Upper Bracket - R4-11" to "Advances to Lower Bracket - R3-10"),
+                9 to ("Advances to Lower Bracket - R4-12" to "Eliminated"),
+                10 to ("Advances to Lower Bracket - R4-12" to "Eliminated"),
+                11 to ("Advances to Finals" to "Advances to Lower Bracket - R5-13"),
+                12 to ("Advances to Lower Bracket - R5-13" to "Eliminated"),
+                13 to ("Advances to Finals" to "Eliminated"),
+            )
+
+        expected.forEach { (set, winLose) ->
+            val msgs = match(setNumber = set).getAdvancement(PlayoffType.DOUBLE_ELIM_8_TEAM)
+            assertEquals(winLose.first, msgs?.red, "set $set red (winner)")
+            assertEquals(winLose.second, msgs?.blue, "set $set blue (loser)")
+        }
+    }
+
+    @Test
+    fun `upper final loser is not eliminated and lower r4 winner goes to m13`() {
+        val upperFinal = match(setNumber = 11, winningAlliance = "blue")
+        val msgs = upperFinal.getAdvancement(PlayoffType.DOUBLE_ELIM_8_TEAM)
+
+        assertEquals("Advances to Finals", msgs?.blue)
+        assertEquals("Advances to Lower Bracket - R5-13", msgs?.red)
+    }
+
+    @Test
+    fun `four team bracket unchanged`() {
+        val msgs = match(setNumber = 3).getAdvancement(PlayoffType.DOUBLE_ELIM_4_TEAM)
+
+        assertEquals("Advances to Finals", msgs?.red)
+        assertEquals("Advances to Lower Bracket - R3-5", msgs?.blue)
+    }
+
+    @Test
+    fun `unplayed match returns null instead of marking both alliances eliminated`() {
+        val unplayed = match(setNumber = 11, winningAlliance = null, redScore = -1, blueScore = -1)
+
+        assertNull(unplayed.getAdvancement(PlayoffType.DOUBLE_ELIM_8_TEAM))
+    }
+
+    @Test
+    fun `tie with empty winning alliance returns null`() {
+        val tie = match(setNumber = 9, winningAlliance = "", redScore = 50, blueScore = 50)
+
+        assertNull(tie.getAdvancement(PlayoffType.DOUBLE_ELIM_8_TEAM))
+    }
+
+    @Test
+    fun `finals and quals return null`() {
+        assertNull(
+            match(
+                setNumber = 1,
+                compLevel = CompLevel.FINAL,
+            ).getAdvancement(PlayoffType.DOUBLE_ELIM_8_TEAM),
+        )
+        assertNull(
+            match(
+                setNumber = 1,
+                compLevel = CompLevel.QUAL,
+            ).getAdvancement(PlayoffType.DOUBLE_ELIM_8_TEAM),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- The 8-alliance double-elim mapping inverted Match 11/12 versus the official 2023+ bracket (FIRST Game Manual Table 11-3): **M11 is the upper-bracket final** — winner to Finals, loser to M13 — and **M12 is lower-bracket R4** — winner to M13, loser out. The app told an upper-final winner "Advances to Lower Bracket - R5-13" and its still-alive loser "Eliminated"; sets 7-10 also pointed at the wrong Round 4 match (R4-12/R4-11 swapped). The 4-team mapping was already correct — and internally contradicted the 8-team one.
- Unplayed matches now return no advancement: with `winningAlliance` null, both alliances previously rendered the *loser* string, so upcoming elims matches showed "Eliminated" on both sides mid-event.
- Table-driven test pins all 13 sets, the 4-team bracket, the unplayed/tie guards, and the finals/quals exclusions.

Verified against the official double-elim structure (M1-M4 upper R1; M5/M6 lower R2; M7/M8 upper R2 with losers feeding M9/M10 — which the app's own sets 7-8 loser-routing already agreed with, contradicting its winner-routing).

## Panel notes
- **FRC Team Member:** top finding of the domain audit — mid-event elims is peak traffic, and this showed confidently wrong elimination status.
- **Tech Lead:** the missing unplayed guard mirrors `rpBonuses()`'s `redScore < 0` check two files away; zero tests existed on this table.

## Test plan
- [x] New `MatchAdvancementMsgsTest` (6 tests) green
- [x] `:app:testDebugUnitTest` + `:app:assembleDebug` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Double-elim match advancement (SF Match 11)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1397_match_before-1a90988e.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1397_match_after-de33b611.png" width="300"> |
<!-- screenshots:end -->