### PR TITLE
fix(mytba): only apply local myTBA writes on confirmed server success

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/MyTBARepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/MyTBARepository.kt
@@ -13,8 +13,16 @@ import com.thebluealliance.android.domain.model.Favorite
 import com.thebluealliance.android.domain.model.Subscription
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import java.net.HttpURLConnection
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private val HTTP_SUCCESS = 200..299
+
+// The setPreferences endpoint reports success as code 0 with per-model results
+// nested in the message JSON; the list endpoints use HTTP-style body codes
+// (see backend src/backend/api/handlers/client_api.py).
+private const val SET_PREFERENCES_SUCCESS = 0
 
 @Singleton
 class MyTBARepository
@@ -68,9 +76,7 @@ class MyTBARepository
                 "MyTBARepository",
                 "refreshFavorites: code=${response.code} message=${response.message} favorites=${response.favorites.size}",
             )
-            if (response.code == 401) {
-                throw MyTBAServerException(response.code, response.message)
-            }
+            ensureListSuccess(response.code, response.message)
             db.withTransaction {
                 favoriteDao.deleteAll()
                 favoriteDao.insertAll(
@@ -83,9 +89,7 @@ class MyTBARepository
 
         suspend fun refreshSubscriptions() {
             val response = clientApi.listSubscriptions()
-            if (response.code == 401) {
-                throw MyTBAServerException(response.code, response.message)
-            }
+            ensureListSuccess(response.code, response.message)
             db.withTransaction {
                 subscriptionDao.deleteAll()
                 subscriptionDao.insertAll(
@@ -117,13 +121,14 @@ class MyTBARepository
                 "MyTBARepository",
                 "addFavorite: code=${response.code} message=${response.message}",
             )
-            if (response.code == 401) {
+            if (response.code == HttpURLConnection.HTTP_UNAUTHORIZED) {
                 try {
                     refreshFavorites()
                 } catch (_: Exception) {
                 }
                 throw MyTBAServerException(response.code, response.message)
             }
+            ensureUpdateSuccess(response.code, response.message)
             favoriteDao.insertAll(
                 listOf(FavoriteEntity(modelKey = modelKey, modelType = modelType)),
             )
@@ -142,13 +147,14 @@ class MyTBARepository
                         favorite = false,
                     ),
                 )
-            if (response.code == 401) {
+            if (response.code == HttpURLConnection.HTTP_UNAUTHORIZED) {
                 try {
                     refreshFavorites()
                 } catch (_: Exception) {
                 }
                 throw MyTBAServerException(response.code, response.message)
             }
+            ensureUpdateSuccess(response.code, response.message)
             favoriteDao.delete(modelKey, modelType)
         }
 
@@ -172,9 +178,7 @@ class MyTBARepository
                 "MyTBARepository",
                 "updatePreferences: code=${response.code} message=${response.message}",
             )
-            if (response.code == 401) {
-                throw MyTBAServerException(response.code, response.message)
-            }
+            ensureUpdateSuccess(response.code, response.message)
             // Refresh both to sync local state with server
             try {
                 refreshFavorites()
@@ -189,6 +193,24 @@ class MyTBARepository
         suspend fun clearLocal() {
             favoriteDao.deleteAll()
             subscriptionDao.deleteAll()
+        }
+
+        private fun ensureListSuccess(
+            code: Int,
+            message: String,
+        ) {
+            if (code !in HTTP_SUCCESS) {
+                throw MyTBAServerException(code, message)
+            }
+        }
+
+        private fun ensureUpdateSuccess(
+            code: Int,
+            message: String,
+        ) {
+            if (code != SET_PREFERENCES_SUCCESS && code !in HTTP_SUCCESS) {
+                throw MyTBAServerException(code, message)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
@@ -212,6 +212,7 @@ class EventDetailViewModel
                         myTBARepository.addFavorite(eventKey, ModelType.EVENT)
                     }
                 } catch (_: Exception) {
+                    _userMessage.emit("Couldn't update favorite")
                 }
             }
         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailViewModel.kt
@@ -143,6 +143,7 @@ class TeamDetailViewModel
                         myTBARepository.addFavorite(teamKey, ModelType.TEAM)
                     }
                 } catch (_: Exception) {
+                    _userMessage.emit("Couldn't update favorite")
                 }
             }
         }

