### PR TITLE
Call ef matches Octofinals like TBA web

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/domain/MatchGroupExtension.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/MatchGroupExtension.kt
@@ -147,7 +147,7 @@ private fun Match.getCompLevelShortLabel(): String =
 private fun Match.getCompLevelFullLabel(): String =
     when (compLevel) {
         CompLevel.QUAL -> "Qual $matchNumber"
-        CompLevel.OCTOFINAL -> "Eights $setNumber-$matchNumber"
+        CompLevel.OCTOFINAL -> "Octos $setNumber-$matchNumber"
         CompLevel.QUARTERFINAL -> "Quarters $setNumber-$matchNumber"
         CompLevel.SEMIFINAL -> "Semis $setNumber-$matchNumber"
         CompLevel.FINAL -> "Final $setNumber-$matchNumber"

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/Alliance.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/Alliance.kt
@@ -69,7 +69,7 @@ private fun String.toAllianceStatusLabel(): String =
 private fun String.toAllianceCompLevelLabel(): String =
     when (lowercase()) {
         CompLevel.QUAL.code -> "Qualifications"
-        CompLevel.OCTOFINAL.code -> "Eighths"
+        CompLevel.OCTOFINAL.code -> "Octofinals"
         CompLevel.QUARTERFINAL.code -> "Quarterfinals"
         CompLevel.SEMIFINAL.code -> "Semifinals"
         CompLevel.FINAL.code -> "Finals"

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/Match.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/Match.kt
@@ -87,7 +87,7 @@ sealed interface MatchGroup {
         override val label =
             when (compLevel) {
                 CompLevel.QUAL -> "Qualifications"
-                CompLevel.OCTOFINAL -> "Eighths"
+                CompLevel.OCTOFINAL -> "Octofinals"
                 CompLevel.QUARTERFINAL -> "Quarterfinals"
                 CompLevel.SEMIFINAL -> "Semifinals"
                 CompLevel.FINAL -> "Finals"

--- a/app/src/test/kotlin/com/thebluealliance/android/domain/MatchGroupExtensionTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/domain/MatchGroupExtensionTest.kt
@@ -467,13 +467,13 @@ class MatchGroupExtensionTest {
         }
 
         @Test
-        fun `OCTOFINAL match full label is Eights followed by set and match number`() {
+        fun `OCTOFINAL match full label is Octos followed by set and match number`() {
             val match = createMatch(compLevel = CompLevel.OCTOFINAL, matchNumber = 1, setNumber = 2)
-            assertEquals("Eights 2-1", match.getFullLabel(PlayoffType.BRACKET_8_TEAM))
+            assertEquals("Octos 2-1", match.getFullLabel(PlayoffType.BRACKET_8_TEAM))
 
             val match2 =
                 createMatch(compLevel = CompLevel.OCTOFINAL, matchNumber = 3, setNumber = 4)
-            assertEquals("Eights 4-3", match2.getFullLabel(PlayoffType.BRACKET_8_TEAM))
+            assertEquals("Octos 4-3", match2.getFullLabel(PlayoffType.BRACKET_8_TEAM))
         }
 
         @Test


### PR DESCRIPTION
## Summary
- The `ef` comp level rendered as "Eighths" in match section headers and alliance playoff summaries, and "Eights" (a typo) in compact match labels. TBA web calls these **Octofinals**.
- Standardized: "Octofinals" for headers/summaries, "Octos N-M" for compact labels (matching the existing "Quarters/Semis" style). Test expectations updated.

## Panel notes
- **FRC Team Member:** nobody at an event says "Eighths" — web parity plus an internal consistency fix (two different spellings of the wrong word).

## Test plan
- [x] `:app:testDebugUnitTest` (updated MatchGroupExtension expectations) + `:app:lintDebug` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)