### PR TITLE
Make notification taps work while the app is running

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/NotificationBuilder.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/NotificationBuilder.kt
@@ -4,8 +4,8 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import androidx.core.app.NotificationCompat
+import androidx.core.net.toUri
 import com.google.firebase.messaging.RemoteMessage
 import com.thebluealliance.android.MainActivity
 import com.thebluealliance.android.R
@@ -60,9 +60,7 @@ class NotificationBuilder
                     // compare filterEquals-equal (extras don't count), which previously
                     // let FLAG_UPDATE_CURRENT rewrite an older notification's target.
                     data =
-                        Uri.parse(
-                            "tba://notification/$notificationType/$eventKey/$matchKey/$teamKey",
-                        )
+                        "tba://notification/$notificationType/$eventKey/$matchKey/$teamKey".toUri()
                     notificationType?.let { putExtra(EXTRA_NOTIFICATION_TYPE, it) }
                     eventKey?.let { putExtra(EXTRA_EVENT_KEY, it) }
                     matchKey?.let { putExtra(EXTRA_MATCH_KEY, it) }

--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/NotificationBuilder.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/NotificationBuilder.kt
@@ -4,6 +4,7 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.RemoteMessage
 import com.thebluealliance.android.MainActivity
@@ -50,14 +51,26 @@ class NotificationBuilder
         ): Notification {
             val intent =
                 Intent(context, MainActivity::class.java).apply {
-                    flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    // NEW_TASK + CLEAR_TASK routes the tap through onCreate (with the
+                    // synthetic back stack) even when the app is already running —
+                    // SINGLE_TOP landed in onNewIntent, which dropped the tap. Same
+                    // pattern as TeamTrackingWidgetOpenAction.
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    // Unique data URI so PendingIntents for different notifications never
+                    // compare filterEquals-equal (extras don't count), which previously
+                    // let FLAG_UPDATE_CURRENT rewrite an older notification's target.
+                    data =
+                        Uri.parse(
+                            "tba://notification/$notificationType/$eventKey/$matchKey/$teamKey",
+                        )
                     notificationType?.let { putExtra(EXTRA_NOTIFICATION_TYPE, it) }
                     eventKey?.let { putExtra(EXTRA_EVENT_KEY, it) }
                     matchKey?.let { putExtra(EXTRA_MATCH_KEY, it) }
                     teamKey?.let { putExtra(EXTRA_TEAM_KEY, it) }
                 }
 
-            val requestCode = (eventKey ?: matchKey ?: teamKey ?: "").hashCode()
+            val requestCode =
+                listOf(notificationType, eventKey, matchKey, teamKey).joinToString("|").hashCode()
             val pendingIntent =
                 PendingIntent.getActivity(
                     context,


### PR DESCRIPTION
## Summary
- Notification content intents used `SINGLE_TOP|CLEAR_TOP`: whenever the task already existed (app foregrounded **or** backgrounded), the tap routed through `onNewIntent()` — which only logs — so the tap did nothing but foreground the app. Now uses `NEW_TASK|CLEAR_TASK`, the same proven pattern as `TeamTrackingWidgetOpenAction`, so every tap goes through `onCreate` and the existing `isNewTask` synthetic-back-stack path.
- PendingIntent collisions fixed: requestCode was `(eventKey ?: matchKey ?: teamKey).hashCode()`, so two match notifications from the same event shared a requestCode with `filterEquals`-identical intents — `FLAG_UPDATE_CURRENT` silently rewrote the older notification to open the newer match. requestCode now hashes all keys, and each intent carries a unique `data` URI so they can never compare equal.

## Verification (API 37 emulator, Settings → Debug test notifications)
- App foregrounded on Settings → fired "Test: Match score notification" → tapped it in the shade → **navigates to Match Detail**. Pre-fix behavior: nothing happened.
- Screenshots in the improvement report (`artifacts/improvement-report/`): shade with the test notification, and the Match Detail screen after the tap.
- Side discovery, observed live: the first test notification was **silently dropped** because POST_NOTIFICATIONS had never been granted (this emulator never ran the sign-in flow) — confirming the queued in-context permission-request finding.

## Panel notes
- **Android Framework Nerd:** "for an app whose marquee feature is myTBA push, the tap-through path needs to actually work."

## Test plan
- [x] Live emulator verification (above)
- [x] `:app:assembleDebug` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)