### PR TITLE
feat(tooling): per-worktree emulator fleet for parallel verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,46 @@
 ## Commits
 
 When asked to commit a checkpoint, write a short summary line and a brief description of what changed and why. Keep it concise.
+
+## Verifying changes on an emulator
+
+After a substantive UI change, build and run the app to confirm it.
+
+Single emulator:
+
+```bash
+scripts/run-emulator.sh Medium_Phone        # boot (idempotent)
+scripts/install-and-launch.sh               # build :app debug, install, launch
+scripts/emu screenshot artifacts/<name>.png
+```
+
+### Parallel worktrees (fan-out)
+
+When several worktree agents verify at once, each drives its **own** read-only
+emulator off a shared base AVD, so they don't contend for one device. Read-only
+instances write to a throwaway overlay and can never modify the base AVD.
+
+**One-time, by the orchestrator** (not each agent):
+
+```bash
+scripts/run-emulator.sh Medium_Phone        # 1. boot the base; get it golden (sign-in, etc.)
+scripts/worktree-emu.sh bless               # 2. save its state as the 'verify-base' snapshot
+# 3. close the base AVD — a read-only fleet can't share an AVD with a read-write base
+```
+
+**Per worktree, given a slot `0..2`:**
+
+```bash
+export ANDROID_SERIAL="$(scripts/worktree-emu.sh up "$SLOT")"   # boot read-only instance
+./gradlew :app:installDebug                                     # adb + Gradle honor ANDROID_SERIAL
+scripts/emu screenshot artifacts/<name>.png                     # scripts/emu honors it too
+scripts/worktree-emu.sh down "$SLOT"                            # tear down when done
+```
+
+Notes:
+
+- Max **3** concurrent instances on a 32 GB host (`TBA_WT_CAP`). Slots use console
+  ports `5580+`, leaving `5554–5578` free for interactive use.
+- `scripts/worktree-emu.sh list` shows slot status; see the script header for env overrides.
+- Gitignored configs (`google-services.json`, `local.properties`) must be present in each
+  worktree for `:app:installDebug` to build — the orchestrator copies them in.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,7 @@ Notes:
 - `scripts/worktree-emu.sh list` shows slot status; see the script header for env overrides.
 - Gitignored configs (`google-services.json`, `local.properties`) must be present in each
   worktree for `:app:installDebug` to build — the orchestrator copies them in.
+- **Emulators parallelize cheaply; builds don't.** Idle read-only instances are light, but
+  three simultaneous `:app:installDebug` builds will thrash a 32 GB host (especially under
+  other load) — serialize or throttle them (`nice -n 10`, `--max-workers`) even while the
+  emulators run in parallel.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,16 @@ When asked to commit a checkpoint, write a short summary line and a brief descri
 
 ## Verifying changes on an emulator
 
-After a substantive UI change, build and run the app to confirm it.
+After a substantive UI change, build and run the app to confirm it. Run all
+commands **from the worktree root**. A base AVD named `Medium_Phone` must exist
+(`"$ANDROID_HOME/emulator/emulator" -list-avds`) or override it with `TBA_BASE_AVD`.
 
 Single emulator:
 
 ```bash
-scripts/run-emulator.sh Medium_Phone        # boot (idempotent)
-scripts/install-and-launch.sh               # build :app debug, install, launch
+scripts/run-emulator.sh Medium_Phone        # boot (idempotent — no-op if already running)
+scripts/install-and-launch.sh               # build :app debug, install, AND launch
+mkdir -p artifacts
 scripts/emu screenshot artifacts/<name>.png
 ```
 
@@ -33,11 +36,19 @@ scripts/worktree-emu.sh bless               # 2. save its state as the 'verify-b
 **Per worktree, given a slot `0..2`:**
 
 ```bash
-export ANDROID_SERIAL="$(scripts/worktree-emu.sh up "$SLOT")"   # boot read-only instance
-./gradlew :app:installDebug                                     # adb + Gradle honor ANDROID_SERIAL
-scripts/emu screenshot artifacts/<name>.png                     # scripts/emu honors it too
+mkdir -p artifacts
+export ANDROID_SERIAL="$(scripts/worktree-emu.sh up "$SLOT")"   # boot read-only instance; prints its serial
+./gradlew :app:installDebug                                     # installs only — adb + Gradle read $ANDROID_SERIAL
+# MUST launch — installDebug does NOT start the app; screenshotting without this captures the launcher:
+scripts/emu -s "$ANDROID_SERIAL" launch \
+  com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity
+scripts/emu -s "$ANDROID_SERIAL" screenshot artifacts/<name>.png
 scripts/worktree-emu.sh down "$SLOT"                            # tear down when done
 ```