--- a/app/src/test/kotlin/com/thebluealliance/android/data/repository/MyTBARepositoryTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/data/repository/MyTBARepositoryTest.kt
@@ -1,0 +1,231 @@
+package com.thebluealliance.android.data.repository
+
+import android.util.Log
+import com.thebluealliance.android.data.local.TBADatabase
+import com.thebluealliance.android.data.local.dao.FavoriteDao
+import com.thebluealliance.android.data.local.dao.SubscriptionDao
+import com.thebluealliance.android.data.local.entity.FavoriteEntity
+import com.thebluealliance.android.data.local.entity.SubscriptionEntity
+import com.thebluealliance.android.data.remote.ClientApi
+import com.thebluealliance.android.data.remote.dto.BaseResponseDto
+import com.thebluealliance.android.data.remote.dto.FavoriteCollectionDto
+import com.thebluealliance.android.data.remote.dto.FavoriteDto
+import com.thebluealliance.android.data.remote.dto.ModelPreferenceRequestDto
+import com.thebluealliance.android.data.remote.dto.SubscriptionCollectionDto
+import com.thebluealliance.android.data.remote.dto.SubscriptionDto
+import com.thebluealliance.android.domain.model.ModelType
+import com.thebluealliance.android.messaging.DeviceRegistrationManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class MyTBARepositoryTest {
+    private val clientApi: ClientApi = mockk()
+    private val db: TBADatabase =
+        mockk(relaxed = true) {
+            val executor =
+                java.util.concurrent.Executors
+                    .newSingleThreadExecutor()
+            every { queryExecutor } returns executor
+            every { transactionExecutor } returns executor
+        }
+    private val favoriteDao: FavoriteDao = mockk(relaxUnitFun = true)
+    private val subscriptionDao: SubscriptionDao = mockk(relaxUnitFun = true)
+    private val deviceRegistrationManager: DeviceRegistrationManager =
+        mockk {
+            every { deviceUuid } returns "test-device-uuid"
+        }
+
+    private val repo =
+        MyTBARepository(db, clientApi, favoriteDao, subscriptionDao, deviceRegistrationManager)
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 0
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    private suspend fun assertThrowsServerError(
+        expectedCode: Int,
+        block: suspend () -> Unit,
+    ) {
+        val thrown = runCatching { block() }.exceptionOrNull()
+        assertTrue(thrown is MyTBAServerException, "expected MyTBAServerException, got $thrown")
+        assertEquals(expectedCode, (thrown as MyTBAServerException).code)
+    }
+
+    @Test
+    fun `addFavorite stores locally when server confirms with setPreferences code 0`() =
+        runTest {
+            coEvery { clientApi.updateModelPreferences(any()) } returns
+                BaseResponseDto(code = 0, message = """{"favorite":{"code":200}}""")
+
+            val insertedSlot = slot<List<FavoriteEntity>>()
+            coEvery { favoriteDao.insertAll(capture(insertedSlot)) } returns Unit
+
+            repo.addFavorite("frc254", ModelType.TEAM)
+
+            assertEquals("frc254", insertedSlot.captured.single().modelKey)
+            assertEquals(ModelType.TEAM, insertedSlot.captured.single().modelType)
+        }
+
+    @Test
+    fun `addFavorite sends device key with favorite flag set`() =
+        runTest {
+            val requestSlot = slot<ModelPreferenceRequestDto>()
+            coEvery { clientApi.updateModelPreferences(capture(requestSlot)) } returns
+                BaseResponseDto(code = 0)
+            coEvery { favoriteDao.insertAll(any()) } returns Unit
+
+            repo.addFavorite("frc254", ModelType.TEAM)
+
+            assertEquals("test-device-uuid", requestSlot.captured.deviceKey)
+            assertEquals(true, requestSlot.captured.favorite)
+        }
+
+    @Test
+    fun `addFavorite throws on server error and skips local write`() =
+        runTest {
+            coEvery { clientApi.updateModelPreferences(any()) } returns
+                BaseResponseDto(code = 500, message = "Internal error")
+
+            assertThrowsServerError(500) { repo.addFavorite("frc254", ModelType.TEAM) }
+
+            coVerify(exactly = 0) { favoriteDao.insertAll(any()) }
+        }
+
+    @Test
+    fun `addFavorite on auth failure attempts refresh and throws without local write`() =
+        runTest {
+            coEvery { clientApi.updateModelPreferences(any()) } returns
+                BaseResponseDto(code = 401, message = "Unauthorized")
+            coEvery { clientApi.listFavorites(any()) } returns
+                FavoriteCollectionDto(code = 401, message = "Unauthorized")
+
+            assertThrowsServerError(401) { repo.addFavorite("frc254", ModelType.TEAM) }
+
+            coVerify(exactly = 1) { clientApi.listFavorites(any()) }
+            coVerify(exactly = 0) { favoriteDao.insertAll(any()) }
+        }
+
+    @Test
+    fun `removeFavorite deletes locally when server confirms`() =
+        runTest {
+            coEvery { clientApi.updateModelPreferences(any()) } returns
+                BaseResponseDto(code = 0, message = """{"favorite":{"code":200}}""")
+
+            repo.removeFavorite("2026nhgrs", ModelType.EVENT)
+
+            coVerify(exactly = 1) { favoriteDao.delete("2026nhgrs", ModelType.EVENT) }
+        }
+
+    @Test
+    fun `removeFavorite throws on server error and keeps local row`() =
+        runTest {
+            coEvery { clientApi.updateModelPreferences(any()) } returns
+                BaseResponseDto(code = 500, message = "Internal error")
+
+            assertThrowsServerError(500) { repo.removeFavorite("2026nhgrs", ModelType.EVENT) }
+
+            coVerify(exactly = 0) { favoriteDao.delete(any(), any()) }
+        }
+
+    @Test
+    fun `updatePreferences refreshes local state on success`() =
+        runTest {
+            coEvery { clientApi.updateModelPreferences(any()) } returns
+                BaseResponseDto(code = 0, message = """{"subscription":{"code":200}}""")
+            coEvery { clientApi.listFavorites(any()) } returns
+                FavoriteCollectionDto(
+                    code = 200,
+                    favorites = listOf(FavoriteDto("frc254", ModelType.TEAM)),
+                )
+            coEvery { clientApi.listSubscriptions(any()) } returns
+                SubscriptionCollectionDto(
+                    code = 200,
+                    subscriptions =
+                        listOf(
+                            SubscriptionDto("frc254", ModelType.TEAM, listOf("upcoming_match")),
+                        ),
+                )
+            coEvery { favoriteDao.insertAll(any()) } returns Unit
+            val subscriptionsSlot = slot<List<SubscriptionEntity>>()
+            coEvery { subscriptionDao.insertAll(capture(subscriptionsSlot)) } returns Unit
+
+            repo.updatePreferences("frc254", ModelType.TEAM, true, listOf("upcoming_match"))
+
+            coVerify(exactly = 1) { favoriteDao.deleteAll() }
+            coVerify(exactly = 1) { subscriptionDao.deleteAll() }
+            assertEquals("upcoming_match", subscriptionsSlot.captured.single().notifications)
+        }
+
+    @Test
+    fun `updatePreferences throws on server error without refreshing`() =
+        runTest {
+            coEvery { clientApi.updateModelPreferences(any()) } returns
+                BaseResponseDto(code = 500, message = "Internal error")
+
+            assertThrowsServerError(500) {
+                repo.updatePreferences("frc254", ModelType.TEAM, true, listOf("upcoming_match"))
+            }
+
+            coVerify(exactly = 0) { clientApi.listFavorites(any()) }
+            coVerify(exactly = 0) { clientApi.listSubscriptions(any()) }
+        }
+
+    @Test
+    fun `refreshFavorites replaces local favorites on success`() =
+        runTest {
+            coEvery { clientApi.listFavorites(any()) } returns
+                FavoriteCollectionDto(
+                    code = 200,
+                    favorites = listOf(FavoriteDto("2026nhgrs", ModelType.EVENT)),
+                )
+            val insertedSlot = slot<List<FavoriteEntity>>()
+            coEvery { favoriteDao.insertAll(capture(insertedSlot)) } returns Unit
+
+            repo.refreshFavorites()
+
+            coVerify(exactly = 1) { favoriteDao.deleteAll() }
+            assertEquals("2026nhgrs", insertedSlot.captured.single().modelKey)
+        }
+
+    @Test
+    fun `refreshFavorites throws on server error without wiping local cache`() =
+        runTest {
+            coEvery { clientApi.listFavorites(any()) } returns
+                FavoriteCollectionDto(code = 500, message = "Internal error")
+
+            assertThrowsServerError(500) { repo.refreshFavorites() }
+
+            coVerify(exactly = 0) { favoriteDao.deleteAll() }
+            coVerify(exactly = 0) { favoriteDao.insertAll(any()) }
+        }
+
+    @Test
+    fun `refreshSubscriptions throws on auth error without wiping local cache`() =
+        runTest {
+            coEvery { clientApi.listSubscriptions(any()) } returns
+                SubscriptionCollectionDto(code = 401, message = "Unauthorized")
+
+            assertThrowsServerError(401) { repo.refreshSubscriptions() }
+
+            coVerify(exactly = 0) { subscriptionDao.deleteAll() }
+            coVerify(exactly = 0) { subscriptionDao.insertAll(any()) }
+        }
+}


