### PR TITLE
Add a Report a bug link to GitHub issues

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -29,9 +30,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.BuildConfig
 import com.thebluealliance.android.ui.components.TBATopAppBar
+import com.thebluealliance.android.util.openUrl
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -78,6 +81,13 @@ fun MoreScreen(
                 onClick = onNavigateToSettings,
             )
             HorizontalDivider()
+            val context = LocalContext.current
+            MoreItem(
+                icon = Icons.Filled.BugReport,
+                label = "Report a bug",
+                onClick = { context.openUrl(ISSUES_URL) },
+            )
+            HorizontalDivider()
 
             Spacer(modifier = Modifier.weight(1f))
 
@@ -112,6 +122,9 @@ fun MoreScreen(
         }
     }
 }
+
+private const val ISSUES_URL =
+    "https://github.com/the-blue-alliance/the-blue-alliance-android/issues"
 
 @Composable
 private fun MoreItem(


### PR DESCRIPTION
## Summary
- Adds a "Report a bug" row to the More menu (BugReport icon, same `MoreItem` pattern), opening the repo's GitHub issues via the existing `openUrl` util.
- Per #1260's framing: GitHub issues are the bug-reporting flow; people motivated enough to report will sign in.

Fixes #1260

## Verification (API 37 emulator)
- Row renders in More (screenshot `1406_more_bugreport.png` in the improvement report); tapping it hands off to Chrome (window focus confirmed via dumpsys).

## Test plan
- [x] `:app:assembleDebug` + `:app:lintDebug` green
- [x] Live tap-through to browser verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **More screen** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1406_more_before-8e2e986a.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1406_more_after-f27a01c0.png" width="300"> |
<!-- screenshots:end -->