+
+If `up` errors with `snapshot 'verify-base' not found` or `base AVD … running
+read-write`, the orchestrator hasn't finished the one-time setup (bless + close
+the base) — stop and surface it; don't try to work around it.
 
 **Tear it all down** (the fleet is headless — `-no-window` — so nothing shows on screen):
 
@@ -49,9 +60,12 @@ adb devices                         # confirm only your base/interactive emulato
 
 Notes:
 
+- Pass `-s "$ANDROID_SERIAL"` to `scripts/emu` — it reads only the `-s` flag, not the
+  environment. `adb` and Gradle pick up `$ANDROID_SERIAL` from the environment on their own.
+- Debug package is `com.thebluealliance.androidclient.development`, activity
+  `com.thebluealliance.android.MainActivity`.
 - Max **3** concurrent instances on a 32 GB host (`TBA_WT_CAP`). Slots use console
   ports `5580+`, leaving `5554–5578` free for interactive use.
-- `scripts/worktree-emu.sh list` shows slot status; see the script header for env overrides.
 - Gitignored configs (`google-services.json`, `local.properties`) must be present in each
   worktree for `:app:installDebug` to build — the orchestrator copies them in.
 - **Emulators parallelize cheaply; builds don't.** Idle read-only instances are light, but

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,9 @@ mkdir -p artifacts
 export ANDROID_SERIAL="$(scripts/worktree-emu.sh up "$SLOT")"   # boot read-only instance; prints its serial
 ./gradlew :app:installDebug                                     # installs only — adb + Gradle read $ANDROID_SERIAL
 # MUST launch — installDebug does NOT start the app; screenshotting without this captures the launcher:
-scripts/emu -s "$ANDROID_SERIAL" launch \
+scripts/emu launch \
   com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity
-scripts/emu -s "$ANDROID_SERIAL" screenshot artifacts/<name>.png
+scripts/emu screenshot artifacts/<name>.png
 scripts/worktree-emu.sh down "$SLOT"                            # tear down when done
 ```
 
@@ -60,8 +60,8 @@ adb devices                         # confirm only your base/interactive emulato
 
 Notes:
 
-- Pass `-s "$ANDROID_SERIAL"` to `scripts/emu` — it reads only the `-s` flag, not the
-  environment. `adb` and Gradle pick up `$ANDROID_SERIAL` from the environment on their own.
+- `scripts/emu`, `adb`, and Gradle all honor `$ANDROID_SERIAL`, so exporting it once points
+  every command at the right device. Pass `-s <serial>` to `scripts/emu` to override it.
 - Debug package is `com.thebluealliance.androidclient.development`, activity
   `com.thebluealliance.android.MainActivity`.
 - Max **3** concurrent instances on a 32 GB host (`TBA_WT_CAP`). Slots use console

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,14 @@ scripts/emu screenshot artifacts/<name>.png                     # scripts/emu ho
 scripts/worktree-emu.sh down "$SLOT"                            # tear down when done
 ```
 
+**Tear it all down** (the fleet is headless — `-no-window` — so nothing shows on screen):
+
+```bash
+scripts/worktree-emu.sh list        # see what's running
+scripts/worktree-emu.sh down-all    # kill the ENTIRE fleet at once (ports 5580+ only; never the base/interactive emulators)
+adb devices                         # confirm only your base/interactive emulators remain
+```
+
 Notes:
 
 - Max **3** concurrent instances on a 32 GB host (`TBA_WT_CAP`). Slots use console

--- a/scripts/emu
+++ b/scripts/emu
@@ -244,7 +244,7 @@ def cmd_list(args):
 def main():
     global _serial
     parser = argparse.ArgumentParser(prog="emu", description="Android emulator automation CLI")
