### PR TITLE
myTBA: show display names, link Match rows, add empty-state CTA

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/MatchDao.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/local/dao/MatchDao.kt
@@ -17,6 +17,9 @@ interface MatchDao {
     @Query("SELECT * FROM matches WHERE key = :key")
     fun observe(key: String): Flow<MatchEntity?>
 
+    @Query("SELECT * FROM matches WHERE key IN (:keys)")
+    fun observeByKeys(keys: List<String>): Flow<List<MatchEntity>>
+
     @Query("DELETE FROM matches WHERE eventKey = :eventKey")
     suspend fun deleteByEvent(eventKey: String)
 

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/EventRepository.kt
@@ -69,6 +69,9 @@ class EventRepository
 
         fun observeEvent(key: String): Flow<Event?> = eventDao.observe(key).map { it?.toDomain() }
 
+        fun observeEvents(keys: List<String>): Flow<List<Event>> =
+            eventDao.observeByKeys(keys).map { list -> list.map { it.toDomain() } }
+
         fun observeEventAwards(eventKey: String): Flow<List<Award>> =
             awardDao.observeByEvent(eventKey).map { list -> list.map { it.toDomain() } }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/data/repository/MatchRepository.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/repository/MatchRepository.kt
@@ -25,6 +25,9 @@ class MatchRepository
 
         fun observeMatch(key: String): Flow<Match?> = matchDao.observe(key).map { it?.toDomain() }
 
+        fun observeMatches(keys: List<String>): Flow<List<Match>> =
+            matchDao.observeByKeys(keys).map { list -> list.map { it.toDomain() } }
+
         suspend fun refreshMatch(matchKey: String) {
             try {
                 val dto = api.getMatch(matchKey)

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -211,6 +211,9 @@ fun TBANavigation(
                                     onNavigateToEvent = { eventKey ->
                                         navigator.navigate(Screen.EventDetail(eventKey))
                                     },
+                                    onNavigateToMatch = { matchKey ->
+                                        navigator.navigate(Screen.MatchDetail(matchKey))
+                                    },
                                     onNavigateToSearch = { navigator.navigate(Screen.Search) },
                                     onNavigateUp = { navigator.navigateUp() },
                                     reselectFlow = tabReselectFlows[Screen.MyTBA] ?: emptyFlow(),

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -65,6 +66,7 @@ import coil3.compose.AsyncImage
 import com.thebluealliance.android.R
 import com.thebluealliance.android.domain.model.Favorite
 import com.thebluealliance.android.domain.model.ModelType
+import com.thebluealliance.android.domain.model.NotificationType
 import com.thebluealliance.android.domain.model.Subscription
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.theme.TBAIndigo400
@@ -84,6 +86,7 @@ fun MyTBAScreen(
     onSignIn: () -> Unit = {},
     onNavigateToTeam: (String) -> Unit = {},
     onNavigateToEvent: (String) -> Unit = {},
+    onNavigateToMatch: (String) -> Unit = {},
     onNavigateUp: (() -> Unit)? = null,
     onNavigateToSearch: () -> Unit,
     reselectFlow: Flow<Unit>,
@@ -277,8 +280,10 @@ fun MyTBAScreen(
                         MyTBATabs.FAVORITES ->
                             FavoritesTab(
                                 favorites = uiState.favorites,
+                                displayNames = uiState.displayNames,
                                 onNavigateToTeam = onNavigateToTeam,
                                 onNavigateToEvent = onNavigateToEvent,
+                                onNavigateToMatch = onNavigateToMatch,
                                 listState = favoritesListState,
                                 canPinShortcuts = uiState.canPinShortcuts,
                                 onAddShortcut = viewModel::requestPinShortcut,
@@ -288,8 +293,10 @@ fun MyTBAScreen(
                         MyTBATabs.NOTIFICATIONS ->
                             NotificationsTab(
                                 subscriptions = uiState.subscriptions,
+                                displayNames = uiState.displayNames,
                                 onNavigateToTeam = onNavigateToTeam,
                                 onNavigateToEvent = onNavigateToEvent,
+                                onNavigateToMatch = onNavigateToMatch,
                                 listState = notificationsListState,
                                 onRemoveSubscription = { sub ->
                                     viewModel.removeSubscription(sub.modelKey, sub.modelType)
@@ -331,27 +338,29 @@ private fun SignInPrompt(onSignIn: () -> Unit) {
 @Composable
 private fun FavoritesTab(
     favorites: List<Favorite>,
+    displayNames: Map<String, String>,
     onNavigateToTeam: (String) -> Unit,
     onNavigateToEvent: (String) -> Unit,
+    onNavigateToMatch: (String) -> Unit,
     listState: LazyListState,
     canPinShortcuts: Boolean,
     onAddShortcut: (Favorite) -> Unit,
     onRemoveFavorite: (Favorite) -> Unit,
 ) {
     if (favorites.isEmpty()) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("No favorites yet", style = MaterialTheme.typography.bodyLarge)
-        }
+        EmptyTabMessage(title = "No favorites yet")
         return
     }
     LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
         items(favorites, key = { "${it.modelType}_${it.modelKey}" }) { favorite ->
             FavoriteItem(
                 favorite = favorite,
+                displayName = displayNames[favorite.modelKey] ?: favorite.modelKey,
                 onClick = {
                     when (favorite.modelType) {
                         ModelType.TEAM -> onNavigateToTeam(favorite.modelKey)
                         ModelType.EVENT -> onNavigateToEvent(favorite.modelKey)
+                        ModelType.MATCH -> onNavigateToMatch(favorite.modelKey)
                     }
                 },
                 canPinShortcuts = canPinShortcuts,
@@ -363,8 +372,28 @@ private fun FavoritesTab(
 }
 
 @Composable
+private fun EmptyTabMessage(title: String) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(horizontal = 32.dp),
+        ) {
+            Text(title, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = "Tap the star on any team or event to add it here.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
 private fun FavoriteItem(
     favorite: Favorite,
+    displayName: String,
     onClick: () -> Unit,
     canPinShortcuts: Boolean,
     onAddShortcut: () -> Unit,
@@ -391,7 +420,7 @@ private fun FavoriteItem(
             modifier = Modifier.weight(1f),
         ) {
             Text(
-                text = favorite.modelKey,
+                text = displayName,
                 style = MaterialTheme.typography.titleMedium,
             )
             Text(
@@ -447,25 +476,27 @@ private fun FavoriteItem(
 @Composable
 private fun NotificationsTab(
     subscriptions: List<Subscription>,
+    displayNames: Map<String, String>,
     onNavigateToTeam: (String) -> Unit,
     onNavigateToEvent: (String) -> Unit,
+    onNavigateToMatch: (String) -> Unit,
     listState: LazyListState,
     onRemoveSubscription: (Subscription) -> Unit,
 ) {
     if (subscriptions.isEmpty()) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("No notifications yet", style = MaterialTheme.typography.bodyLarge)
-        }
+        EmptyTabMessage(title = "No notifications yet")
         return
     }
     LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
         items(subscriptions, key = { "${it.modelType}_${it.modelKey}" }) { subscription ->
             SubscriptionItem(
                 subscription = subscription,
+                displayName = displayNames[subscription.modelKey] ?: subscription.modelKey,
                 onClick = {
                     when (subscription.modelType) {
                         ModelType.TEAM -> onNavigateToTeam(subscription.modelKey)
                         ModelType.EVENT -> onNavigateToEvent(subscription.modelKey)
+                        ModelType.MATCH -> onNavigateToMatch(subscription.modelKey)
                     }
                 },
                 onRemove = { onRemoveSubscription(subscription) },
@@ -477,6 +508,7 @@ private fun NotificationsTab(
 @Composable
 private fun SubscriptionItem(
     subscription: Subscription,
+    displayName: String,
     onClick: () -> Unit,
     onRemove: () -> Unit,
 ) {
@@ -500,12 +532,20 @@ private fun SubscriptionItem(
         Column(
             modifier = Modifier.weight(1f),
         ) {
+            val notificationNames =
+                subscription.notifications.joinToString(", ") { serverKey ->
+                    NotificationType
+                        .fromServerKey(serverKey)
+                        ?.displayName
+                        ?.takeIf { it.isNotBlank() }
+                        ?: serverKey
+                }
             Text(
-                text = subscription.modelKey,
+                text = displayName,
                 style = MaterialTheme.typography.titleMedium,
             )
             Text(
-                text = "$typeLabel · ${subscription.notifications.joinToString(", ")}",
+                text = "$typeLabel · $notificationNames",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAUiState.kt
@@ -10,5 +10,6 @@ data class MyTBAUiState(
     val userPhotoUrl: String? = null,
     val favorites: List<Favorite> = emptyList(),
     val subscriptions: List<Subscription> = emptyList(),
+    val displayNames: Map<String, String> = emptyMap(),
     val canPinShortcuts: Boolean = false,
 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
@@ -2,21 +2,33 @@ package com.thebluealliance.android.ui.mytba
 
 import androidx.lifecycle.viewModelScope
 import com.thebluealliance.android.data.repository.AuthRepository
+import com.thebluealliance.android.data.repository.EventRepository
+import com.thebluealliance.android.data.repository.MatchRepository
 import com.thebluealliance.android.data.repository.MyTBARepository
+import com.thebluealliance.android.data.repository.TeamRepository
+import com.thebluealliance.android.domain.getFullLabel
+import com.thebluealliance.android.domain.model.Event
 import com.thebluealliance.android.domain.model.Favorite
+import com.thebluealliance.android.domain.model.Match
+import com.thebluealliance.android.domain.model.ModelType
+import com.thebluealliance.android.domain.model.Team
 import com.thebluealliance.android.messaging.DeviceRegistrationManager
 import com.thebluealliance.android.shortcuts.TBAShortcutManager
 import com.thebluealliance.android.ui.common.RefreshableViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class MyTBAViewModel
     @Inject
@@ -25,13 +37,38 @@ class MyTBAViewModel
         private val myTBARepository: MyTBARepository,
         private val deviceRegistrationManager: DeviceRegistrationManager,
         private val shortcutManager: TBAShortcutManager,
+        teamRepository: TeamRepository,
+        eventRepository: EventRepository,
+        matchRepository: MatchRepository,
     ) : RefreshableViewModel() {
+        private val displayNames: Flow<Map<String, String>> =
+            combine(
+                myTBARepository.observeFavorites(),
+                myTBARepository.observeSubscriptions(),
+            ) { favorites, subscriptions ->
+                (
+                    favorites.map { it.modelKey to it.modelType } +
+                        subscriptions.map { it.modelKey to it.modelType }
+                ).distinct()
+            }.distinctUntilChanged().flatMapLatest { keyedTypes ->
+                fun keysOf(type: Int) = keyedTypes.filter { it.second == type }.map { it.first }
+                val matchKeys = keysOf(ModelType.MATCH)
+                val eventKeys =
+                    (keysOf(ModelType.EVENT) + matchKeys.map { it.substringBefore('_') }).distinct()
+                combine(
+                    teamRepository.observeTeams(keysOf(ModelType.TEAM)),
+                    eventRepository.observeEvents(eventKeys),
+                    matchRepository.observeMatches(matchKeys),
+                ) { teams, events, matches -> buildMyTBADisplayNames(teams, events, matches) }
+            }
+
         val uiState: StateFlow<MyTBAUiState> =
             combine(
                 authRepository.currentUser,
                 myTBARepository.observeFavorites(),
                 myTBARepository.observeSubscriptions(),
-            ) { user, favorites, subscriptions ->
+                displayNames,
+            ) { user, favorites, subscriptions, displayNames ->
                 MyTBAUiState(
                     isSignedIn = user != null,
                     userName = user?.displayName,
@@ -39,6 +76,7 @@ class MyTBAViewModel
                     userPhotoUrl = user?.photoUrl?.toString(),
                     favorites = favorites,
                     subscriptions = subscriptions,
+                    displayNames = displayNames,
                     canPinShortcuts = shortcutManager.canPinShortcuts(),
                 )
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), MyTBAUiState())
@@ -134,3 +172,26 @@ class MyTBAViewModel
             }
         }
     }
+
+internal fun buildMyTBADisplayNames(
+    teams: List<Team>,
+    events: List<Event>,
+    matches: List<Match>,
+): Map<String, String> {
+    val eventsByKey = events.associateBy { it.key }
+    return buildMap {
+        teams.forEach { team ->
+            val label = team.nickname ?: team.name
+            val name = if (label.isNullOrBlank()) "${team.number}" else "${team.number} - $label"
+            put(team.key, name)
+        }
+        events.forEach { event ->
+            put(event.key, "${event.year} ${event.name}")
+        }
+        matches.forEach { match ->
+            val event = eventsByKey[match.eventKey] ?: return@forEach
+            val label = match.getFullLabel(event.playoffType)
+            put(match.key, "$label - ${event.year} ${event.name}")
+        }
+    }
+}

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/mytba/MyTBADisplayNamesTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/mytba/MyTBADisplayNamesTest.kt
@@ -1,0 +1,138 @@
+package com.thebluealliance.android.ui.mytba
+
+import com.thebluealliance.android.domain.model.CompLevel
+import com.thebluealliance.android.domain.model.Event
+import com.thebluealliance.android.domain.model.EventType
+import com.thebluealliance.android.domain.model.Match
+import com.thebluealliance.android.domain.model.PlayoffType
+import com.thebluealliance.android.domain.model.Team
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class MyTBADisplayNamesTest {
+    private fun makeTeam(
+        key: String = "frc254",
+        number: Int = 254,
+        name: String? = "NASA Ames Research Center & Team 254",
+        nickname: String? = "The Cheesy Poofs",
+    ) = Team(
+        key = key,
+        number = number,
+        name = name,
+        nickname = nickname,
+        city = null,
+        state = null,
+        country = null,
+        rookieYear = null,
+    )
+
+    private fun makeEvent(
+        key: String = "2026casj",
+        name: String = "Silicon Valley Regional",
+        year: Int = 2026,
+        playoffType: PlayoffType = PlayoffType.DOUBLE_ELIM_8_TEAM,
+    ) = Event(
+        key = key,
+        name = name,
+        eventCode = key.removePrefix("$year"),
+        year = year,
+        type = EventType.REGIONAL,
+        district = null,
+        city = null,
+        state = null,
+        country = null,
+        startDate = null,
+        endDate = null,
+        week = null,
+        shortName = null,
+        website = null,
+        timezone = null,
+        locationName = null,
+        address = null,
+        gmapsUrl = null,
+        webcasts = emptyList(),
+        playoffType = playoffType,
+    )
+
+    private fun makeMatch(
+        key: String = "2026casj_qm42",
+        eventKey: String = "2026casj",
+        compLevel: CompLevel = CompLevel.QUAL,
+        matchNumber: Int = 42,
+        setNumber: Int = 1,
+    ) = Match(
+        key = key,
+        eventKey = eventKey,
+        compLevel = compLevel,
+        matchNumber = matchNumber,
+        setNumber = setNumber,
+        time = null,
+        predictedTime = null,
+        actualTime = null,
+        redTeamKeys = emptyList(),
+        redScore = -1,
+        blueTeamKeys = emptyList(),
+        blueScore = -1,
+        winningAlliance = null,
+    )
+
+    @Test
+    fun `team maps to number and nickname`() {
+        val names = buildMyTBADisplayNames(listOf(makeTeam()), emptyList(), emptyList())
+
+        assertEquals("254 - The Cheesy Poofs", names["frc254"])
+    }
+
+    @Test
+    fun `team without nickname falls back to name then number`() {
+        val names =
+            buildMyTBADisplayNames(
+                listOf(
+                    makeTeam(key = "frc1", number = 1, nickname = null, name = "The Juggernauts"),
+                    makeTeam(key = "frc2", number = 2, nickname = null, name = null),
+                ),
+                emptyList(),
+                emptyList(),
+            )
+
+        assertEquals("1 - The Juggernauts", names["frc1"])
+        assertEquals("2", names["frc2"])
+    }
+
+    @Test
+    fun `event maps to year and name`() {
+        val names = buildMyTBADisplayNames(emptyList(), listOf(makeEvent()), emptyList())
+
+        assertEquals("2026 Silicon Valley Regional", names["2026casj"])
+    }
+
+    @Test
+    fun `match with cached event maps to match label and event name`() {
+        val names = buildMyTBADisplayNames(emptyList(), listOf(makeEvent()), listOf(makeMatch()))
+
+        assertEquals("Qual 42 - 2026 Silicon Valley Regional", names["2026casj_qm42"])
+    }
+
+    @Test
+    fun `match label uses event playoff type`() {
+        val match =
+            makeMatch(
+                key = "2026casj_sf8m1",
+                compLevel = CompLevel.SEMIFINAL,
+                matchNumber = 1,
+                setNumber = 8,
+            )
+
+        val names = buildMyTBADisplayNames(emptyList(), listOf(makeEvent()), listOf(match))
+
+        assertEquals("Match 8 (Round 2) - 2026 Silicon Valley Regional", names["2026casj_sf8m1"])
+    }
+
+    @Test
+    fun `match without cached event is omitted so callers fall back to the raw key`() {
+        val names = buildMyTBADisplayNames(emptyList(), emptyList(), listOf(makeMatch()))
+
+        assertNull(names["2026casj_qm42"])
+    }
+}


### PR DESCRIPTION
## Summary
- myTBA rows rendered raw API keys ("frc254 / Team", "2026casj / Event"); they now join cached Team/Event names via the repositories ("254 - The Cheesy Poofs", "2026 Silicon Valley Regional"), falling back to the raw key when uncached (no new network fetches in this PR — cached-name join only; on-miss fetch is a follow-up).
- Subscription rows render NotificationType.displayName instead of raw server keys.
- Match favorites/subscriptions were tappable no-ops — they now navigate to Match Detail via the existing route.
- Empty states gain a call to action: "Tap the star on any team or event to add it here."

Fixes #1391

## Panel notes
- **PM:** "myTBA is our retention surface and it reads like a debug dump."

## Test plan
- [x] `:app:testDebugUnitTest` + `:app:lintDebug` green (verified by orchestrator post-salvage)
- [ ] Orchestrator visual pass (needs signed-in session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Agent-implemented; the agent session ended before reporting — work verified and shipped by the orchestrator.)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Favorites show display names (raw keys → resolved names)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1420_names_before-4e7ac004.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1420_names_after-26760c25.png" width="300"> |
| **myTBA empty state CTA** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1420_empty_before-392b86f5.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1420_empty_after-0e640496.png" width="300"> |
<!-- screenshots:end -->