### PR TITLE
refactor(events): gate and dedupe regional cmp advancement fetches

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
@@ -26,7 +26,6 @@ import com.thebluealliance.android.data.remote.TbaApi
 import com.thebluealliance.android.data.remote.dto.EventInsightsDto
 import com.thebluealliance.android.domain.model.Alliance
 import com.thebluealliance.android.domain.model.Award
-import com.thebluealliance.android.domain.model.CmpAdvancement
 import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.EventAdvancementPoints
 import com.thebluealliance.android.domain.model.EventCOPRs
@@ -227,50 +226,6 @@ class EventRepository
                 }
             } catch (_: Exception) {
             }
-        }
-
-        suspend fun fetchRegionalCmpAdvancementByTeam(year: Int): Map<String, CmpAdvancement> {
-            val advancements = api.getRegionalAdvancement(year).orEmpty()
-
-            // Pre-load event names for any EventQualified entries
-            val eventKeys =
-                advancements.values
-                    .filter { it.cmpStatus == "EventQualified" }
-                    .mapNotNull { it.qualifyingEvent }
-                    .distinct()
-            val eventsByKey =
-                if (eventKeys.isNotEmpty()) {
-                    eventDao.getByKeys(eventKeys).associateBy { it.key }
-                } else {
-                    emptyMap()
-                }
-
-            return advancements
-                .mapNotNull { (teamKey, advancement) ->
-                    if (!advancement.cmp) return@mapNotNull null
-                    val cmpAdv: CmpAdvancement =
-                        when (advancement.cmpStatus) {
-                            "EventQualified" -> {
-                                val eventKey = advancement.qualifyingEvent ?: ""
-                                val entity = eventsByKey[eventKey]
-                                val shortName =
-                                    entity?.shortName?.takeIf { it.isNotBlank() }
-                                        ?: entity?.name
-                                        ?: eventKey.ifBlank { null }
-                                CmpAdvancement.EventQualified(
-                                    eventKey = eventKey,
-                                    eventShortName = shortName,
-                                )
-                            }
-                            "PoolQualified" ->
-                                CmpAdvancement.PoolQualified(
-                                    week =
-                                        advancement.qualifyingPoolWeek ?: 0,
-                                )
-                            else -> CmpAdvancement.Qualified
-                        }
-                    teamKey to cmpAdv
-                }.toMap()
         }
 
         suspend fun refreshEventAlliances(eventKey: String) {

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/RegionalAdvancementRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/RegionalAdvancementRepository.kt
@@ -1,8 +1,12 @@
 package com.thebluealliance.android.data.repository
 
+import com.thebluealliance.android.data.local.dao.EventDao
 import com.thebluealliance.android.data.mappers.toDomain
 import com.thebluealliance.android.data.remote.TbaApi
+import com.thebluealliance.android.domain.model.CmpAdvancement
 import com.thebluealliance.android.domain.model.RegionalRanking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -11,7 +15,11 @@ class RegionalAdvancementRepository
     @Inject
     constructor(
         private val api: TbaApi,
+        private val eventDao: EventDao,
     ) {
+        private val cmpAdvancementMutex = Mutex()
+        private val cmpAdvancementByYear = mutableMapOf<Int, Map<String, CmpAdvancement>>()
+
         suspend fun getRegionalRankings(year: Int): List<RegionalRanking> {
             val rankings = api.getRegionalAdvancementRankings(year).orEmpty()
             val advancements = api.getRegionalAdvancement(year).orEmpty()
@@ -21,5 +29,72 @@ class RegionalAdvancementRepository
                     val advancement = advancements[ranking.teamKey]
                     ranking.toDomain(year, advancement?.cmpStatus)
                 }.sortedBy { it.rank }
+        }
+
+        /**
+         * Championship advancement status for every team in [year]. The payload covers the whole
+         * season, so it is fetched at most once per year per app session and shared across
+         * screens; [forceRefresh] (e.g. pull-to-refresh) bypasses the cache.
+         */
+        suspend fun getCmpAdvancementByTeam(
+            year: Int,
+            forceRefresh: Boolean = false,
+        ): Map<String, CmpAdvancement> {
+            if (year < FIRST_REGIONAL_ADVANCEMENT_YEAR) return emptyMap()
+            return cmpAdvancementMutex.withLock {
+                val cached = if (forceRefresh) null else cmpAdvancementByYear[year]
+                cached
+                    ?: fetchCmpAdvancementByTeam(year).also { cmpAdvancementByYear[year] = it }
+            }
+        }
+
+        private suspend fun fetchCmpAdvancementByTeam(year: Int): Map<String, CmpAdvancement> {
+            val advancements = api.getRegionalAdvancement(year).orEmpty()
+
+            val eventKeys =
+                advancements.values
+                    .filter { it.cmpStatus == CMP_STATUS_EVENT_QUALIFIED }
+                    .mapNotNull { it.qualifyingEvent }
+                    .distinct()
+            val eventsByKey =
+                if (eventKeys.isNotEmpty()) {
+                    eventDao.getByKeys(eventKeys).associateBy { it.key }
+                } else {
+                    emptyMap()
+                }
+
+            return advancements
+                .mapNotNull { (teamKey, advancement) ->
+                    if (!advancement.cmp) return@mapNotNull null
+                    val cmpAdv: CmpAdvancement =
+                        when (advancement.cmpStatus) {
+                            CMP_STATUS_EVENT_QUALIFIED -> {
+                                val eventKey = advancement.qualifyingEvent ?: ""
+                                val entity = eventsByKey[eventKey]
+                                val shortName =
+                                    entity?.shortName?.takeIf { it.isNotBlank() }
+                                        ?: entity?.name
+                                        ?: eventKey.ifBlank { null }
+                                CmpAdvancement.EventQualified(
+                                    eventKey = eventKey,
+                                    eventShortName = shortName,
+                                )
+                            }
+                            CMP_STATUS_POOL_QUALIFIED ->
+                                CmpAdvancement.PoolQualified(
+                                    week = advancement.qualifyingPoolWeek ?: 0,
+                                )
+                            else -> CmpAdvancement.Qualified
+                        }
+                    teamKey to cmpAdv
+                }.toMap()
+        }
+
+        companion object {
+            /** Regional championship advancement points were introduced in the 2025 season. */
+            const val FIRST_REGIONAL_ADVANCEMENT_YEAR = 2025
+
+            private const val CMP_STATUS_EVENT_QUALIFIED = "EventQualified"
+            private const val CMP_STATUS_POOL_QUALIFIED = "PoolQualified"
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailViewModel.kt
@@ -6,6 +6,7 @@ import com.thebluealliance.android.data.repository.DistrictRepository
 import com.thebluealliance.android.data.repository.EventRepository
 import com.thebluealliance.android.data.repository.MatchRepository
 import com.thebluealliance.android.data.repository.MyTBARepository
+import com.thebluealliance.android.data.repository.RegionalAdvancementRepository
 import com.thebluealliance.android.data.repository.TeamRepository
 import com.thebluealliance.android.domain.model.CmpAdvancement
 import com.thebluealliance.android.domain.model.Favorite
@@ -27,6 +28,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
@@ -42,6 +44,7 @@ class EventDetailViewModel
         private val teamRepository: TeamRepository,
         private val matchRepository: MatchRepository,
         private val districtRepository: DistrictRepository,
+        private val regionalAdvancementRepository: RegionalAdvancementRepository,
         private val myTBARepository: MyTBARepository,
         private val authRepository: AuthRepository,
         private val shortcutManager: TBAShortcutManager,
@@ -248,7 +251,10 @@ class EventDetailViewModel
 
         fun refreshAll() {
             refreshing(
-                { eventRepository.refreshEvent(eventKey) },
+                {
+                    eventRepository.refreshEvent(eventKey)
+                    refreshRegionalCmpAdvancement()
+                },
                 { teamRepository.refreshEventTeams(eventKey) },
                 { matchRepository.refreshEventMatches(eventKey) },
                 { eventRepository.refreshEventRankings(eventKey) },
@@ -256,10 +262,6 @@ class EventDetailViewModel
                 { eventRepository.refreshEventAwards(eventKey) },
                 { eventRepository.refreshEventDistrictPoints(eventKey) },
                 { eventRepository.refreshEventRegionalPoints(eventKey) },
-                {
-                    regionalCmpAdvancementByTeam.value =
-                        eventRepository.fetchRegionalCmpAdvancementByTeam(eventYear)
-                },
                 { eventRepository.refreshEventOPRs(eventKey) },
                 { eventRepository.refreshEventCOPRs(eventKey) },
                 { eventRepository.refreshEventInsights(eventKey) },
@@ -296,14 +298,20 @@ class EventDetailViewModel
                     refreshing(
                         { eventRepository.refreshEventDistrictPoints(eventKey) },
                         { eventRepository.refreshEventRegionalPoints(eventKey) },
-                        {
-                            regionalCmpAdvancementByTeam.value =
-                                eventRepository.fetchRegionalCmpAdvancementByTeam(eventYear)
-                        },
+                        { refreshRegionalCmpAdvancement(forceRefresh = true) },
                     )
                 EventDetailTab.AWARDS ->
                     refreshing({ eventRepository.refreshEventAwards(eventKey) })
             }
+        }
+
+        // Regional advancement is a whole-season payload that only applies to non-district
+        // events, so skip it entirely when the event belongs to a district.
+        private suspend fun refreshRegionalCmpAdvancement(forceRefresh: Boolean = false) {
+            val event = eventRepository.observeEvent(eventKey).first() ?: return
+            if (event.district != null) return
+            regionalCmpAdvancementByTeam.value =
+                regionalAdvancementRepository.getCmpAdvancementByTeam(eventYear, forceRefresh)
         }
 
         @AssistedFactory

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.thebluealliance.android.ui.teamevent
 import androidx.lifecycle.viewModelScope
 import com.thebluealliance.android.data.repository.EventRepository
 import com.thebluealliance.android.data.repository.MatchRepository
+import com.thebluealliance.android.data.repository.RegionalAdvancementRepository
 import com.thebluealliance.android.data.repository.TeamRepository
 import com.thebluealliance.android.domain.model.Alliance
 import com.thebluealliance.android.domain.model.Award
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
@@ -44,6 +46,7 @@ class TeamEventDetailViewModel
         private val teamRepository: TeamRepository,
         private val eventRepository: EventRepository,
         private val matchRepository: MatchRepository,
+        private val regionalAdvancementRepository: RegionalAdvancementRepository,
     ) : RefreshableViewModel() {
         val teamKey: String = navKey.teamKey
         val eventKey: String = navKey.eventKey
@@ -145,7 +148,10 @@ class TeamEventDetailViewModel
         fun refreshAll() {
             refreshing(
                 { teamRepository.refreshTeam(teamKey) },
-                { eventRepository.refreshEvent(eventKey) },
+                {
+                    eventRepository.refreshEvent(eventKey)
+                    refreshRegionalCmpAdvancement()
+                },
                 { matchRepository.refreshEventMatches(eventKey) },
                 { eventRepository.refreshEventRankings(eventKey) },
                 { eventRepository.refreshEventAwards(eventKey) },
@@ -153,10 +159,6 @@ class TeamEventDetailViewModel
                 { eventRepository.refreshEventAlliances(eventKey) },
                 { eventRepository.refreshEventDistrictPoints(eventKey) },
                 { eventRepository.refreshEventRegionalPoints(eventKey) },
-                {
-                    regionalCmpAdvancementByTeam.value =
-                        eventRepository.fetchRegionalCmpAdvancementByTeam(year)
-                },
                 { teamRepository.refreshTeamMedia(teamKey, year) },
                 { teamRepository.refreshTeamEventPitLocation(teamKey, eventKey) },
             )
@@ -168,17 +170,16 @@ class TeamEventDetailViewModel
                 0 ->
                     refreshing(
                         { teamRepository.refreshTeam(teamKey) },
-                        { eventRepository.refreshEvent(eventKey) },
+                        {
+                            eventRepository.refreshEvent(eventKey)
+                            refreshRegionalCmpAdvancement(forceRefresh = true)
+                        },
                         { matchRepository.refreshEventMatches(eventKey) },
                         { eventRepository.refreshEventRankings(eventKey) },
                         { eventRepository.refreshEventAlliances(eventKey) },
                         { eventRepository.refreshEventAwards(eventKey) },
                         { eventRepository.refreshEventDistrictPoints(eventKey) },
                         { eventRepository.refreshEventRegionalPoints(eventKey) },
-                        {
-                            regionalCmpAdvancementByTeam.value =
-                                eventRepository.fetchRegionalCmpAdvancementByTeam(year)
-                        },
                         { teamRepository.refreshTeamEventPitLocation(teamKey, eventKey) },
                     )
                 // Matches
@@ -190,6 +191,15 @@ class TeamEventDetailViewModel
                 // Awards
                 4 -> refreshing({ eventRepository.refreshEventAwards(eventKey) })
             }
+        }
+
+        // Regional advancement is a whole-season payload that only applies to non-district
+        // events, so skip it entirely when the event belongs to a district.
+        private suspend fun refreshRegionalCmpAdvancement(forceRefresh: Boolean = false) {
+            val event = eventRepository.observeEvent(eventKey).first() ?: return
+            if (event.district != null) return
+            regionalCmpAdvancementByTeam.value =
+                regionalAdvancementRepository.getCmpAdvancementByTeam(year, forceRefresh)
         }
 
         @AssistedFactory

--- a/app/src/test/kotlin/com/thebluealliance/android/data/repository/RegionalAdvancementRepositoryTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/data/repository/RegionalAdvancementRepositoryTest.kt
@@ -1,19 +1,25 @@
 package com.thebluealliance.android.data.repository
 
+import com.thebluealliance.android.data.local.dao.EventDao
+import com.thebluealliance.android.data.local.entity.EventEntity
 import com.thebluealliance.android.data.remote.TbaApi
 import com.thebluealliance.android.data.remote.dto.RegionalAdvancementDto
 import com.thebluealliance.android.data.remote.dto.RegionalEventPointsDto
 import com.thebluealliance.android.data.remote.dto.RegionalRankingDto
+import com.thebluealliance.android.domain.model.CmpAdvancement
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class RegionalAdvancementRepositoryTest {
     private val api: TbaApi = mockk()
-    private val repository = RegionalAdvancementRepository(api)
+    private val eventDao: EventDao = mockk()
+    private val repository = RegionalAdvancementRepository(api, eventDao)
 
     @Test
     fun `getRegionalRankings maps and sorts rankings`() =
@@ -196,4 +202,119 @@ class RegionalAdvancementRepositoryTest {
             assertEquals(4, rankings[3].rank)
             assertEquals(5, rankings[4].rank)
         }
+
+    @Test
+    fun `getCmpAdvancementByTeam maps statuses and skips non-qualified teams`() =
+        runTest {
+            coEvery { api.getRegionalAdvancement(2026) } returns
+                mapOf(
+                    "frc254" to
+                        RegionalAdvancementDto(
+                            cmp = true,
+                            cmpStatus = "EventQualified",
+                            qualifyingEvent = "2026casj",
+                        ),
+                    "frc1114" to
+                        RegionalAdvancementDto(
+                            cmp = true,
+                            cmpStatus = "EventQualified",
+                            qualifyingEvent = "2026mike",
+                        ),
+                    "frc1816" to
+                        RegionalAdvancementDto(
+                            cmp = true,
+                            cmpStatus = "PoolQualified",
+                            qualifyingPoolWeek = 3,
+                        ),
+                    "frc971" to RegionalAdvancementDto(cmp = true, cmpStatus = "PreQualified"),
+                    "frc118" to RegionalAdvancementDto(cmp = false),
+                )
+            coEvery { eventDao.getByKeys(any()) } returns
+                listOf(eventEntity(key = "2026casj", shortName = "Silicon Valley"))
+
+            val advancement = repository.getCmpAdvancementByTeam(2026)
+
+            assertEquals(4, advancement.size)
+            assertEquals(
+                CmpAdvancement.EventQualified("2026casj", "Silicon Valley"),
+                advancement["frc254"],
+            )
+            assertEquals(
+                CmpAdvancement.EventQualified("2026mike", "2026mike"),
+                advancement["frc1114"],
+            )
+            assertEquals(CmpAdvancement.PoolQualified(week = 3), advancement["frc1816"])
+            assertEquals(CmpAdvancement.Qualified, advancement["frc971"])
+            assertNull(advancement["frc118"])
+        }
+
+    @Test
+    fun `getCmpAdvancementByTeam fetches once per year and shares the cached result`() =
+        runTest {
+            coEvery { api.getRegionalAdvancement(2026) } returns
+                mapOf("frc1816" to RegionalAdvancementDto(cmp = true, cmpStatus = "Qualified"))
+
+            val first = repository.getCmpAdvancementByTeam(2026)
+            val second = repository.getCmpAdvancementByTeam(2026)
+
+            assertEquals(first, second)
+            coVerify(exactly = 1) { api.getRegionalAdvancement(2026) }
+        }
+
+    @Test
+    fun `getCmpAdvancementByTeam refetches when forceRefresh is set`() =
+        runTest {
+            coEvery { api.getRegionalAdvancement(2026) } returns
+                mapOf("frc1816" to RegionalAdvancementDto(cmp = true, cmpStatus = "Qualified"))
+
+            repository.getCmpAdvancementByTeam(2026)
+            repository.getCmpAdvancementByTeam(2026, forceRefresh = true)
+
+            coVerify(exactly = 2) { api.getRegionalAdvancement(2026) }
+        }
+
+    @Test
+    fun `getCmpAdvancementByTeam skips years before regional advancement existed`() =
+        runTest {
+            val advancement = repository.getCmpAdvancementByTeam(2024)
+
+            assertTrue(advancement.isEmpty())
+            coVerify(exactly = 0) { api.getRegionalAdvancement(any()) }
+        }
+
+    @Test
+    fun `getCmpAdvancementByTeam handles null API response`() =
+        runTest {
+            coEvery { api.getRegionalAdvancement(2026) } returns null
+
+            val advancement = repository.getCmpAdvancementByTeam(2026)
+
+            assertTrue(advancement.isEmpty())
+        }
+
+    private fun eventEntity(
+        key: String,
+        shortName: String?,
+    ) = EventEntity(
+        key = key,
+        name = "Event $key",
+        eventCode = key.drop(4),
+        year = key.take(4).toInt(),
+        type = null,
+        district = null,
+        city = null,
+        state = null,
+        country = null,
+        startDate = null,
+        endDate = null,
+        week = null,
+        shortName = shortName,
+        website = null,
+        timezone = null,
+        webcasts = null,
+        locationName = null,
+        address = null,
+        gmapsUrl = null,
+        playoffType = 0,
+    )
 }


### PR DESCRIPTION
## Summary
- Every event-detail open fired `GET /regional_advancement/{year}` — an all-teams, whole-season payload — unconditionally, even for district events (meaningless there) and pre-2025 seasons (endpoint has no data). The fetch is now gated: skipped when the event belongs to a district (checked after the event row refresh, so cold opens gate correctly) and short-circuited in the repository for years before `FIRST_REGIONAL_ADVANCEMENT_YEAR` (2025).
- Consolidates the split-brain ownership of the endpoint: `EventRepository.fetchRegionalCmpAdvancementByTeam` is deleted and `RegionalAdvancementRepository.getCmpAdvancementByTeam` is the single path, behind a year-keyed in-memory cache with in-flight dedupe (mutex), so EventDetail and TeamEventDetail opened back-to-back share one request. Pull-to-refresh (`refreshTab`) passes `forceRefresh = true` to bypass the cache; initial loads (`refreshAll` from `init`) hit it. Room persistence remains a follow-up.
- Replaces the raw `cmp_status` wire strings with named constants and extends `RegionalAdvancementRepositoryTest` (11 tests) to cover status mapping, per-year caching, force refresh, and the pre-2025 gate.

## Panel notes
Tech Lead — "browsing 10 events on event-day Wi-Fi is ~140 requests." This trims the heaviest of the ~14 per-open calls: district events and historical years now make zero advancement requests, and regional events in the same season share one cached payload per session instead of one per screen.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — all green, including 5 new `getCmpAdvancementByTeam` tests
- [x] `./gradlew :app:lintDebug` — clean
- [x] Verified no remaining references to the deleted `EventRepository.fetchRegionalCmpAdvancementByTeam` across modules
- [ ] orchestrator visual pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)