### PR DESCRIPTION
## Summary
- myTBA writes only checked the body code for 401 — any other server failure still ran the local DAO insert/delete, desyncing the device from the backend: the star fills in, the user thinks they're subscribed, and the push never comes (relates to #826 / #1391).
- `MyTBARepository` now validates every ClientAPI response before touching Room: list endpoints must return a 2xx body code; `setPreferences` must return its documented success code **0** (verified verbatim against the backend's `client_api.py` — it nests per-model results in the `message` JSON, so the naive "require 2xx" fix would have rejected every *successful* favorite write). The 401 refresh-then-throw special case is preserved.
- Failed `refreshFavorites`/`refreshSubscriptions` responses (e.g. a 401/500 body with an empty list) no longer wipe the local cache inside the transaction.
- `toggleFavorite` in `TeamDetailViewModel`/`EventDetailViewModel` swallowed all of this silently while `updatePreferences` right next to it emitted a snackbar message; it now emits "Couldn't update favorite" through the same existing `_userMessage` flow — this also surfaces plain network failures (airplane mode, HTTP 5xx) that were previously invisible.

## Panel notes
Tech Lead: "the user thinks they're subscribed and never gets the push" — silent-success on non-401 errors plus a silent favorite star left no signal that a myTBA write was lost.

## Test plan
- [x] New `MyTBARepositoryTest` (11 cases): local write happens on confirmed success (including the real `code=0` setPreferences contract), throws and skips the DAO write on 500, 401 triggers the refresh-then-throw path, error responses never wipe the local cache, request carries the device key.
- [x] `./gradlew :app:testDebugUnitTest :app:lintDebug -q` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)