### PR TITLE
fix(tooling)+docs: ACCESS_LOCAL_NETWORK for the Android 17 local-dev backend (#1396)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,12 +12,11 @@ The TBA web server (backend + frontend) is checked out at `~/codez/the-blue-alli
 ./gradlew :app:testDebugUnitTest
 ```
 
-After installing a debug build, always relaunch the app on the emulator:
+After installing a debug build, always relaunch the app on the emulator with `scripts/emu launch`
+(it also grants Android 17's `ACCESS_LOCAL_NETWORK` so the `10.0.2.2` local backend stays reachable):
 ```bash
-adb shell am force-stop com.thebluealliance.androidclient.development && adb shell am start -n com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity
+scripts/emu launch com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity
 ```
-
-On Android 17 (targetSdk 37), reaching the `10.0.2.2` local backend needs the `ACCESS_LOCAL_NETWORK` runtime permission granted (declaring it isn't enough). `scripts/install-and-launch.sh` does this for you; with a manual `installDebug`, grant it once: `adb shell pm grant com.thebluealliance.androidclient.development android.permission.ACCESS_LOCAL_NETWORK`.
 
 ## Emulator Interaction
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,6 +17,8 @@ After installing a debug build, always relaunch the app on the emulator:
 adb shell am force-stop com.thebluealliance.androidclient.development && adb shell am start -n com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity
 ```
 
+On Android 17 (targetSdk 37), reaching the `10.0.2.2` local backend needs the `ACCESS_LOCAL_NETWORK` runtime permission granted (declaring it isn't enough). `scripts/install-and-launch.sh` does this for you; with a manual `installDebug`, grant it once: `adb shell pm grant com.thebluealliance.androidclient.development android.permission.ACCESS_LOCAL_NETWORK`.
+
 ## Emulator Interaction
 
 Use `scripts/emu` (a Python CLI included in the repo) instead of raw `adb` commands. It provides text-based UI element matching which is far more reliable than guessing pixel coordinates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,8 @@ scripts/worktree-emu.sh bless               # 2. save its state as the 'verify-b
 mkdir -p artifacts
 export ANDROID_SERIAL="$(scripts/worktree-emu.sh up "$SLOT")"   # boot read-only instance; prints its serial
 ./gradlew :app:installDebug                                     # installs only — adb + Gradle read $ANDROID_SERIAL
-# Android 17 gates the 10.0.2.2 local backend behind ACCESS_LOCAL_NETWORK; declaring it isn't enough.
-# Without this grant the app installs + launches fine but silently can't reach the local server (empty screenshots):
-adb shell pm grant com.thebluealliance.androidclient.development \
-  android.permission.ACCESS_LOCAL_NETWORK 2>/dev/null || true
-# MUST launch — installDebug does NOT start the app; screenshotting without this captures the launcher:
+# MUST launch — installDebug does NOT start the app; screenshotting without this captures the launcher.
+# (scripts/emu launch also grants Android 17's ACCESS_LOCAL_NETWORK so the 10.0.2.2 backend is reachable.)
 scripts/emu launch \
   com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity
 scripts/emu screenshot artifacts/<name>.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,10 @@ scripts/worktree-emu.sh bless               # 2. save its state as the 'verify-b
 mkdir -p artifacts
 export ANDROID_SERIAL="$(scripts/worktree-emu.sh up "$SLOT")"   # boot read-only instance; prints its serial
 ./gradlew :app:installDebug                                     # installs only — adb + Gradle read $ANDROID_SERIAL
+# Android 17 gates the 10.0.2.2 local backend behind ACCESS_LOCAL_NETWORK; declaring it isn't enough.
+# Without this grant the app installs + launches fine but silently can't reach the local server (empty screenshots):
+adb shell pm grant com.thebluealliance.androidclient.development \
+  android.permission.ACCESS_LOCAL_NETWORK 2>/dev/null || true
 # MUST launch — installDebug does NOT start the app; screenshotting without this captures the launcher:
 scripts/emu launch \
   com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ The Android debug build defaults to `http://10.0.2.2:8080/` (the emulator's alia
 
 The Docker Compose stack includes a Firebase Auth emulator, and debug builds of the Android app are wired to it in `AuthModule` — so Google Sign-In works against the local backend with the stub `google-services.json` alone. No real Firebase project needed.
 
+**On Android 17 (API 37):** the debug build's `10.0.2.2` dev server and the Firebase Auth emulator are on a local network (`10.0.0.0/8`), which Android 17 gates behind the runtime `ACCESS_LOCAL_NETWORK` permission. The debug manifest declares it, but as a *dangerous* permission it isn't auto-granted — a fresh debug install silently times out reaching the local backend until it's granted. `scripts/install-and-launch.sh` grants it for you; if you install another way (Android Studio's ▶ button or `./gradlew :app:installDebug`), grant it once per install:
+
+```bash
+adb shell pm grant com.thebluealliance.androidclient.development android.permission.ACCESS_LOCAL_NETWORK
+```
+
 ## Firebase project (optional)
 
 Only needed if you want to test Google Sign-In or push notifications **against production**. For local development the stub `google-services.json` is enough.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The Android debug build defaults to `http://10.0.2.2:8080/` (the emulator's alia
 
 The Docker Compose stack includes a Firebase Auth emulator, and debug builds of the Android app are wired to it in `AuthModule` — so Google Sign-In works against the local backend with the stub `google-services.json` alone. No real Firebase project needed.
 
-**On Android 17 (API 37):** the debug build's `10.0.2.2` dev server and the Firebase Auth emulator are on a local network (`10.0.0.0/8`), which Android 17 gates behind the runtime `ACCESS_LOCAL_NETWORK` permission. The debug manifest declares it, but as a *dangerous* permission it isn't auto-granted — a fresh debug install silently times out reaching the local backend until it's granted. `scripts/install-and-launch.sh` grants it for you; if you install another way (Android Studio's ▶ button or `./gradlew :app:installDebug`), grant it once per install:
+**On Android 17 (API 37):** the debug build's `10.0.2.2` dev server is on a local network (`10.0.0.0/8`), which Android 17 gates behind the runtime `ACCESS_LOCAL_NETWORK` permission (the debug manifest declares it, but as a *dangerous* permission it isn't auto-granted). `scripts/install-and-launch.sh` and `scripts/emu launch` grant it for you; only if you launch straight from Android Studio's ▶ button do you need to grant it once:
 
 ```bash
 adb shell pm grant com.thebluealliance.androidclient.development android.permission.ACCESS_LOCAL_NETWORK

--- a/scripts/emu
+++ b/scripts/emu
@@ -181,6 +181,11 @@ def cmd_back(args):
 
 def cmd_launch(args):
     pkg = args.component.split("/")[0]
+    # Android 17+ gates the local-network dev backend (10.0.2.2) behind the dangerous
+    # ACCESS_LOCAL_NETWORK permission; declaring it in the manifest isn't enough. Grant it
+    # best-effort so the debug build can reach the local server. adb() captures output, so this
+    # is a silent no-op on pre-17, when already granted, or when the build doesn't declare it.
+    adb("shell", "pm", "grant", pkg, "android.permission.ACCESS_LOCAL_NETWORK")
     adb("shell", "am", "force-stop", pkg)
     adb_check("shell", "am", "start", "-n", args.component)
     print(f"Launched {args.component}")

--- a/scripts/install-and-launch.sh
+++ b/scripts/install-and-launch.sh
@@ -8,11 +8,6 @@ export JAVA_HOME="${JAVA_HOME:-/Applications/Android Studio.app/Contents/jbr/Con
 
 ./gradlew :app:installDebug
 
-# Android 17 (targetSdk 37) gates local-network access (the 10.0.2.2 dev server is in
-# 10.0.0.0/8) behind the runtime ACCESS_LOCAL_NETWORK permission. It's declared in the debug
-# manifest, but being a dangerous permission it isn't auto-granted — grant it so the debug
-# build reaches the local backend without a manual step. No-op on pre-17 / if already granted.
-adb shell pm grant com.thebluealliance.androidclient.development \
-    android.permission.ACCESS_LOCAL_NETWORK 2>/dev/null || true
-
-adb shell am start -n com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity
+# Launch via scripts/emu, which also grants the Android 17 ACCESS_LOCAL_NETWORK permission so
+# the debug build can reach the 10.0.2.2 local backend (the grant lives in one place — cmd_launch).
+scripts/emu launch com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity

--- a/scripts/install-and-launch.sh
+++ b/scripts/install-and-launch.sh
@@ -8,4 +8,11 @@ export JAVA_HOME="${JAVA_HOME:-/Applications/Android Studio.app/Contents/jbr/Con
 
 ./gradlew :app:installDebug
 
+# Android 17 (targetSdk 37) gates local-network access (the 10.0.2.2 dev server is in
+# 10.0.0.0/8) behind the runtime ACCESS_LOCAL_NETWORK permission. It's declared in the debug
+# manifest, but being a dangerous permission it isn't auto-granted — grant it so the debug
+# build reaches the local backend without a manual step. No-op on pre-17 / if already granted.
+adb shell pm grant com.thebluealliance.androidclient.development \
+    android.permission.ACCESS_LOCAL_NETWORK 2>/dev/null || true
+
 adb shell am start -n com.thebluealliance.androidclient.development/com.thebluealliance.android.MainActivity


### PR DESCRIPTION
Part of #1396 (targetSdk 37 / Android 17 readiness).

## Problem
The `targetSdk 36 → 37` bump (#1422) put the app under Android 17's [Local Network Protections](https://developer.android.com/about/versions/17/behavior-changes-17): reaching an RFC1918 address now requires the **`ACCESS_LOCAL_NETWORK`** runtime permission. The local dev backend is `http://10.0.2.2:8080` (in `10.0.0.0/8`), so the **debug** build is affected. Production talks to public HTTPS — unaffected.

The debug manifest already **declares** the permission, but `ACCESS_LOCAL_NETWORK` is a **dangerous** permission — declaring it doesn't grant it. So a fresh debug install silently can't reach the local server (connections just time out) until someone runs the grant by hand. I hit exactly this while verifying another PR on an Android 17 emulator.

## Fix (two parts)
**1. Tooling.** `scripts/install-and-launch.sh` grants the permission automatically right after `installDebug`, so the local-dev workflow works on Android 17 with no manual step. Best-effort (`|| true`), no-op on pre-17 / when already granted.

**2. Docs.** The auto-grant only helps developers who use that script — Android Studio's ▶ button and a direct `./gradlew :app:installDebug` both bypass it and hit the same silent timeout. So the requirement is now documented where each doc prescribes a bypassing install path:
- **README.md** "Option B: Run the local backend" — the canonical note + the one-time `adb shell pm grant` command.
- **.claude/CLAUDE.md** Build Commands — a one-line pointer (it prescribes `installDebug` + manual relaunch).
- **AGENTS.md** fan-out per-worktree block — the grant inline, so that runnable sequence is correct on Android 17.

## Verified
On a Pixel API 37 emulator: `dumpsys package` showed `ACCESS_LOCAL_NETWORK: granted=false` after a plain install (hence the silent block); `pm grant …` flips it to `granted=true`, restoring local-server reachability. (A doc-surface audit confirmed README is the canonical home and that `screenshot-playbook.sh` / `copilot-setup-steps.yml` are unaffected — they use the release/mock paths.)

The rest of the #1396 punch list (the bump itself, Certificate Transparency, and the other Android 17 behavior changes) is audited on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)