### PR TITLE
chore(build): bump Gradle wrapper 9.6.0 → 9.6.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Gradle **9.6.1** released today, and lint's `AndroidGradlePluginVersion` check now flags 9.6.0 as outdated. Under `warningsAsErrors` that **fails `:app:lintDebug`**, breaking the `android-lint` CI job on **every open PR** (e.g. #1443 — the only failing check there is this, all builds + ktlint pass).

## Fix
Bump the wrapper to 9.6.1 (`./gradlew wrapper --gradle-version 9.6.1`). Only `distributionUrl` changes — no wrapper-jar or sha256 update needed for a patch.

## Verified
`Welcome to Gradle 9.6.1!` → `:app:lintDebug` **BUILD SUCCESSFUL**; the `AndroidGradlePluginVersion` error is gone.

Merge this first to unblock `android-lint` on the other open PRs. (Tracked in `tasks/todo.md`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)