-    parser.add_argument("-s", "--serial", help="Target device serial (passed to adb -s)")
+    parser.add_argument("-s", "--serial", help="Target device serial (passed to adb -s; defaults to $ANDROID_SERIAL)")
     sub = parser.add_subparsers(dest="command")
 
     p = sub.add_parser("screenshot", help="Capture screenshot")
@@ -288,7 +288,9 @@ def main():
     p = sub.add_parser("list", help="Dump UI hierarchy tree")
 
     args = parser.parse_args()
-    _serial = args.serial
+    # Explicit -s wins; otherwise fall back to $ANDROID_SERIAL so emu targets the
+    # same device as adb and Gradle (which read it natively).
+    _serial = args.serial or os.environ.get("ANDROID_SERIAL")
     if not args.command:
         parser.print_help()
         sys.exit(1)

--- a/scripts/install-and-launch.sh
+++ b/scripts/install-and-launch.sh
@@ -8,4 +8,4 @@ export JAVA_HOME="${JAVA_HOME:-/Applications/Android Studio.app/Contents/jbr/Con
 
 ./gradlew :app:installDebug
 
-adb shell am start -n com.thebluealliance.android.dev/com.thebluealliance.android.MainActivity
+adb shell am start -n com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity

--- a/scripts/run-emulator.sh
+++ b/scripts/run-emulator.sh
@@ -2,8 +2,14 @@
 # Start an Android emulator. Pass --headless for CI (no window).
 set -euo pipefail
 
-EMULATOR="${ANDROID_HOME:-$HOME/Library/Android/sdk}/emulator/emulator"
-AVD="${1:-Pixel_8_API_35}"
+SDK="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+EMULATOR="$SDK/emulator/emulator"
+ADB="$SDK/platform-tools/adb"
+AVD="${1:-Medium_Phone}"
+
+# Snapshot the set of running emulators so we can identify the one we launch,
+# rather than `adb wait-for-device` (which is ambiguous with multiple devices).
+before="$("$ADB" devices | awk '/^emulator-/{print $1}' | sort)"
 
 if [[ "${2:-}" == "--headless" ]]; then
     "$EMULATOR" -avd "$AVD" -no-window -no-audio -gpu swiftshader_indirect &
@@ -12,6 +18,15 @@ else
 fi
 
 echo "Waiting for emulator to boot..."
-adb wait-for-device
-adb shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done'
-echo "Emulator ready."
+serial=""
+for _ in $(seq 1 60); do
+    sleep 1
+    after="$("$ADB" devices | awk '/^emulator-/{print $1}' | sort)"
+    serial="$(comm -13 <(echo "$before") <(echo "$after") | head -1)"
+    [[ -n "$serial" ]] && break
+done
+[[ -n "$serial" ]] || { echo "Emulator did not register with adb." >&2; exit 1; }
+
+"$ADB" -s "$serial" wait-for-device
+"$ADB" -s "$serial" shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done'
+echo "Emulator ready: $serial ($AVD)"

--- a/scripts/run-emulator.sh
+++ b/scripts/run-emulator.sh
@@ -7,6 +7,14 @@ EMULATOR="$SDK/emulator/emulator"
 ADB="$SDK/platform-tools/adb"
 AVD="${1:-Medium_Phone}"
 
+# Idempotent: if this AVD is already running, report its serial and stop.
+for s in $("$ADB" devices | awk '/^emulator-/{print $1}'); do
+    if [[ "$("$ADB" -s "$s" emu avd name 2>/dev/null | head -1 | tr -d '\r')" == "$AVD" ]]; then
+        echo "Emulator already running: $s ($AVD)"
+        exit 0
+    fi
+done
+
 # Snapshot the set of running emulators so we can identify the one we launch,
 # rather than `adb wait-for-device` (which is ambiguous with multiple devices).
 before="$("$ADB" devices | awk '/^emulator-/{print $1}' | sort)"

--- a/scripts/worktree-emu.sh
+++ b/scripts/worktree-emu.sh
@@ -11,6 +11,7 @@
 #   worktree-emu.sh up    <slot>     # boot a read-only verify instance for <slot>; prints its serial
 #   worktree-emu.sh serial <slot>    # print the serial for <slot> (no boot)
 #   worktree-emu.sh down  <slot>     # shut down the instance for <slot>
