### PR TITLE
Label alliance roles and show the backup team

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
@@ -82,20 +82,47 @@ fun EventAlliancesTab(
                 }
                 FlowRow(
                     modifier = Modifier.padding(top = 4.dp),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     alliance.picks.forEachIndexed { index, teamKey ->
-                        Text(
-                            text =
-                                teamKey.teamNumber +
-                                    if (index < alliance.picks.lastIndex) "," else "",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.clickable { onTeamClick(teamKey) },
+                        AllianceSlot(
+                            label = if (index == 0) "Captain" else "Pick $index",
+                            teamKey = teamKey,
+                            onTeamClick = onTeamClick,
+                        )
+                    }
+                    alliance.backupIn?.let { backupKey ->
+                        AllianceSlot(
+                            label = "Backup",
+                            teamKey = backupKey,
+                            onTeamClick = onTeamClick,
                         )
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun AllianceSlot(
+    label: String,
+    teamKey: String,
+    onTeamClick: (teamKey: String) -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.clickable { onTeamClick(teamKey) },
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = teamKey.teamNumber,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
     }
 }


### PR DESCRIPTION
## Summary
- The alliances tab showed picks as a flat comma list ("254, 1678, 971") — no indication of who's captain, and a backup team that entered play (`Alliance.backupIn`, parsed but never rendered) was invisible. Scouts reading elims rosters got the wrong picture.
- Each slot now renders a small role label (Captain / Pick 1 / Pick 2 / Backup) above the tappable team number, mirroring how TBA web and the team@event summary (which already computes these roles) present alliances.
- The whole label+number column is now the click target — slightly bigger than the bare text it replaces (the full 48dp touch-target sweep remains queued).

## Panel notes
- **FRC Team Member:** "a flat comma list hides who's captain, and a backup that entered never appears — wrong roster for anyone scouting elims."
- **Designer:** role labels use `labelSmall`/`onSurfaceVariant` over the existing `titleMedium`/primary numbers — no new visual language.

## Test plan
- [x] `:app:testDebugUnitTest` + `:app:lintDebug` green
- [ ] Visual before/after pending the local-backend API key (tracked in the improvement report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Event alliances tab** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1404_alliances_before-1cbdf8e7.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1404_alliances_after-0ead2ad7.png" width="300"> |
<!-- screenshots:end -->