### PR TITLE
Sum all DCMP entries in the district rankings table

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictDetailScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.thebluealliance.android.domain.model.DistrictEventPoints
 import com.thebluealliance.android.domain.model.DistrictRanking
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
@@ -380,12 +381,7 @@ private fun RankingsTab(
                     ?.toInt()
                     ?.toString()
                     ?: "-"
-            val dcmpPoints =
-                ranking.eventPoints
-                    .find { it.districtCmp }
-                    ?.total
-                    ?.toInt()
-                    ?.toString() ?: "-"
+            val dcmpPoints = dcmpPointsLabel(ranking.eventPoints)
 
             Row(
                 modifier =
@@ -441,4 +437,11 @@ private fun RankingsTab(
             HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp), thickness = 0.5.dp)
         }
     }
+}
+
+/** DCMPs with divisions report division + finals as separate districtCmp entries; sum them. */
+internal fun dcmpPointsLabel(eventPoints: List<DistrictEventPoints>): String {
+    val dcmpEntries = eventPoints.filter { it.districtCmp }
+    if (dcmpEntries.isEmpty()) return "-"
+    return dcmpEntries.sumOf { it.total }.toInt().toString()
 }

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/districts/DcmpPointsLabelTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/districts/DcmpPointsLabelTest.kt
@@ -1,0 +1,43 @@
+package com.thebluealliance.android.ui.districts
+
+import com.thebluealliance.android.domain.model.DistrictEventPoints
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DcmpPointsLabelTest {
+    private fun points(
+        eventKey: String,
+        total: Double,
+        districtCmp: Boolean,
+    ) = DistrictEventPoints(eventKey = eventKey, total = total, districtCmp = districtCmp)
+
+    @Test
+    fun `sums division and finals points at a dcmp with divisions`() {
+        val eventPoints =
+            listOf(
+                points("2026necmp1", 45.0, districtCmp = true),
+                points("2026necmp", 30.0, districtCmp = true),
+                points("2026nhgrs", 60.0, districtCmp = false),
+            )
+
+        assertEquals("75", dcmpPointsLabel(eventPoints))
+    }
+
+    @Test
+    fun `single dcmp entry shows its total`() {
+        val eventPoints =
+            listOf(
+                points("2026micmp", 52.0, districtCmp = true),
+                points("2026miket", 70.0, districtCmp = false),
+            )
+
+        assertEquals("52", dcmpPointsLabel(eventPoints))
+    }
+
+    @Test
+    fun `no dcmp entries shows a dash`() {
+        val eventPoints = listOf(points("2026nhgrs", 60.0, districtCmp = false))
+
+        assertEquals("-", dcmpPointsLabel(eventPoints))
+    }
+}


### PR DESCRIPTION
## Summary
- At district championships with divisions (FIM, NE, ONT, FIT…), a team earns **two** `districtCmp = true` point entries — the division field and the finals field. The DCMP column used `.find` and displayed only the first, so Event 1 + Event 2 + DCMP + Rookie Bonus visibly didn't add up to the Total column for any team that made the DCMP finals field.
- Extracted `dcmpPointsLabel()` which sums all `districtCmp` entries (TBA web behavior), with "-" when a team hasn't played a DCMP.

## Panel notes
- **FRC Team Member:** "instantly distrust-inducing for anyone sweating Michigan's cutline" — the table contradicted its own Total column at exactly the moment people scrutinize it.

## Test plan
- [x] New `DcmpPointsLabelTest`: divisions summed, single-entry unchanged, dash when absent
- [x] `:app:testDebugUnitTest` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)