### PR TITLE
fix(events): no flash-of-empty in event-detail tabs during first fetch

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/EventDetailScreen.kt
@@ -343,6 +343,7 @@ fun EventDetailScreen(
                                 val eventKey = uiState.event?.key
                                 if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
                             },
+                            isRefreshing = isRefreshing,
                             innerPadding = bottomPadding,
                         )
                     EventDetailTab.MATCHES ->
@@ -359,6 +360,7 @@ fun EventDetailScreen(
                                 val eventKey = uiState.event?.key
                                 if (eventKey != null) onNavigateToTeamEvent(teamKey, eventKey)
                             },
+                            isRefreshing = isRefreshing,
                             innerPadding = bottomPadding,
                         )
                     EventDetailTab.INSIGHTS ->
@@ -396,6 +398,7 @@ fun EventDetailScreen(
                                     onNavigateToTeam(teamKey)
                                 }
                             },
+                            isRefreshing = isRefreshing,
                             innerPadding = bottomPadding,
                         )
                 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
@@ -31,6 +31,7 @@ import com.thebluealliance.android.util.teamNumber
 fun EventAlliancesTab(
     alliances: List<Alliance>?,
     onTeamClick: (teamKey: String) -> Unit = {},
+    isRefreshing: Boolean = false,
     innerPadding: PaddingValues = PaddingValues.Zero,
 ) {
     if (alliances == null) {
@@ -40,10 +41,12 @@ fun EventAlliancesTab(
         return
     }
     if (alliances.isEmpty()) {
-        EmptyBox(
-            modifier = Modifier.padding(innerPadding),
-            message = "No alliances",
-        )
+        // An empty list while the first fetch is still in flight is loading, not empty.
+        if (isRefreshing) {
+            LoadingBox(modifier = Modifier.padding(innerPadding))
+        } else {
+            EmptyBox(modifier = Modifier.padding(innerPadding), message = "No alliances")
+        }
         return
     }
     LazyColumn(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAwardsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAwardsTab.kt
@@ -22,6 +22,7 @@ import com.thebluealliance.android.util.teamNumber
 fun EventAwardsTab(
     awards: List<Award>?,
     onTeamClick: (String) -> Unit = {},
+    isRefreshing: Boolean = false,
     innerPadding: PaddingValues = PaddingValues.Zero,
 ) {
     if (awards == null) {
@@ -31,10 +32,12 @@ fun EventAwardsTab(
         return
     }
     if (awards.isEmpty()) {
-        EmptyBox(
-            modifier = Modifier.padding(innerPadding),
-            message = "No awards",
-        )
+        // An empty list while the first fetch is still in flight is loading, not empty.
+        if (isRefreshing) {
+            LoadingBox(modifier = Modifier.padding(innerPadding))
+        } else {
+            EmptyBox(modifier = Modifier.padding(innerPadding), message = "No awards")
+        }
         return
     }
     LazyColumn(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -125,6 +125,7 @@ fun EventRankingsTab(
     rankingSortOrders: List<RankingSortOrder>?,
     rankingExtraStatsInfo: List<RankingSortOrder>?,
     onTeamClick: (String) -> Unit = {},
+    isRefreshing: Boolean = false,
     innerPadding: PaddingValues = PaddingValues.Zero,
 ) {
     if (rankings == null) {
@@ -134,10 +135,12 @@ fun EventRankingsTab(
         return
     }
     if (rankings.isEmpty()) {
-        EmptyBox(
-            modifier = Modifier.padding(innerPadding),
-            message = "No rankings",
-        )
+        // An empty list while the first fetch is still in flight is loading, not empty.
+        if (isRefreshing) {
+            LoadingBox(modifier = Modifier.padding(innerPadding))
+        } else {
+            EmptyBox(modifier = Modifier.padding(innerPadding), message = "No rankings")
+        }
         return
     }
 


### PR DESCRIPTION
Part of #1392 (the "flash of No rankings/awards" failure mode).

## Problem
The event-detail **Rankings / Alliances / Awards** tabs distinguish loading (`null`) from empty (`emptyList()`), but Room emits `emptyList()` immediately, so they flash **"No rankings / No alliances / No awards"** for a beat while the first network fetch is still in flight.

## Fix
Extend the convention `EventInsightsTab` **already** uses: pass `isRefreshing` into each tab and show `LoadingBox` for an empty list *while a refresh is in flight*, falling back to `EmptyBox` only once a refresh has completed. Three tabs + their call sites in `EventDetailScreen`.

(The sibling slice of #1392 — infinite-spinner-offline in Teams/Districts — is already fixed on `main` via the `RefreshOutcome` pattern, so it's not included here.)

## Verification
- [x] `:app:compileDebugKotlin` green; mirrors the in-production `EventInsightsTab` logic exactly
- [x] **UI-verified on the emulator** (debug build → local dev server): on an event with no rankings, the tab shows a **spinner during the first fetch** (no "No rankings" flash) and resolves to **"No rankings"** once the refresh completes — gate releases correctly, **no infinite spinner**, even when the refresh times out. The non-empty render path is unchanged by the diff. (Screenshots below.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Event-detail tab with no data, first fetch → resolved (debug build, local backend)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1440_rankings_loading-f5204dd4.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/district-dcmp-points/1440_rankings_empty-e449aff4.png" width="300"> |
<!-- screenshots:end -->
