### PR TITLE
fix(ui): grow inline link touch targets to the 48dp minimum

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -25,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.R
 import com.thebluealliance.android.domain.model.Event
@@ -122,10 +124,10 @@ fun EventInfoTab(
                     modifier =
                         Modifier
                             .padding(top = 8.dp)
-                            .clickable {
+                            .clickable(role = Role.Button) {
                                 val url = event.gmapsUrl ?: "geo:0,0?q=${Uri.encode(event.address)}"
                                 context.openUrl(url)
-                            },
+                            }.heightIn(min = 48.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
@@ -151,9 +153,9 @@ fun EventInfoTab(
                     modifier =
                         Modifier
                             .padding(top = 8.dp)
-                            .clickable {
+                            .clickable(role = Role.Button) {
                                 context.openUrl(event.website)
-                            },
+                            }.heightIn(min = 48.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
@@ -179,9 +181,9 @@ fun EventInfoTab(
                     modifier =
                         Modifier
                             .padding(top = 8.dp)
-                            .clickable {
+                            .clickable(role = Role.Button) {
                                 onNavigateToPitMap(event.key, favoriteTeamKeys)
-                            },
+                            }.heightIn(min = 48.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
@@ -221,10 +223,9 @@ fun EventInfoTab(
                     Row(
                         modifier =
                             Modifier
-                                .padding(top = 4.dp)
-                                .clickable {
+                                .clickable(role = Role.Button) {
                                     context.openUrl(url)
-                                },
+                                }.heightIn(min = 48.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,6 +28,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Ranking
@@ -272,7 +275,8 @@ private fun RankingItem(
                 Modifier
                     .fillMaxWidth()
                     .clickable { expanded = !expanded }
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .heightIn(min = 48.dp)
+                    .padding(horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -286,7 +290,8 @@ private fun RankingItem(
                 modifier =
                     Modifier
                         .weight(0.22f)
-                        .clickable { onTeamClick(ranking.teamKey) },
+                        .clickable(role = Role.Button) { onTeamClick(ranking.teamKey) }
+                        .minimumInteractiveComponentSize(),
                 color = MaterialTheme.colorScheme.primary,
             )
             Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -31,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -245,7 +247,10 @@ private fun EventInfo(
                 text = eventName,
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.clickable { onNavigateToEvent(eventKey) },
+                modifier =
+                    Modifier
+                        .clickable(role = Role.Button) { onNavigateToEvent(eventKey) }
+                        .minimumInteractiveComponentSize(),
             )
         }
         if (formattedTime != null) {
@@ -398,8 +403,8 @@ private fun AllianceTeams(
                     color = MaterialTheme.colorScheme.error,
                     modifier =
                         Modifier
-                            .clickable { onTeamClick(key) }
-                            .padding(top = 2.dp),
+                            .clickable(role = Role.Button) { onTeamClick(key) }
+                            .minimumInteractiveComponentSize(),
                 )
             }
         }
@@ -423,8 +428,8 @@ private fun AllianceTeams(
                     color = MaterialTheme.colorScheme.primary,
                     modifier =
                         Modifier
-                            .clickable { onTeamClick(key) }
-                            .padding(top = 2.dp),
+                            .clickable(role = Role.Button) { onTeamClick(key) }
+                            .minimumInteractiveComponentSize(),
                 )
             }
         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
@@ -25,10 +25,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.BuildConfig
 import com.thebluealliance.android.ui.components.TBATopAppBar
@@ -81,12 +83,18 @@ fun MoreScreen(
 
             Spacer(modifier = Modifier.weight(1f))
 
-            Row(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)) {
+            Row(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 Text(
                     text = "About",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.clickable(onClick = onNavigateToAbout),
+                    modifier =
+                        Modifier
+                            .clickable(role = Role.Button, onClick = onNavigateToAbout)
+                            .minimumInteractiveComponentSize(),
                 )
                 Text(
                     text = " · ",
@@ -97,7 +105,10 @@ fun MoreScreen(
                     text = "Thanks",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.clickable(onClick = onNavigateToThanks),
+                    modifier =
+                        Modifier
+                            .clickable(role = Role.Button, onClick = onNavigateToThanks)
+                            .minimumInteractiveComponentSize(),
                 )
             }
 


### PR DESCRIPTION
## Summary
- Grows the app's undersized inline tap targets to the 48dp accessibility minimum using pure modifier work — no layout redesigns.
- **MatchDetailScreen**: the event link and the stacked alliance team numbers (previously ~24dp tall at a 2dp pitch) now use `clickable(...).minimumInteractiveComponentSize()`, giving each a >=48dp box and a 48dp pitch between team numbers.
- **EventRankingsTab**: the team-number link nested inside the expandable row now fills a full 48dp target instead of ~24dp, resolving the two competing targets; the row swaps its 12dp vertical padding for `heightIn(min = 48.dp)` so its visual height is unchanged.
- **EventInfoTab**: the address / website / pit-map / webcast link rows get `heightIn(min = 48.dp)` inside the clickable (rows were ~20dp tall). LazyColumn modifier and the week line are untouched (owned by other open PRs).
- **MoreScreen**: the bodySmall About/Thanks footer links (~16dp tall) get full 48x48 `minimumInteractiveComponentSize()` boxes, vertically centered against the dot separator.
- All touched links/rows gain `Role.Button` semantics.

## Panel notes
Designer — "the highest-traffic links in the app, used in gloves and bleachers, are the hardest things to hit."

## Test plan
- [x] `./gradlew :app:testDebugUnitTest :app:lintDebug` passes (warningsAsErrors)
- [x] Diff is modifier-only: clickable regions wrap the size expansion (`clickable` precedes `minimumInteractiveComponentSize`/`heightIn`), so the grown area is actually tappable
- [ ] orchestrator visual pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Event Info — inline link rows grow to 48dp touch targets** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1418_info_before-b60f1dac.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1418_info_after-39c6dd3a.png" width="300"> |
<!-- screenshots:end -->