### PR TITLE
2024 Coopertition is not a ranking point bonus

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/domain/MatchScoreBreakdown.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/MatchScoreBreakdown.kt
@@ -14,7 +14,8 @@ val rpBonusFieldsByYear =
     mapOf(
         2026 to listOf("energizedAchieved", "superchargedAchieved", "traversalAchieved"),
         2025 to listOf("autoBonusAchieved", "coralBonusAchieved", "bargeBonusAchieved"),
-        2024 to listOf("coopertitionBonusAchieved", "melodyBonusAchieved", "ensembleBonusAchieved"),
+        // Crescendo's coopertition lowered the Melody threshold but awarded no RP.
+        2024 to listOf("melodyBonusAchieved", "ensembleBonusAchieved"),
         2023 to listOf("activationBonusAchieved", "sustainabilityBonusAchieved"),
     )
 
@@ -23,7 +24,7 @@ val rpBonusFields: Set<String> = rpBonusFieldsByYear.values.flatten().toSet()
 
 /** Boolean fields that should display as ✓/✗ (RP bonuses + other booleans). */
 val booleanDisplayFields: Set<String> =
-    rpBonusFields + setOf("coopertitionCriteriaMet", "g206Penalty")
+    rpBonusFields + setOf("coopertitionBonusAchieved", "coopertitionCriteriaMet", "g206Penalty")
 
 data class AllianceRpBonuses(
     val red: List<Boolean>,

--- a/app/src/test/kotlin/com/thebluealliance/android/domain/MatchScoreBreakdownTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/domain/MatchScoreBreakdownTest.kt
@@ -1,0 +1,89 @@
+package com.thebluealliance.android.domain
+
+import com.thebluealliance.android.domain.model.CompLevel
+import com.thebluealliance.android.domain.model.Match
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class MatchScoreBreakdownTest {
+    private fun match(
+        eventKey: String = "2024bcvi",
+        compLevel: CompLevel = CompLevel.QUAL,
+        redScore: Int = 80,
+        scoreBreakdown: String?,
+    ) = Match(
+        key = "${eventKey}_qm1",
+        eventKey = eventKey,
+        compLevel = compLevel,
+        matchNumber = 1,
+        setNumber = 1,
+        time = null,
+        predictedTime = null,
+        actualTime = null,
+        redTeamKeys = listOf("frc1", "frc2", "frc3"),
+        redScore = redScore,
+        blueTeamKeys = listOf("frc4", "frc5", "frc6"),
+        blueScore = 60,
+        winningAlliance = "red",
+        scoreBreakdown = scoreBreakdown,
+    )
+
+    @Test
+    fun `2024 has exactly two rp bonuses and coopertition is not one of them`() {
+        assertEquals(
+            listOf("melodyBonusAchieved", "ensembleBonusAchieved"),
+            rpBonusFieldsByYear[2024],
+        )
+    }
+
+    @Test
+    fun `2024 coopertition does not produce an rp dot but melody and ensemble do`() {
+        val breakdown =
+            """
+            {
+              "red": {"coopertitionBonusAchieved": true, "melodyBonusAchieved": true, "ensembleBonusAchieved": false},
+              "blue": {"coopertitionBonusAchieved": true, "melodyBonusAchieved": false, "ensembleBonusAchieved": false}
+            }
+            """.trimIndent()
+
+        val bonuses = match(scoreBreakdown = breakdown).rpBonuses()
+
+        assertEquals(listOf(true, false), bonuses?.red)
+        assertEquals(listOf(false, false), bonuses?.blue)
+    }
+
+    @Test
+    fun `unplayed and non-qual matches have no rp bonuses`() {
+        val breakdown = """{"red": {"melodyBonusAchieved": true}, "blue": {}}"""
+
+        assertNull(match(redScore = -1, scoreBreakdown = breakdown).rpBonuses())
+        assertNull(match(compLevel = CompLevel.SEMIFINAL, scoreBreakdown = breakdown).rpBonuses())
+        assertNull(match(scoreBreakdown = null).rpBonuses())
+    }
+
+    @Test
+    fun `malformed breakdown json returns null instead of throwing`() {
+        assertNull(match(scoreBreakdown = "not json {").rpBonuses())
+    }
+
+    @Test
+    fun `unsupported year returns null`() {
+        val breakdown = """{"red": {}, "blue": {}}"""
+
+        assertNull(match(eventKey = "2019abc", scoreBreakdown = breakdown).rpBonuses())
+    }
+
+    @Test
+    fun `2024 coopertition formats as plain check without rp credit`() {
+        assertEquals("✓", formatBreakdownValue("coopertitionBonusAchieved", "true"))
+        assertEquals("✗", formatBreakdownValue("coopertitionBonusAchieved", "false"))
+    }
+
+    @Test
+    fun `rp bonus fields format with rp credit`() {
+        assertEquals("✓ (+1 RP)", formatBreakdownValue("melodyBonusAchieved", "true"))
+        assertEquals("+2 RP", formatBreakdownValue("rp", "2"))
+        assertEquals("42", formatBreakdownValue("totalPoints", "42"))
+    }
+}


### PR DESCRIPTION
## Summary
- Crescendo (2024)'s coopertition bonus lowered the Melody RP threshold but awarded **no ranking point** — yet 2024 match rows rendered a third RP dot for it and the breakdown said "✓ (+1 RP)". TBA web shows two dots for 2024.
- Dropped `coopertitionBonusAchieved` from the 2024 RP list; it stays a plain ✓/✗ row in the score breakdown (added to `booleanDisplayFields`).
- Brings the first unit tests to the year-keyed breakdown parsing (`rpBonuses()` per-year fields, unplayed/non-qual/malformed/unsupported-year guards, `formatBreakdownValue` cases) — partially addressing the Tech Lead's "annual game-field update is a blind edit" finding.

## Panel notes
- **FRC Team Member:** scouts count RP dots during quals; a phantom third dot in 2024 misstates records.

## Test plan
- [x] New `MatchScoreBreakdownTest` (7 tests) green
- [x] `:app:testDebugUnitTest` + `:app:lintDebug` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)