### PR TITLE
fix(ui): persist tab sort and dialog state with rememberSaveable

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -106,8 +107,8 @@ fun EventDetailScreen(
         )
     val coroutineScope = rememberCoroutineScope()
 
-    var showSignInDialog by remember { mutableStateOf(false) }
-    var showNotificationSheet by remember { mutableStateOf(false) }
+    var showSignInDialog by rememberSaveable { mutableStateOf(false) }
+    var showNotificationSheet by rememberSaveable { mutableStateOf(false) }
     val context = LocalContext.current
     LaunchedEffect(Unit) {
         viewModel.showSignInPrompt.collect { showSignInDialog = true }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
@@ -30,6 +30,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,6 +79,32 @@ enum class CoprSortColumn {
     VALUE,
 }
 
+private val StatTypeSaver =
+    listSaver<StatType, String>(
+        save = {
+            when (it) {
+                StatType.StandardOPRs -> listOf("StandardOPRs")
+                StatType.QualInsights -> listOf("QualInsights")
+                StatType.PlayoffInsights -> listOf("PlayoffInsights")
+                is StatType.COPR -> listOf("COPR", it.statName)
+            }
+        },
+        restore = {
+            when (it[0]) {
+                "QualInsights" -> StatType.QualInsights
+                "PlayoffInsights" -> StatType.PlayoffInsights
+                "COPR" -> StatType.COPR(it[1])
+                else -> StatType.StandardOPRs
+            }
+        },
+    )
+
+private inline fun <reified T : Enum<T>> enumSaver(): Saver<T, String> =
+    Saver(
+        save = { it.name },
+        restore = { enumValueOf<T>(it) },
+    )
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun EventInsightsTab(
@@ -100,11 +129,15 @@ fun EventInsightsTab(
     }
 
     val context = LocalContext.current
-    var oprSortColumn by remember { mutableStateOf(OprSortColumn.OPR) }
-    var oprSortAscending by remember { mutableStateOf(false) }
-    var coprSortColumn by remember { mutableStateOf(CoprSortColumn.VALUE) }
-    var coprSortAscending by remember { mutableStateOf(false) }
-    var showStatSelector by remember { mutableStateOf(false) }
+    var oprSortColumn by rememberSaveable(stateSaver = enumSaver<OprSortColumn>()) {
+        mutableStateOf(OprSortColumn.OPR)
+    }
+    var oprSortAscending by rememberSaveable { mutableStateOf(false) }
+    var coprSortColumn by rememberSaveable(stateSaver = enumSaver<CoprSortColumn>()) {
+        mutableStateOf(CoprSortColumn.VALUE)
+    }
+    var coprSortAscending by rememberSaveable { mutableStateOf(false) }
+    var showStatSelector by rememberSaveable { mutableStateOf(false) }
     val defaultStatType =
         when {
             hasOprData -> StatType.StandardOPRs
@@ -113,7 +146,9 @@ fun EventInsightsTab(
             hasCoprData -> StatType.COPR(coprs.coprs.keys.first())
             else -> StatType.StandardOPRs
         }
-    var selectedStatType by remember { mutableStateOf(defaultStatType) }
+    var selectedStatType by rememberSaveable(stateSaver = StatTypeSaver) {
+        mutableStateOf(defaultStatType)
+    }
 
     // Get available COPR stat names
     val coprStatNames =

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,6 +59,17 @@ internal data class RankingSortState(
     val column: RankingSortColumn = RankingSortColumn.PRIMARY,
     val ascending: Boolean = false,
 )
+
+private val RankingSortStateSaver =
+    listSaver<RankingSortState, Any>(
+        save = { listOf(it.column.name, it.ascending) },
+        restore = {
+            RankingSortState(
+                column = RankingSortColumn.valueOf(it[0] as String),
+                ascending = it[1] as Boolean,
+            )
+        },
+    )
 
 internal fun rankingHeaderLabels(rankingSortOrders: List<RankingSortOrder>?): Pair<String, String> {
     val primaryLabel = rankingSortOrders?.getOrNull(0)?.name?.takeIf { it.isNotBlank() } ?: "RS"
@@ -130,7 +143,9 @@ fun EventRankingsTab(
 
     val (primaryLabel, secondaryLabel) = rankingHeaderLabels(rankingSortOrders)
 
-    var sortState by remember { mutableStateOf(RankingSortState()) }
+    var sortState by rememberSaveable(stateSaver = RankingSortStateSaver) {
+        mutableStateOf(RankingSortState())
+    }
 
     val sortedRankings =
         remember(rankings, sortState) {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -105,7 +106,7 @@ fun MyTBAScreen(
         }
     }
 
-    var showSignOutDialog by remember { mutableStateOf(false) }
+    var showSignOutDialog by rememberSaveable { mutableStateOf(false) }
     var menuExpanded by remember { mutableStateOf(false) }
 
     if (showSignOutDialog) {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamDetailScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -103,8 +104,8 @@ fun TeamDetailScreen(
     val pagerState = rememberPagerState(initialPage = initialTab, pageCount = { TABS.size })
     val coroutineScope = rememberCoroutineScope()
 
-    var showSignInDialog by remember { mutableStateOf(false) }
-    var showNotificationSheet by remember { mutableStateOf(false) }
+    var showSignInDialog by rememberSaveable { mutableStateOf(false) }
+    var showNotificationSheet by rememberSaveable { mutableStateOf(false) }
     val context = LocalContext.current
     LaunchedEffect(Unit) {
         viewModel.showSignInPrompt.collect { showSignInDialog = true }


### PR DESCRIPTION
## Summary
- NavDisplay disposes non-top entries and HorizontalPager disposes far pages, so plain `remember {}` UI state (sort orders, dialog visibility) silently reset on drill-in/back, far tab swipes, and rotation. The `rememberSaveableStateHolderNavEntryDecorator` is already installed on every nav entry, so converting these declarations to `rememberSaveable` is all that's needed.
- Converted: rankings sort column/direction (`RankingSortState` via a `listSaver` saving the enum by name), insights stat selection + OPR/COPR sorts (sealed `StatType` via `listSaver`, enums via a name-based `Saver`), and dialog/sheet visibility booleans on `TeamDetailScreen`, `EventDetailScreen`, and `MyTBAScreen`.
- Left genuinely transient state as plain `remember`: `menuExpanded` dropdowns, per-row ranking expansion, and the avatar red/blue toggle.

## Panel notes
Android Framework Nerd — "sort the rankings by OPR, peek at a team, press back — your sort is gone."

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] `./gradlew :app:lintDebug` passes
- [x] `./gradlew :app:ktlintCheck` passes
- [ ] orchestrator visual pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)