### PR TITLE
fix(data): order MatchDao event matches by competition stage

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/MatchDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/MatchDao.kt
@@ -10,7 +10,8 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface MatchDao {
     @Query(
-        "SELECT * FROM matches WHERE eventKey = :eventKey ORDER BY compLevel, setNumber, matchNumber ASC",
+        // CASE mirrors CompLevel.order; sorting the TEXT codes alphabetically puts finals first
+        "SELECT * FROM matches WHERE eventKey = :eventKey ORDER BY CASE compLevel WHEN 'qm' THEN 0 WHEN 'ef' THEN 1 WHEN 'qf' THEN 2 WHEN 'sf' THEN 3 WHEN 'f' THEN 4 ELSE 5 END, setNumber, matchNumber ASC",
     )
     fun observeByEvent(eventKey: String): Flow<List<MatchEntity>>
 


### PR DESCRIPTION
## Summary
- `MatchDao.observeByEvent` ordered by the raw `compLevel` TEXT column, which sorts alphabetically (`ef → f → qf → qm → sf`) — i.e. Finals before Quals.
- No user-visible bug today because every current consumer (`MatchList`, `TeamEventDetailScreen`, `TeamTrackingWorker`) re-sorts in memory by `CompLevel.order`, but any new DAO consumer would silently inherit the wrong order.
- Replace the column sort with a `CASE` expression mirroring `CompLevel.order` (`qm=0, ef=1, qf=2, sf=3, f=4, else 5`), then `setNumber`, then `matchNumber` — the same key order as the in-memory comparators, which are kept as a guard for non-DAO paths.

## Panel notes
FRC Team Member flagged this as a latent footgun: the DAO's implied "sorted" contract didn't match competition order, low impact today but a trap for the next feature.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — passes
- [x] `./gradlew :app:lintDebug` — passes (warnings-as-errors)
- [x] `./gradlew :app:ktlintCheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)