### PR TITLE
Make Teams and Districts Empty/Error states reachable

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/common/RefreshableViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/common/RefreshableViewModel.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+enum class RefreshOutcome { PENDING, SUCCEEDED, FAILED }
+
 /**
  * Base for screens that pull-to-refresh. Owns the shared [isRefreshing] flag and runs
  * refresh tasks concurrently, logging (instead of swallowing) any failure.
@@ -17,6 +19,45 @@ import kotlinx.coroutines.launch
 abstract class RefreshableViewModel : ViewModel() {
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    /**
+     * Like [refreshing], but records completion into [outcome] — an empty cache only
+     * means Empty/Error once a refresh has actually finished.
+     */
+    protected fun refreshingTracked(
+        outcome: MutableStateFlow<RefreshOutcome>,
+        vararg tasks: suspend () -> Unit,
+    ) {
+        val remaining =
+            java.util.concurrent.atomic
+                .AtomicInteger(tasks.size)
+        val anyFailed =
+            java.util.concurrent.atomic
+                .AtomicBoolean(false)
+        val tracked =
+            tasks.map { task ->
+                suspend {
+                    try {
+                        task()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        anyFailed.set(true)
+                        throw e
+                    } finally {
+                        if (remaining.decrementAndGet() == 0) {
+                            outcome.value =
+                                if (anyFailed.get()) {
+                                    RefreshOutcome.FAILED
+                                } else {
+                                    RefreshOutcome.SUCCEEDED
+                                }
+                        }
+                    }
+                }
+            }
+        refreshing(*tracked.toTypedArray())
+    }
 
     protected fun refreshing(vararg tasks: suspend () -> Unit) {
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/districts/DistrictsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.thebluealliance.android.data.remote.TbaApi
 import com.thebluealliance.android.data.repository.DistrictRepository
 import com.thebluealliance.android.domain.model.District
+import com.thebluealliance.android.ui.common.RefreshOutcome
 import com.thebluealliance.android.ui.common.RefreshableViewModel
 import com.thebluealliance.android.ui.common.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,8 +12,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.Calendar
@@ -32,15 +33,22 @@ class DistrictsViewModel
         private val _selectedYear = MutableStateFlow(Calendar.getInstance().get(Calendar.YEAR))
         val selectedYear: StateFlow<Int> = _selectedYear.asStateFlow()
 
+        private val refreshOutcome = MutableStateFlow(RefreshOutcome.PENDING)
+
         val uiState: StateFlow<UiState<List<District>>> =
             _selectedYear
                 .flatMapLatest { year ->
-                    districtRepository.observeDistrictsForYear(year).map { districts ->
+                    combine(
+                        districtRepository.observeDistrictsForYear(year),
+                        refreshOutcome,
+                    ) { districts, outcome ->
                         val state: UiState<List<District>> =
-                            if (districts.isEmpty()) {
-                                UiState.Loading
-                            } else {
-                                UiState.Success(districts)
+                            when {
+                                districts.isNotEmpty() -> UiState.Success(districts)
+                                outcome == RefreshOutcome.PENDING -> UiState.Loading
+                                outcome == RefreshOutcome.FAILED ->
+                                    UiState.Error("Couldn't load districts")
+                                else -> UiState.Empty
                             }
                         state
                     }
@@ -70,11 +78,15 @@ class DistrictsViewModel
         }
 
         fun selectYear(year: Int) {
+            refreshOutcome.value = RefreshOutcome.PENDING
             _selectedYear.value = year
             refreshDistricts()
         }
 
         fun refreshDistricts() {
-            refreshing({ districtRepository.refreshDistrictsForYear(_selectedYear.value) })
+            refreshingTracked(
+                refreshOutcome,
+                { districtRepository.refreshDistrictsForYear(_selectedYear.value) },
+            )
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teams/TeamsViewModel.kt
@@ -6,9 +6,11 @@ import com.thebluealliance.android.data.repository.MyTBARepository
 import com.thebluealliance.android.data.repository.TeamRepository
 import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.domain.model.Team
+import com.thebluealliance.android.ui.common.RefreshOutcome
 import com.thebluealliance.android.ui.common.RefreshableViewModel
 import com.thebluealliance.android.ui.common.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -29,21 +31,27 @@ class TeamsViewModel
         private val myTBARepository: MyTBARepository,
         private val authRepository: AuthRepository,
     ) : RefreshableViewModel() {
+        private val refreshOutcome = MutableStateFlow(RefreshOutcome.PENDING)
+
         val uiState: StateFlow<UiState<TeamsData>> =
             combine(
                 teamRepository.observeAllTeams(),
                 myTBARepository.observeFavorites(),
-            ) { teams, favorites ->
+                refreshOutcome,
+            ) { teams, favorites, outcome ->
                 val state: UiState<TeamsData> =
-                    if (teams.isEmpty()) {
-                        UiState.Loading
-                    } else {
-                        val favoriteTeamKeys =
-                            favorites
-                                .filter { it.modelType == ModelType.TEAM }
-                                .map { it.modelKey }
-                                .toSet()
-                        UiState.Success(TeamsData(teams, favoriteTeamKeys))
+                    when {
+                        teams.isNotEmpty() -> {
+                            val favoriteTeamKeys =
+                                favorites
+                                    .filter { it.modelType == ModelType.TEAM }
+                                    .map { it.modelKey }
+                                    .toSet()
+                            UiState.Success(TeamsData(teams, favoriteTeamKeys))
+                        }
+                        outcome == RefreshOutcome.PENDING -> UiState.Loading
+                        outcome == RefreshOutcome.FAILED -> UiState.Error("Couldn't load teams")
+                        else -> UiState.Empty
                     }
                 state
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), UiState.Loading)
@@ -66,6 +74,6 @@ class TeamsViewModel
         fun refreshTeams() {
             val pages: List<suspend () -> Unit> =
                 (0..19).map { page -> { teamRepository.refreshTeamsPage(page) } }
-            refreshing(*pages.toTypedArray())
+            refreshingTracked(refreshOutcome, *pages.toTypedArray())
         }
     }


### PR DESCRIPTION
## Summary
- Teams and Districts mapped an empty cache straight to `Loading`, so a fresh install with no network spun forever; their Empty states were unreachable code, and a failed first refresh showed nothing. `StateContent` already renders `Empty`/`Error` (with Retry wired to refresh) — the states just couldn't occur.
- New shared `RefreshableViewModel.refreshingTracked(outcome, …tasks)` records when a refresh round completes and whether any task failed: screens stay `Loading` only until the first refresh finishes, then show `Empty` or `Error`+Retry; cached data always wins when present. Districts resets to `PENDING` on year change so year switches show Loading, not a premature Empty.
- First slice of the state-machine unification — event-detail tabs' flash-of-empty and refresh snackbars are the remaining slices.

Part of #1392

## Panel notes
- **PM + Tech Lead:** "open Teams offline on a fresh install and you get an infinite spinner; the empty strings are literally unreachable code."

## Test plan
- [x] `:app:testDebugUnitTest` + `:app:lintDebug` green
- [ ] Orchestrator visual pass (airplane-mode first-run) pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Agent-implemented ViewModel tracking; helper deduplicated into RefreshableViewModel and shipped by the orchestrator after the agent session ended.)