### PR TITLE
Request POST_NOTIFICATIONS in context; log dropped pushes

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/TBAFirebaseMessagingService.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/TBAFirebaseMessagingService.kt
@@ -60,6 +60,11 @@ class TBAFirebaseMessagingService : FirebaseMessagingService() {
         // Build and show display notification
         val notification = notificationBuilder.buildFromRemoteMessage(message) ?: return
         val manager = getSystemService(NotificationManager::class.java)
+        if (!manager.areNotificationsEnabled()) {
+            // notify() would silently no-op; make the drop diagnosable.
+            Log.w(TAG, "Dropping notification (type=$typeKey): POST_NOTIFICATIONS not granted")
+            return
+        }
         val notificationId = message.data.hashCode()
         manager.notify(notificationId, notification)
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/NotificationPreferencesSheet.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/NotificationPreferencesSheet.kt
@@ -1,5 +1,10 @@
 package com.thebluealliance.android.ui.components
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,7 +22,9 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.thebluealliance.android.domain.model.NotificationType
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -37,6 +44,9 @@ fun NotificationPreferencesSheet(
             mutableStateListOf<String>().apply { addAll(currentNotifications) }
         }
     val favoriteState = remember { androidx.compose.runtime.mutableStateOf(isFavorite) }
+    val context = LocalContext.current
+    val permissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {}
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -97,7 +107,21 @@ fun NotificationPreferencesSheet(
             }
 
             TextButton(
-                onClick = { onSave(favoriteState.value, selectedNotifications.toList()) },
+                onClick = {
+                    // Ask for POST_NOTIFICATIONS at the moment the user enables
+                    // notification-bearing preferences — the sign-in prompt is the only
+                    // other ask, and pushes are silently dropped without the grant.
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                        selectedNotifications.isNotEmpty() &&
+                        ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.POST_NOTIFICATIONS,
+                        ) != PackageManager.PERMISSION_GRANTED
+                    ) {
+                        permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                    onSave(favoriteState.value, selectedNotifications.toList())
+                },
                 modifier =
                     Modifier
                         .fillMaxWidth()


### PR DESCRIPTION
## Summary
- The only POST_NOTIFICATIONS ask lived in the two sign-in flows; dismiss it once and you could subscribe to match alerts the OS then silently discarded. Saving notification-bearing preferences from `NotificationPreferencesSheet` now requests the permission when missing (API 33+), at the moment the user is opting into notifications — the platform-recommended in-context ask.
- `TBAFirebaseMessagingService` now logs a warning instead of silently no-oping when notifications are disabled, so dropped pushes are diagnosable in logcat.

This gap was observed live while verifying #1401: the first test notification was silently dropped because the permission had never been granted on a fresh emulator.

## Verification notes
- `:app:testDebugUnitTest`, `:app:assembleDebug`, `:app:lintDebug` all green locally.
- The sheet flow requires a signed-in myTBA session to open, which the test emulator doesn't have — the launcher pattern is the standard `rememberLauncherForActivityResult(RequestPermission())` and compiles against the existing activity result infrastructure. The service guard only triggers on real FCM messages (the Settings debug senders post directly), so it's covered by inspection.

## Panel notes
- **Android Framework Nerd:** "request the permission in context, at the moment the user enables a notification-bearing feature."

🤖 Generated with [Claude Code](https://claude.com/claude-code)