+#   worktree-emu.sh down-all         # shut down the ENTIRE fleet (safe; never touches the base)
 #   worktree-emu.sh list             # show all slots and their status
 #
 # Orchestrator usage:
@@ -109,6 +110,22 @@ cmd_down() {
   echo "stopped $serial" >&2
 }
 
+# Tear down the WHOLE fleet: every running emulator on a fleet-range console
+# port (>= PORT_BASE). Never touches base / interactive emulators (ports below
+# PORT_BASE), so it's always safe to run.
+cmd_down_all() {
+  local s port killed=0
+  for s in $("$ADB" devices | awk '/^emulator-/{print $1}'); do
+    port="${s#emulator-}"
+    if (( port >= PORT_BASE )); then
+      "$ADB" -s "$s" emu kill >/dev/null 2>&1 || true
+      echo "stopped $s" >&2
+      killed=$(( killed + 1 ))
+    fi
+  done
+  echo "stopped $killed fleet instance(s); emulators on ports < $PORT_BASE left untouched" >&2
+}
+
 cmd_list() {
   printf '%-5s %-18s %s\n' SLOT SERIAL STATUS
   local i serial
@@ -126,7 +143,8 @@ case "${1:-}" in
   bless)  cmd_bless ;;
   up)     cmd_up "${2:-}" ;;
   serial) require_slot "${2:-}"; serial_for "$2" ;;
-  down)   cmd_down "${2:-}" ;;
-  list)   cmd_list ;;
-  *) echo "usage: $0 {bless | up <slot> | serial <slot> | down <slot> | list}" >&2; exit 2 ;;
+  down)     cmd_down "${2:-}" ;;
+  down-all) cmd_down_all ;;
+  list)     cmd_list ;;
+  *) echo "usage: $0 {bless | up <slot> | serial <slot> | down <slot> | down-all | list}" >&2; exit 2 ;;
 esac

