### PR TITLE
Repositories throw on refresh failure instead of swallowing

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
@@ -125,16 +125,13 @@ class EventRepository
             teamKey: String,
             year: Int,
         ) {
-            try {
-                val dtos = api.getTeamEvents(teamKey, year)
-                db.withTransaction {
-                    eventDao.insertAll(dtos.map { it.toEntity() })
-                    eventTeamDao.deleteByTeamAndYear(teamKey, year.toString())
-                    eventTeamDao.insertAll(
-                        dtos.map { EventTeamEntity(eventKey = it.key, teamKey = teamKey) },
-                    )
-                }
-            } catch (_: Exception) {
+            val dtos = api.getTeamEvents(teamKey, year)
+            db.withTransaction {
+                eventDao.insertAll(dtos.map { it.toEntity() })
+                eventTeamDao.deleteByTeamAndYear(teamKey, year.toString())
+                eventTeamDao.insertAll(
+                    dtos.map { EventTeamEntity(eventKey = it.key, teamKey = teamKey) },
+                )
             }
         }
 
@@ -142,13 +139,10 @@ class EventRepository
             eventDao.observeByDistrict(districtKey).map { list -> list.map { it.toDomain() } }
 
         suspend fun refreshDistrictEvents(districtKey: String) {
-            try {
-                val dtos = api.getDistrictEvents(districtKey)
-                db.withTransaction {
-                    eventDao.deleteByDistrict(districtKey)
-                    eventDao.insertAll(dtos.map { it.toEntity() })
-                }
-            } catch (_: Exception) {
+            val dtos = api.getDistrictEvents(districtKey)
+            db.withTransaction {
+                eventDao.deleteByDistrict(districtKey)
+                eventDao.insertAll(dtos.map { it.toEntity() })
             }
         }
 
@@ -166,26 +160,20 @@ class EventRepository
         }
 
         suspend fun refreshEventAwards(eventKey: String) {
-            try {
-                val dtos = api.getEventAwards(eventKey)
-                db.withTransaction {
-                    awardDao.deleteByEvent(eventKey)
-                    awardDao.insertAll(dtos.flatMap { it.toEntities() })
-                }
-            } catch (_: Exception) {
+            val dtos = api.getEventAwards(eventKey)
+            db.withTransaction {
+                awardDao.deleteByEvent(eventKey)
+                awardDao.insertAll(dtos.flatMap { it.toEntities() })
             }
         }
 
         suspend fun refreshEventRankings(eventKey: String) {
-            try {
-                val response = api.getEventRankings(eventKey)
-                db.withTransaction {
-                    rankingDao.deleteByEvent(eventKey)
-                    rankingDao.insertAll(response.rankings.map { it.toEntity(eventKey) })
-                    eventRankingSortOrderDao.delete(eventKey)
-                    eventRankingSortOrderDao.insert(response.toSortOrderEntity(eventKey))
-                }
-            } catch (_: Exception) {
+            val response = api.getEventRankings(eventKey)
+            db.withTransaction {
+                rankingDao.deleteByEvent(eventKey)
+                rankingDao.insertAll(response.rankings.map { it.toEntity(eventKey) })
+                eventRankingSortOrderDao.delete(eventKey)
+                eventRankingSortOrderDao.insert(response.toSortOrderEntity(eventKey))
             }
         }
 
@@ -195,17 +183,14 @@ class EventRepository
             }
 
         suspend fun refreshEventDistrictPoints(eventKey: String) {
-            try {
-                val response = api.getEventDistrictPoints(eventKey)
-                val entities =
-                    response.points.map { (teamKey, entry) ->
-                        entry.toEntity(eventKey, teamKey, PointsSource.DISTRICT)
-                    }
-                db.withTransaction {
-                    eventAdvancementPointsDao.deleteByEvent(eventKey, PointsSource.DISTRICT)
-                    eventAdvancementPointsDao.insertAll(entities)
+            val response = api.getEventDistrictPoints(eventKey)
+            val entities =
+                response.points.map { (teamKey, entry) ->
+                    entry.toEntity(eventKey, teamKey, PointsSource.DISTRICT)
                 }
-            } catch (_: Exception) {
+            db.withTransaction {
+                eventAdvancementPointsDao.deleteByEvent(eventKey, PointsSource.DISTRICT)
+                eventAdvancementPointsDao.insertAll(entities)
             }
         }
 
@@ -215,17 +200,14 @@ class EventRepository
             }
 
         suspend fun refreshEventRegionalPoints(eventKey: String) {
-            try {
-                val response = api.getEventRegionalPoints(eventKey)
-                val entities =
-                    response.points.map { (teamKey, entry) ->
-                        entry.toEntity(eventKey, teamKey, PointsSource.REGIONAL)
-                    }
-                db.withTransaction {
-                    eventAdvancementPointsDao.deleteByEvent(eventKey, PointsSource.REGIONAL)
-                    eventAdvancementPointsDao.insertAll(entities)
+            val response = api.getEventRegionalPoints(eventKey)
+            val entities =
+                response.points.map { (teamKey, entry) ->
+                    entry.toEntity(eventKey, teamKey, PointsSource.REGIONAL)
                 }
-            } catch (_: Exception) {
+            db.withTransaction {
+                eventAdvancementPointsDao.deleteByEvent(eventKey, PointsSource.REGIONAL)
+                eventAdvancementPointsDao.insertAll(entities)
             }
         }
 
@@ -274,20 +256,17 @@ class EventRepository
         }
 
         suspend fun refreshEventAlliances(eventKey: String) {
-            try {
-                val dtos = api.getEventAlliances(eventKey)
-                db.withTransaction {
-                    allianceDao.deleteByEvent(eventKey)
-                    allianceDao.insertAll(
-                        dtos.mapIndexed { index, dto ->
-                            dto.toEntity(
-                                eventKey,
-                                index + 1,
-                            )
-                        },
-                    )
-                }
-            } catch (_: Exception) {
+            val dtos = api.getEventAlliances(eventKey)
+            db.withTransaction {
+                allianceDao.deleteByEvent(eventKey)
+                allianceDao.insertAll(
+                    dtos.mapIndexed { index, dto ->
+                        dto.toEntity(
+                            eventKey,
+                            index + 1,
+                        )
+                    },
+                )
             }
         }
 
@@ -295,13 +274,10 @@ class EventRepository
             eventOPRsDao.observe(eventKey).map { it?.toDomain() }
 
         suspend fun refreshEventOPRs(eventKey: String) {
-            try {
-                val dto = api.getEventOPRs(eventKey)
-                db.withTransaction {
-                    eventOPRsDao.delete(eventKey)
-                    eventOPRsDao.insert(dto.toEntity(eventKey))
-                }
-            } catch (_: Exception) {
+            val dto = api.getEventOPRs(eventKey)
+            db.withTransaction {
+                eventOPRsDao.delete(eventKey)
+                eventOPRsDao.insert(dto.toEntity(eventKey))
             }
         }
 
@@ -309,13 +285,10 @@ class EventRepository
             eventCOPRsDao.observe(eventKey).map { it?.toDomain() }
 
         suspend fun refreshEventCOPRs(eventKey: String) {
-            try {
-                val dto = api.getEventCOPRs(eventKey)
-                db.withTransaction {
-                    eventCOPRsDao.delete(eventKey)
-                    eventCOPRsDao.insert(dto.toEntity(eventKey))
-                }
-            } catch (_: Exception) {
+            val dto = api.getEventCOPRs(eventKey)
+            db.withTransaction {
+                eventCOPRsDao.delete(eventKey)
+                eventCOPRsDao.insert(dto.toEntity(eventKey))
             }
         }
 
@@ -323,18 +296,15 @@ class EventRepository
             eventInsightsDao.observe(eventKey).map { it?.toDomain() }
 
         suspend fun refreshEventInsights(eventKey: String) {
-            try {
-                val insights = api.getEventInsights(eventKey)
-                val dto =
-                    EventInsightsDto(
-                        qual = insights["qual"]?.toString(),
-                        playoff = insights["playoff"]?.toString(),
-                    )
-                db.withTransaction {
-                    eventInsightsDao.delete(eventKey)
-                    eventInsightsDao.insert(dto.toEntity(eventKey))
-                }
-            } catch (_: Exception) {
+            val insights = api.getEventInsights(eventKey)
+            val dto =
+                EventInsightsDto(
+                    qual = insights["qual"]?.toString(),
+                    playoff = insights["playoff"]?.toString(),
+                )
+            db.withTransaction {
+                eventInsightsDao.delete(eventKey)
+                eventInsightsDao.insert(dto.toEntity(eventKey))
             }
         }
 
@@ -347,17 +317,14 @@ class EventRepository
             }
 
         suspend fun refreshEventPitLocations(eventKey: String) {
-            try {
-                val statuses = api.getEventTeamsStatuses(eventKey)
-                val entities =
-                    statuses.map { (teamKey, status) ->
-                        TeamEventStatusEntity(teamKey, eventKey, status?.pitLocation)
-                    }
-                db.withTransaction {
-                    teamEventStatusDao.deleteByEvent(eventKey)
-                    teamEventStatusDao.insertAll(entities)
+            val statuses = api.getEventTeamsStatuses(eventKey)
+            val entities =
+                statuses.map { (teamKey, status) ->
+                    TeamEventStatusEntity(teamKey, eventKey, status?.pitLocation)
                 }
-            } catch (_: Exception) {
+            db.withTransaction {
+                teamEventStatusDao.deleteByEvent(eventKey)
+                teamEventStatusDao.insertAll(entities)
             }
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/MatchRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/MatchRepository.kt
@@ -26,21 +26,15 @@ class MatchRepository
         fun observeMatch(key: String): Flow<Match?> = matchDao.observe(key).map { it?.toDomain() }
 
         suspend fun refreshMatch(matchKey: String) {
-            try {
-                val dto = api.getMatch(matchKey)
-                matchDao.insertAll(listOf(dto.toEntity()))
-            } catch (_: Exception) {
-            }
+            val dto = api.getMatch(matchKey)
+            matchDao.insertAll(listOf(dto.toEntity()))
         }
 
         suspend fun refreshEventMatches(eventKey: String) {
-            try {
-                val dtos = api.getEventMatches(eventKey)
-                db.withTransaction {
-                    matchDao.deleteByEvent(eventKey)
-                    matchDao.insertAll(dtos.map { it.toEntity() })
-                }
-            } catch (_: Exception) {
+            val dtos = api.getEventMatches(eventKey)
+            db.withTransaction {
+                matchDao.deleteByEvent(eventKey)
+                matchDao.insertAll(dtos.map { it.toEntity() })
             }
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/TeamRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/TeamRepository.kt
@@ -57,16 +57,13 @@ class TeamRepository
             eventTeamDao.observeByEvent(eventKey).map { list -> list.map { it.teamKey } }
 
         suspend fun refreshEventTeams(eventKey: String) {
-            try {
-                val dtos = api.getEventTeams(eventKey)
-                db.withTransaction {
-                    teamDao.insertAll(dtos.map { it.toEntity() })
-                    eventTeamDao.deleteByEvent(eventKey)
-                    eventTeamDao.insertAll(
-                        dtos.map { EventTeamEntity(eventKey = eventKey, teamKey = it.key) },
-                    )
-                }
-            } catch (_: Exception) {
+            val dtos = api.getEventTeams(eventKey)
+            db.withTransaction {
+                teamDao.insertAll(dtos.map { it.toEntity() })
+                eventTeamDao.deleteByEvent(eventKey)
+                eventTeamDao.insertAll(
+                    dtos.map { EventTeamEntity(eventKey = eventKey, teamKey = it.key) },
+                )
             }
         }
 
@@ -95,10 +92,7 @@ class TeamRepository
             teamKey: String,
             eventKey: String,
         ) {
-            try {
-                val pitLocation = api.getTeamEventStatus(teamKey, eventKey)?.pitLocation
-                teamEventStatusDao.insert(TeamEventStatusEntity(teamKey, eventKey, pitLocation))
-            } catch (_: Exception) {
-            }
+            val pitLocation = api.getTeamEventStatus(teamKey, eventKey)?.pitLocation
+            teamEventStatusDao.insert(TeamEventStatusEntity(teamKey, eventKey, pitLocation))
         }
     }

--- a/app/src/test/kotlin/com/thebluealliance/android/data/repository/EventRepositoryTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/data/repository/EventRepositoryTest.kt
@@ -75,6 +75,17 @@ class EventRepositoryTest {
         )
 
     @Test
+    fun `refresh methods propagate API failures without touching the DAO`() =
+        runTest {
+            coEvery { api.getEventAwards("2026test") } throws java.io.IOException("network down")
+
+            val thrown = runCatching { repo.refreshEventAwards("2026test") }.exceptionOrNull()
+
+            assertEquals("network down", thrown?.message)
+            coVerify(exactly = 0) { awardDao.deleteByEvent(any()) }
+        }
+
+    @Test
     fun `refreshEventsForYear fetches from API and inserts into DAO`() =
         runTest {
             val dto =


### PR DESCRIPTION
## Summary
- Fifteen `refresh*` methods across `EventRepository`/`MatchRepository`/`TeamRepository` wrapped their entire body in `try { … } catch (_: Exception) {}`. Consequences: `UiState.Error` was unreachable for those flows, pull-to-refresh on a dead network "succeeded" silently, nothing reached logcat, and `TeamTrackingWorker`'s defensive try/catch+`Log.w` was dead code. `DistrictRepository` (and `refreshEvent`/`refreshEventsForYear`/`refreshTeam`/`refreshTeamMedia`/`refreshTeamsPage`) already threw — two contradictory conventions in one layer.
- Remove the catches so failures propagate. Data integrity is unchanged: every write happens after the fetch, inside `db.withTransaction`, so a failure still leaves cached rows untouched.
- **Every caller verified:** all ViewModel refreshes route through `RefreshableViewModel.refreshing()` which catches per-task (rethrowing `CancellationException`) and logs; all three `TeamTrackingWorker` call sites have their own try/catch + log; `MatchDetailViewModel.init` guards its cold-cache event fetch. `MyTBARepository`'s catches are intentionally out of scope — its error semantics are a separate finding with user-facing messaging implications.
- Contract test pins that a failing API call propagates and performs no DAO writes.

The convention is expressed by the code itself plus the contract test — no separate docs note.

## Panel notes
- **Tech Lead:** this was the top code-health finding — "exactly how the next 'content regressing on spotty network' bug stays undiagnosable." Unblocks the state-machine work in #1392.

## Test plan
- [x] New contract test (`refresh methods propagate API failures without touching the DAO`)
- [x] Full `:app:testDebugUnitTest` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
