### PR TITLE
docs(play): mention the Android TV app in the store description

### DIFF
--- a/app/src/main/play/listings/en-US/full-description.txt
+++ b/app/src/main/play/listings/en-US/full-description.txt
@@ -5,6 +5,7 @@ Event schedules, match results, team information, and notifications about the FI
 ✅ Match results with score breakdowns and videos
 👥 Team photos, videos, and stats
 🗺️ District rankings and results
+📺 Android TV app to see what's happening now and watch event webcasts
 ⌚ Wear OS complication showing your team's next match on your watch face
 
 Are you a developer? Check out the source on GitHub and start contributing today!


### PR DESCRIPTION
The Play Store full description listed phone features + the Wear OS complication, but never mentioned the **Android TV** app — even though the TV app now ships on the alpha/beta tracks and its banner + "Happening Now" screenshot are already in the listing graphics.

## Change
Added one bullet to `app/src/main/play/listings/en-US/full-description.txt`:

> 📺 Android TV app to see what's happening now and watch event webcasts

Kept it accurate to what the TV app actually does (the leanback "Happening Now" browse + Twitch/YouTube webcasts), not full phone-feature parity. Description is now 6 bullets / ~640 chars (limit 4000).

## Notes
- The **short** description (`short-description.txt`) is at 66/80 chars and is phone-feature-focused; there isn't room to add TV without cutting, so I left it. Easy to reword if you'd rather it mention TV too.
- This only goes live on the next release publish (Gradle Play Publisher) — nothing is pushed to the live listing by this PR.
- Wording is a judgment call — happy to tweak the bullet copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)