--- a/scripts/worktree-emu.sh
+++ b/scripts/worktree-emu.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Per-worktree Android emulator instances for parallel verification.
+#
+# Model: ONE shared base AVD is your "real", interactive emulator. You bless its
+# current state into a named snapshot; each worktree then boots a *read-only*
+# instance from that snapshot on its own console port / serial. Read-only
+# instances write to a throwaway copy-on-write overlay, so they can NEVER modify
+# the base AVD — verification runs can't corrupt your real emulator.
+#
+#   worktree-emu.sh bless            # save the running base AVD's state as the verify snapshot
+#   worktree-emu.sh up    <slot>     # boot a read-only verify instance for <slot>; prints its serial
+#   worktree-emu.sh serial <slot>    # print the serial for <slot> (no boot)
+#   worktree-emu.sh down  <slot>     # shut down the instance for <slot>
+#   worktree-emu.sh list             # show all slots and their status
+#
+# Orchestrator usage:
+#   export ANDROID_SERIAL="$(scripts/worktree-emu.sh up "$SLOT")"
+#   ./gradlew :app:installDebug          # adb + AGP both honor ANDROID_SERIAL
+#   scripts/emu screenshot out.png       # scripts/emu reads ANDROID_SERIAL too
+#
+# Env overrides:
+#   TBA_BASE_AVD         (default: Medium_Phone)  the shared base AVD
+#   TBA_VERIFY_SNAPSHOT  (default: verify-base)   named snapshot the fleet boots from
+#   TBA_WT_CAP           (default: 3)             max concurrent instances this host sustains
+#   TBA_WT_PORT_BASE     (default: 5580)          first console port; slot N -> base + N*2
+#                                                 (keeps 5554-5578 free for interactive use)
+set -euo pipefail
+
+SDK="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+EMULATOR="$SDK/emulator/emulator"
+ADB="$SDK/platform-tools/adb"
+BASE_AVD="${TBA_BASE_AVD:-Medium_Phone}"
+SNAPSHOT="${TBA_VERIFY_SNAPSHOT:-verify-base}"
+CAP="${TBA_WT_CAP:-3}"
+PORT_BASE="${TBA_WT_PORT_BASE:-5580}"
+BOOT_TIMEOUT="${TBA_WT_BOOT_TIMEOUT:-180}"
+
+port_for()   { echo $(( PORT_BASE + $1 * 2 )); }
+serial_for() { echo "emulator-$(port_for "$1")"; }
+
+die() { echo "worktree-emu: $*" >&2; exit 1; }
+
+require_slot() {
+  [[ "${1:-}" =~ ^[0-9]+$ ]] || die "slot must be a non-negative integer"
+  (( $1 < CAP )) || die "slot $1 exceeds cap $CAP (this host sustains $CAP concurrent instances; raise TBA_WT_CAP if you have the RAM)"
+}
+
+is_running() { "$ADB" devices | grep -q "^$1[[:space:]]"; }
+
+# Find a running RW base instance of BASE_AVD. Fleet slots also report the same
+# avd name, so only consider emulators on console ports BELOW the fleet range.
+base_serial() {
+  local s port
+  for s in $("$ADB" devices | awk '/^emulator-/{print $1}'); do
+    port="${s#emulator-}"
+    (( port >= PORT_BASE )) && continue   # skip fleet slots
+    if [[ "$("$ADB" -s "$s" emu avd name 2>/dev/null | head -1 | tr -d '\r')" == "$BASE_AVD" ]]; then
+      echo "$s"; return 0
+    fi
+  done
+  return 1
+}
+
+wait_boot() {
+  local serial="$1" i=0
+  "$ADB" -s "$serial" wait-for-device
+  until [[ "$("$ADB" -s "$serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]; do
+    (( i++ >= BOOT_TIMEOUT )) && die "$serial did not finish booting within ${BOOT_TIMEOUT}s (see /tmp/worktree-emu-*.log)"
+    sleep 1
+  done
+}
+
+cmd_bless() {
+  local s
+  s="$(base_serial)" || die "base AVD '$BASE_AVD' is not running — start it (e.g. scripts/run-emulator.sh $BASE_AVD), get it into the state you want, then bless"
+  echo "Blessing snapshot '$SNAPSHOT' from $s ($BASE_AVD)..." >&2
+  "$ADB" -s "$s" emu avd snapshot save "$SNAPSHOT"
+  echo "Done. Worktrees can now boot from it: scripts/worktree-emu.sh up <slot>" >&2
+}
+
+cmd_up() {
+  require_slot "$1"
+  local port serial base; port="$(port_for "$1")"; serial="$(serial_for "$1")"
+  if is_running "$serial"; then echo "$serial"; return 0; fi
+  [[ -d "$HOME/.android/avd/${BASE_AVD}.avd/snapshots/${SNAPSHOT}" ]] \
+    || die "snapshot '$SNAPSHOT' not found for $BASE_AVD — run 'scripts/worktree-emu.sh bless' first"
+  # Sequential model: the read-only fleet can't share an AVD with a read-write
+  # base instance. Fail clearly here instead of the emulator's cryptic lock error.
+  if base="$(base_serial)"; then
+    die "base AVD '$BASE_AVD' is running read-write on $base — close it before booting the read-only fleet (sequential model). Bless first if you have unsaved golden state."
+  fi
+  echo "Booting read-only verify instance: slot=$1 serial=$serial avd=$BASE_AVD snapshot=$SNAPSHOT" >&2
+  "$EMULATOR" -avd "$BASE_AVD" \
+    -read-only \
+    -snapshot "$SNAPSHOT" \
+    -no-snapshot-save \
+    -ports "$port,$((port + 1))" \
+    -no-window -no-audio -no-boot-anim \
+    -gpu swiftshader_indirect \
+    >"/tmp/worktree-emu-$1.log" 2>&1 &
+  wait_boot "$serial"
+  echo "$serial"
+}
+
+cmd_down() {
+  require_slot "$1"
+  local serial; serial="$(serial_for "$1")"
+  is_running "$serial" && "$ADB" -s "$serial" emu kill >/dev/null 2>&1 || true
+  echo "stopped $serial" >&2
+}
+
+cmd_list() {
+  printf '%-5s %-18s %s\n' SLOT SERIAL STATUS
+  local i serial
+  for (( i = 0; i < CAP; i++ )); do
+    serial="$(serial_for "$i")"
+    if is_running "$serial"; then
+      printf '%-5s %-18s %s\n' "$i" "$serial" "running ($BASE_AVD @ $SNAPSHOT)"
+    else
+      printf '%-5s %-18s %s\n' "$i" "$serial" "-"
+    fi
+  done
+}
+
+case "${1:-}" in
+  bless)  cmd_bless ;;
+  up)     cmd_up "${2:-}" ;;
+  serial) require_slot "${2:-}"; serial_for "$2" ;;
+  down)   cmd_down "${2:-}" ;;
+  list)   cmd_list ;;
+  *) echo "usage: $0 {bless | up <slot> | serial <slot> | down <slot> | list}" >&2; exit 2 ;;
+esac

