### PR TITLE
fix(network): keep null elements in place in the rankings sort_orders arrays (#1445)

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/data/mappers/Mappers.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/data/mappers/Mappers.kt
@@ -288,9 +288,16 @@ fun RankingResponseDto.toSortOrderEntity(eventKey: String) =
         extraStatsInfo = json.encodeToString(extraStatsInfo ?: emptyList()),
     )
 
+// A null element is kept in place (decoded as RankingSortOrderDto?) and coalesced to a
+// blank-name placeholder, so this column stays index-aligned with its sort_orders values
+// instead of shifting; the UI falls back to "Sort N" for a blank name. #1445.
+private val placeholderSortOrder = RankingSortOrder(name = "", precision = 2)
+
 fun EventRankingSortOrderEntity.getSortOrderInfo(): List<RankingSortOrder> =
     try {
-        json.decodeFromString<List<RankingSortOrderDto>>(sortOrderInfo).map { it.toDomain() }
+        json
+            .decodeFromString<List<RankingSortOrderDto?>>(sortOrderInfo)
+            .map { it?.toDomain() ?: placeholderSortOrder }
     } catch (_: Exception) {
         emptyList()
     }
@@ -298,7 +305,9 @@ fun EventRankingSortOrderEntity.getSortOrderInfo(): List<RankingSortOrder> =
 fun EventRankingSortOrderEntity.getExtraStatsInfo(): List<RankingSortOrder> =
     try {
         if (extraStatsInfo != null) {
-            json.decodeFromString<List<RankingSortOrderDto>>(extraStatsInfo).map { it.toDomain() }
+            json
+                .decodeFromString<List<RankingSortOrderDto?>>(extraStatsInfo)
+                .map { it?.toDomain() ?: placeholderSortOrder }
         } else {
             emptyList()
         }

--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/Ranking.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/Ranking.kt
@@ -10,6 +10,8 @@ data class Ranking(
     val losses: Int,
     val ties: Int,
     val qualAverage: Double?,
-    val sortOrders: List<Double> = emptyList(),
-    val extraStats: List<Double> = emptyList(),
+    // Nullable elements: a null is a missing component kept in place so it stays index-aligned
+    // with sortOrderInfo (the UI renders that cell blank). #1445.
+    val sortOrders: List<Double?> = emptyList(),
+    val extraStats: List<Double?> = emptyList(),
 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -375,12 +375,11 @@ private fun RankingItem(
                     for (i in 2 until minOf(ranking.sortOrders.size, sortOrders.size)) {
                         val sortOrder = sortOrders[i]
                         val value = ranking.sortOrders[i]
+                        // null = a missing component kept in place to preserve column alignment.
                         val formattedValue =
-                            String.format(
-                                Locale.US,
-                                "%.${sortOrder.precision}f",
-                                value,
-                            )
+                            value?.let {
+                                String.format(Locale.US, "%.${sortOrder.precision}f", it)
+                            } ?: "--"
 
                         Row(
                             modifier =
@@ -389,7 +388,9 @@ private fun RankingItem(
                                     .padding(vertical = 2.dp),
                         ) {
                             Text(
-                                text = sortOrder.name,
+                                // Blank when a null sort_order_info element was coalesced to a
+                                // placeholder; fall back like the header/extra-stats rows.
+                                text = sortOrder.name.ifBlank { "Sort ${i + 1}" },
                                 style = MaterialTheme.typography.bodyMedium,
                                 modifier = Modifier.weight(1f),
                             )
@@ -428,7 +429,9 @@ private fun RankingItem(
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
-                                text = String.format(Locale.US, "%.${precision}f", value),
+                                text =
+                                    value?.let { String.format(Locale.US, "%.${precision}f", it) }
+                                        ?: "--",
                                 style = MaterialTheme.typography.labelMedium,
                             )
                         }

--- a/core-network/build.gradle.kts
+++ b/core-network/build.gradle.kts
@@ -17,10 +17,21 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        unitTests.all {
+            it.useJUnitPlatform()
+        }
+    }
 }
 
 dependencies {
     api(libs.serialization.json)
+
+    testImplementation(libs.junit.api)
+    testRuntimeOnly(libs.junit.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
 
     // ApiKeyProvider + TbaClientFactory live here (RFC 0004 network unification, #1393).
     // FirebaseRemoteConfig, Retrofit and OkHttpClient appear in their public signatures, so

--- a/core-network/src/main/kotlin/com/thebluealliance/android/data/remote/dto/RankingDto.kt
+++ b/core-network/src/main/kotlin/com/thebluealliance/android/data/remote/dto/RankingDto.kt
@@ -6,8 +6,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RankingResponseDto(
     val rankings: List<RankingItemDto> = emptyList(),
-    @SerialName("sort_order_info") val sortOrderInfo: List<RankingSortOrderDto>? = null,
-    @SerialName("extra_stats_info") val extraStatsInfo: List<RankingSortOrderDto>? = null,
+    // Nullable ELEMENTS (not just a nullable list): a null entry is kept in place so it stays
+    // index-aligned with the sort_orders column it labels. Dropping would shift columns. The
+    // mapper coalesces a null to a blank-name placeholder, so the domain/UI type is unaffected.
+    @SerialName("sort_order_info") val sortOrderInfo: List<RankingSortOrderDto?>? = null,
+    @SerialName("extra_stats_info") val extraStatsInfo: List<RankingSortOrderDto?>? = null,
 )
 
 @Serializable
@@ -17,8 +20,12 @@ data class RankingItemDto(
     val dq: Int = 0,
     @SerialName("matches_played") val matchesPlayed: Int = 0,
     val record: TeamRecordDto? = null,
-    @SerialName("sort_orders") val sortOrders: List<Double> = emptyList(),
-    @SerialName("extra_stats") val extraStats: List<Double> = emptyList(),
+    // Nullable ELEMENTS: a null component is kept in place (index-aligned with sort_order_info)
+    // rather than dropped, so the UI renders that one cell blank instead of shifting every later
+    // tiebreaker under the wrong column header. A team with incomplete ranking data is the
+    // realistic source; JSON null round-trips through the Room entity cleanly (NaN would not). #1445.
+    @SerialName("sort_orders") val sortOrders: List<Double?> = emptyList(),
+    @SerialName("extra_stats") val extraStats: List<Double?> = emptyList(),
     @SerialName("qual_average") val qualAverage: Double? = null,
 )
 

--- a/core-network/src/test/kotlin/com/thebluealliance/android/data/remote/dto/RankingNullElementTest.kt
+++ b/core-network/src/test/kotlin/com/thebluealliance/android/data/remote/dto/RankingNullElementTest.kt
@@ -1,0 +1,57 @@
+package com.thebluealliance.android.data.remote.dto
+
+import com.thebluealliance.android.core.network.TbaClientFactory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks the #1445 ranking null-element handling against the REAL canonical config
+ * (TbaClientFactory.json). A team with incomplete ranking data can emit a null *element* inside
+ * the index-aligned `sort_orders` / `extra_stats` / `sort_order_info` arrays; the element is kept
+ * in place (so columns stay aligned and the UI renders that one cell blank) rather than dropped.
+ */
+class RankingNullElementTest {
+    private val json = TbaClientFactory.json
+
+    @Test
+    fun `null element inside sort_orders or extra_stats is kept in place, not crashed`() {
+        val payload =
+            """{"team_key":"frc254","rank":1,"sort_orders":[2.0,null,0.5],"extra_stats":[null,3.0]}"""
+        val item = json.decodeFromString(RankingItemDto.serializer(), payload)
+        assertEquals(listOf(2.0, null, 0.5), item.sortOrders)
+        assertEquals(listOf(null, 3.0), item.extraStats)
+    }
+
+    @Test
+    fun `null element inside sort_order_info is kept in place, not crashed`() {
+        val payload =
+            """{"rankings":[],"sort_order_info":[{"name":"RS","precision":2},null,{"name":"Coop","precision":0}]}"""
+        val resp = json.decodeFromString(RankingResponseDto.serializer(), payload)
+        assertEquals(3, resp.sortOrderInfo?.size)
+        assertEquals(null, resp.sortOrderInfo?.get(1))
+        assertEquals("Coop", resp.sortOrderInfo?.get(2)?.name)
+    }
+
+    @Test
+    fun `well-formed payload still parses unchanged`() {
+        val item =
+            json.decodeFromString(
+                RankingItemDto.serializer(),
+                """{"team_key":"frc254","rank":3,"sort_orders":[2.0,1.0],"extra_stats":[5.0]}""",
+            )
+        assertEquals(3, item.rank)
+        assertEquals(listOf(2.0, 1.0), item.sortOrders)
+        assertEquals(listOf(5.0), item.extraStats)
+    }
+
+    @Test
+    fun `serialization still emits a plain array`() {
+        val encoded =
+            json.encodeToString(
+                RankingItemDto.serializer(),
+                RankingItemDto(teamKey = "frc254", rank = 1, sortOrders = listOf(2.0, 0.5)),
+            )
+        assertTrue(encoded.contains("\"sort_orders\":[2.0,0.5]"), "got: $encoded")
+    }
+}


### PR DESCRIPTION
Closes #1445. **Stacked on #1443 (#1393)** — base is `unify-network-stack`; retarget to `main` once #1443 merges.

## Problem
A team with incomplete ranking data can emit a `null` **element** inside the index-aligned `sort_orders` / `extra_stats` / `sort_order_info` arrays. The canonical `Json`'s `coerceInputValues` rescues a `null` for a *defaulted property* but does nothing for a `null` *list element* — it throws and blanks the **whole rankings response**.

## Fix
Keep the `null` **in place** (not dropped) so the columns stay aligned:
- `RankingItemDto.sortOrders` / `extraStats` → `List<Double?>` (the rankings UI renders that one cell `--`).
- `RankingResponseDto.sortOrderInfo` / `extraStatsInfo` → `List<RankingSortOrderDto?>?`; the mapper coalesces a null element to a blank-name placeholder, so the domain/UI type is unchanged and stays index-aligned.

JSON `null` round-trips cleanly through the Room entity (a `NaN` sentinel would not).

## Scope (per review — thanks @bherbst)
Originally this also null-**dropped** several other lists defensively. Per review, a null in `team_keys`/`picks`/etc. isn't a valid backend response (it'd be a bad-ingest bug), so the speculative front-end handling was removed. The PR now covers **only** the rankings arrays — the one place TBA realistically emits a null element. Dropped: `team_keys`/`surrogate_team_keys`, alliance `picks`/`declines`, the rankings-array drop, and the `rank`/`precision` defaults (+ the `NullDroppingListSerializer`).

## Verified
- New `:core-network` test `RankingNullElementTest` (**4/4**) decodes through the real `TbaClientFactory.json`.
- `:app`/`:tv`/`:wear` `compileDebugKotlin` succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)