### PR TITLE
fix(network): give :app/:wear TBA read clients an absolute callTimeout (#1446)

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/di/NetworkModule.kt
@@ -30,6 +30,11 @@ import javax.inject.Singleton
 object NetworkModule {
     private const val HTTP_CACHE_SIZE_BYTES = 20L * 1024 * 1024
 
+    // Absolute ceiling on a whole TBA read call so a trickle/stalled response (which keeps
+    // resetting the per-byte read timeout) can't hang indefinitely. Generous vs TBA's small
+    // payloads, so it won't abort a legitimately slow load. (#1446)
+    private const val TBA_CALL_TIMEOUT_SECONDS = 45L
+
     // Canonical JSON for every client in this module (TBA read, authenticated ClientApi,
     // GitHub) so they cannot drift — see TbaClientFactory.json for the flag rationale.
     @Provides
@@ -62,6 +67,7 @@ object NetworkModule {
             cacheDir = context.cacheDir.resolve("http_cache"),
             cacheSizeBytes = HTTP_CACHE_SIZE_BYTES,
             isDebug = BuildConfig.DEBUG,
+            callTimeoutSeconds = TBA_CALL_TIMEOUT_SECONDS,
         )
 
     @Provides

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/data/WearNetworkModule.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/data/WearNetworkModule.kt
@@ -20,6 +20,10 @@ object WearNetworkModule {
     // The watch keeps a deliberately small HTTP cache; the size stays a per-module choice.
     private const val HTTP_CACHE_SIZE_BYTES = 5L * 1024 * 1024
 
+    // Absolute ceiling on a whole TBA read call so a trickle/stalled response can't hang the
+    // watch indefinitely. Generous vs TBA's small payloads. (#1446)
+    private const val TBA_CALL_TIMEOUT_SECONDS = 45L
+
     @Provides
     @Singleton
     fun provideFirebaseRemoteConfig(): FirebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
@@ -53,6 +57,7 @@ object WearNetworkModule {
             cacheDir = context.cacheDir.resolve("http_cache"),
             cacheSizeBytes = HTTP_CACHE_SIZE_BYTES,
             isDebug = BuildConfig.DEBUG,
+            callTimeoutSeconds = TBA_CALL_TIMEOUT_SECONDS,
         )
 
     @Provides


### PR DESCRIPTION
Closes #1446. **Stacked on #1443 (#1393)** — base is `unify-network-stack` because it uses that PR's `TbaClientFactory.okHttpClient(callTimeoutSeconds = …)` param; I'll retarget to `main` once #1443 merges.

## Problem
The `:app` and `:wear` TBA read clients set `connectTimeout(30s)` + `readTimeout(30s)` but **no `callTimeout`**. `readTimeout` is per-byte, so a server that trickles data just under the 30s window keeps resetting it and the call can hang indefinitely — there's no absolute ceiling. (Surfaced by the Designer seat reviewing #1393; `:tv` already sets one, `:app`/`:wear` were left as pre-existing.)

## Fix
Pass `callTimeoutSeconds = 45L` into the shared factory for both modules' read clients. **45s** is deliberately generous against TBA's small payloads (events/rankings/matches) so it won't abort a legitimately slow load, while bounding the trickle/stall case. (`:tv` keeps its tighter 20s for the no-retry 10-foot UI; `:app`/`:wear` have pull-to-refresh + error states, so a looser ceiling is appropriate.)

## Verified
`:app`/`:wear` `compileDebugKotlin` + `:app:lintDebug` all succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)