--- a/scripts/worktree-emu.sh
+++ b/scripts/worktree-emu.sh
@@ -16,8 +16,9 @@
 #
 # Orchestrator usage:
 #   export ANDROID_SERIAL="$(scripts/worktree-emu.sh up "$SLOT")"
-#   ./gradlew :app:installDebug          # adb + AGP both honor ANDROID_SERIAL
-#   scripts/emu screenshot out.png       # scripts/emu reads ANDROID_SERIAL too
+#   ./gradlew :app:installDebug          # installs only (adb + AGP honor ANDROID_SERIAL)
+#   scripts/emu launch <pkg>/<activity>  # installDebug only installs — launch before screenshotting
+#   scripts/emu screenshot out.png       # scripts/emu honors ANDROID_SERIAL too
 #
 # Env overrides:
 #   TBA_BASE_AVD         (default: Medium_Phone)  the shared base AVD


### PR DESCRIPTION
## What

`scripts/worktree-emu.sh` lets parallel fan-out worktrees each drive their **own** read-only emulator off a shared base AVD, so verification (build → install → screenshot) stops serializing through one device. Plus a fix to `run-emulator.sh`.

## Model — sequential, single base AVD

One base AVD is your **real** interactive emulator. You get it golden, bless a snapshot, then worktrees boot **read-only** instances from that snapshot — they use a throwaway overlay and can never modify the base.

```
run Medium_Phone normally   ──►  get it golden (sign in, etc.)
worktree-emu.sh bless        ──►  saves snapshot 'verify-base'
(close the base)
worktree-emu.sh up 0/1/2     ──►  read-only fleet @ verify-base, one serial each
```

Orchestrator integration is just an env var — `adb`, Gradle `installDebug`, and `scripts/emu` all honor `ANDROID_SERIAL`:

```bash
export ANDROID_SERIAL="$(scripts/worktree-emu.sh up "$SLOT")"
./gradlew :app:installDebug
scripts/emu screenshot out.png
scripts/worktree-emu.sh down "$SLOT"
```

Commands: `bless` · `up <slot>` · `serial <slot>` · `down <slot>` · `list`. Tunables via env: `TBA_BASE_AVD` (default `Medium_Phone`), `TBA_VERIFY_SNAPSHOT` (`verify-base`), `TBA_WT_CAP` (`3`), `TBA_WT_PORT_BASE` (`5580`, keeps `5554–5578` free for interactive use).

## Validated locally

- Read-only instances **warm-boot from the snapshot in ~2s** and run concurrently off one AVD.
- Each is independently addressable via `ANDROID_SERIAL` (no `-s` threading).
- `up` refuses to start the fleet while a **read-write base of the same AVD is running** (the emulator otherwise errors `"run all emulators with -read-only flag"`) — detected by console port below the fleet range, so fleet instances aren't mistaken for the base.

## `run-emulator.sh` fix

- Stale default AVD `Pixel_8_API_35` → `Medium_Phone` (the old one no longer exists).
- Serial-blind boot wait (`adb wait-for-device` / `adb shell`) breaks with multiple devices attached → now identifies the launched emulator via an `adb devices` diff and pins `-s` for the boot wait.

## Known constraint / alternative

The emulator enforces an exclusive lock: you **can't** run a read-write base + a read-only fleet on the *same* AVD at once. The sequential model above sidesteps this (bless, then run the fleet). If we later want the base usable RW *during* a batch, that needs **cloned AVDs per slot** (~3–5 GB disk each) — captured as the alternative in #1424.

Refs #1424

🤖 Generated with [Claude Code](https://claude.com/claude-code)