### PR TITLE
feat(widget): report widget usage to Firebase Analytics (#1227)

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidget.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidget.kt
@@ -121,14 +121,7 @@ class TeamTrackingWidget : GlanceAppWidget() {
                 "2x2" -> "square"
                 "2x1" -> "minimal"
                 "1x1" -> "tiny"
-                else ->
-                    when {
-                        size.width >= 250.dp && size.height >= 110.dp -> "full"
-                        size.width >= 250.dp -> "compact"
-                        size.width >= 110.dp && size.height >= 110.dp -> "square"
-                        size.width >= 110.dp -> "minimal"
-                        else -> "tiny"
-                    }
+                else -> WidgetSizeTier.classify(size.width, size.height)
             }
 
         when (tier) {

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetConfigActivity.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetConfigActivity.kt
@@ -198,6 +198,9 @@ class TeamTrackingWidgetConfigActivity : ComponentActivity() {
             updateAppWidgetState(this@TeamTrackingWidgetConfigActivity, glanceId) { prefs ->
                 prefs[TeamTrackingWidgetKeys.TEAM_NUMBER] = teamNumber
                 prefs[TeamTrackingWidgetKeys.TEAM_KEY] = "frc$teamNumber"
+                // Sane default until the first worker run stamps the real state — shrinks the
+                // "unknown" widget_state window for analytics.
+                prefs[TeamTrackingWidgetKeys.WIDGET_STATE] = WidgetState.NO_UPCOMING.value
             }
 
             // Update widget UI to show loading state

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetKeys.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetKeys.kt
@@ -33,6 +33,9 @@ object TeamTrackingWidgetKeys {
     // Upcoming events (when no current event) — tab-separated rows: "name\tcity\tdate"
     val UPCOMING_EVENTS = stringPreferencesKey("upcoming_events")
 
+    // Which of the three render states the widget is in — the analytics `widget_state` dimension.
+    val WIDGET_STATE = stringPreferencesKey("widget_state")
+
     // Debug: force a specific size tier (e.g. "1x1", "2x1", "2x2", "4x1", "4x2")
     val DEBUG_FORCED_SIZE = stringPreferencesKey("debug_forced_size")
 

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetOpenAction.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetOpenAction.kt
@@ -23,6 +23,7 @@ class TeamTrackingWidgetOpenAction : ActionCallback {
         glanceId: GlanceId,
         parameters: ActionParameters,
     ) {
+        WidgetAnalytics.logWidgetClick(context, WidgetAnalytics.SURFACE_OPEN, glanceId)
         val state = getAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId)
         val teamKey = state[TeamTrackingWidgetKeys.TEAM_KEY]
 

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetReceiver.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetReceiver.kt
@@ -1,5 +1,6 @@
 package com.thebluealliance.android.widget
 
+import android.appwidget.AppWidgetManager
 import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
@@ -12,11 +13,25 @@ class TeamTrackingWidgetReceiver : GlanceAppWidgetReceiver() {
         // Schedule periodic refresh when first widget is added.
         // The config activity handles the first real refresh after the user picks a team.
         TeamTrackingWorker.enqueuePeriodicRefresh(context)
+        WidgetMetricsWorker.enqueueDaily(context)
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        super.onUpdate(context, appWidgetManager, appWidgetIds)
+        // Self-heal: widgets installed before metrics shipped already fired onEnabled and won't
+        // re-fire it on app update, so schedule here too. KEEP makes it idempotent and it only
+        // runs when a widget actually exists (never wakes widget-less devices).
+        WidgetMetricsWorker.enqueueDaily(context)
     }
 
     override fun onDisabled(context: Context) {
         super.onDisabled(context)
-        // Cancel periodic refresh when last widget is removed
+        // Cancel periodic work when last widget is removed
         TeamTrackingWorker.cancelPeriodicRefresh(context)
+        WidgetMetricsWorker.cancel(context)
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetRefreshAction.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetRefreshAction.kt
@@ -13,6 +13,7 @@ class TeamTrackingWidgetRefreshAction : ActionCallback {
         glanceId: GlanceId,
         parameters: ActionParameters,
     ) {
+        WidgetAnalytics.logWidgetClick(context, WidgetAnalytics.SURFACE_REFRESH, glanceId)
         val workRequest = OneTimeWorkRequestBuilder<TeamTrackingWorker>().build()
         WorkManager.getInstance(context).enqueue(workRequest)
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetSettingsAction.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWidgetSettingsAction.kt
@@ -14,6 +14,7 @@ class TeamTrackingWidgetSettingsAction : ActionCallback {
         glanceId: GlanceId,
         parameters: ActionParameters,
     ) {
+        WidgetAnalytics.logWidgetClick(context, WidgetAnalytics.SURFACE_SETTINGS, glanceId)
         val manager = GlanceAppWidgetManager(context)
         val appWidgetId = manager.getAppWidgetId(glanceId)
 

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWorker.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/TeamTrackingWorker.kt
@@ -255,6 +255,14 @@ class TeamTrackingWorker
                     } else {
                         prefs.remove(TeamTrackingWidgetKeys.UPCOMING_EVENTS)
                     }
+                    prefs[TeamTrackingWidgetKeys.WIDGET_STATE] =
+                        (
+                            if (upcomingEventsData.isNotEmpty()) {
+                                WidgetState.UPCOMING
+                            } else {
+                                WidgetState.NO_UPCOMING
+                            }
+                        ).value
                     TeamTrackingWidgetKeys.ALL_LAST_MATCH_KEYS.forEach { prefs.remove(it) }
                     TeamTrackingWidgetKeys.ALL_NEXT_MATCH_KEYS.forEach { prefs.remove(it) }
                 }
@@ -311,6 +319,7 @@ class TeamTrackingWorker
                     }
                 prefs[TeamTrackingWidgetKeys.NEXT_ALLIANCE] = nextAlliance
                 prefs.remove(TeamTrackingWidgetKeys.UPCOMING_EVENTS)
+                prefs[TeamTrackingWidgetKeys.WIDGET_STATE] = WidgetState.CURRENT_EVENT.value
 
                 if (lastMatch != null) {
                     prefs[TeamTrackingWidgetKeys.LAST_MATCH_LABEL] =

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/WidgetAnalytics.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/WidgetAnalytics.kt
@@ -1,0 +1,103 @@
+package com.thebluealliance.android.widget
+
+import android.content.Context
+import android.util.Log
+import androidx.glance.GlanceId
+import androidx.glance.appwidget.state.getAppWidgetState
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import com.google.firebase.Firebase
+import com.google.firebase.analytics.analytics
+import com.google.firebase.analytics.logEvent
+
+/** One widget's aggregate engagement over a query window, read from `AppWidgetEvent`. */
+data class WidgetEventSnapshot(
+    val appWidgetId: Int,
+    val visibleMillis: Long,
+)
+
+/** A folded `widget_engagement` row, one per (state x size-tier) group. */
+data class EngagementGroup(
+    val widgetState: String,
+    val tier: String,
+    val visibleWindowCount: Int,
+    val impressionMillis: Long,
+)
+
+/**
+ * Firebase Analytics for the Team Tracking widget — clicks (in-process, every device) and the
+ * daily engagement rollup (views, QPR2+ only; see [WidgetMetricsWorker]). No PII: no team key,
+ * no appWidgetId, no user id leaves the device.
+ */
+object WidgetAnalytics {
+    const val EVENT_WIDGET_CLICK = "widget_click"
+    const val EVENT_WIDGET_ENGAGEMENT = "widget_engagement"
+
+    const val PARAM_SURFACE = "surface"
+    const val PARAM_WIDGET_STATE = "widget_state"
+    const val PARAM_WIDGET_SIZE_TIER = "widget_size_tier"
+
+    // An AppWidgetEvent is a reporting window (~hourly, OEM-tunable), NOT a discrete view, so this
+    // is a coarse activity count; impression_ms (summed visible time) is the primary view signal.
+    // Per-tap clicks come from widget_click (every tap, all devices), not from here.
+    const val PARAM_VISIBLE_WINDOW_COUNT = "visible_window_count"
+    const val PARAM_IMPRESSION_MS = "impression_ms"
+
+    const val SURFACE_OPEN = "open"
+    const val SURFACE_SETTINGS = "settings"
+    const val SURFACE_REFRESH = "refresh"
+
+    /** `widget_state` when the worker hasn't stamped a state yet (freshly added widget). */
+    const val STATE_UNKNOWN = "unknown"
+
+    private const val TAG = "WidgetAnalytics"
+
+    /**
+     * Logs a `widget_click` for a tap on [surface], tagged with the widget's current
+     * [WidgetState]. Runs on every device/Android version (no platform-API dependency).
+     */
+    suspend fun logWidgetClick(
+        context: Context,
+        surface: String,
+        glanceId: GlanceId,
+    ) {
+        val widgetState =
+            try {
+                val state = getAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId)
+                state[TeamTrackingWidgetKeys.WIDGET_STATE] ?: STATE_UNKNOWN
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to read widget state for click", e)
+                STATE_UNKNOWN
+            }
+        Firebase.analytics.logEvent(EVENT_WIDGET_CLICK) {
+            param(PARAM_SURFACE, surface)
+            param(PARAM_WIDGET_STATE, widgetState)
+        }
+    }
+
+    /**
+     * Pure fold of per-widget snapshots into one [EngagementGroup] per (state x tier).
+     * [stateTierFor] maps an `appWidgetId` to its (widget_state, tier); a null result drops the
+     * snapshot (the widget is gone). No Android dependency — unit-tested directly.
+     */
+    fun foldEngagement(
+        snapshots: List<WidgetEventSnapshot>,
+        stateTierFor: (appWidgetId: Int) -> Pair<String, String>?,
+    ): List<EngagementGroup> {
+        // accumulator per group: [visibleWindowCount, impressionMillis]
+        val acc = LinkedHashMap<Pair<String, String>, LongArray>()
+        for (s in snapshots) {
+            val key = stateTierFor(s.appWidgetId) ?: continue
+            val a = acc.getOrPut(key) { LongArray(2) }
+            a[0] += 1
+            a[1] += s.visibleMillis
+        }
+        return acc.map { (key, a) ->
+            EngagementGroup(
+                widgetState = key.first,
+                tier = key.second,
+                visibleWindowCount = a[0].toInt(),
+                impressionMillis = a[1],
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/WidgetMetricsWorker.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/WidgetMetricsWorker.kt
@@ -121,7 +121,9 @@ class WidgetMetricsWorker
                 val snapshots = ArrayList<WidgetEventSnapshot>()
                 for (event in events) {
                     // Identity over the overlapping window: a re-seen (id, start, end) is skipped.
-                    val key = "${event.appWidgetId}:${event.start.toEpochMilli()}:${event.end.toEpochMilli()}"
+                    val startMs = event.start.toEpochMilli()
+                    val endMs = event.end.toEpochMilli()
+                    val key = "${event.appWidgetId}:$startMs:$endMs"
                     if (!seen.add(key)) continue
                     snapshots.add(
                         WidgetEventSnapshot(

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/WidgetMetricsWorker.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/WidgetMetricsWorker.kt
@@ -1,0 +1,167 @@
+package com.thebluealliance.android.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.annotation.ChecksSdkIntAtLeast
+import androidx.core.content.edit
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.getAppWidgetState
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.google.firebase.Firebase
+import com.google.firebase.analytics.analytics
+import com.google.firebase.analytics.logEvent
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.util.concurrent.TimeUnit
+
+/**
+ * Daily rollup of Team Tracking widget engagement (views / visible time) from
+ * `AppWidgetManager.queryAppWidgetEvents`, folded by widget state x size-tier and forwarded to
+ * Firebase Analytics as `widget_engagement` (see [WidgetAnalytics]).
+ *
+ * Views only exist on Android 16 QPR2+ — we gate on Android 17 (`SDK_INT >= 37`), a safe major
+ * check that avoids touching the API-36-only `SDK_INT_FULL` field on older devices, at the cost
+ * of not collecting views on the comparatively rare Android 16 QPR2 devices. Clicks
+ * (`widget_click`) are logged in-process and are unaffected by this gate.
+ */
+@HiltWorker
+class WidgetMetricsWorker
+    @AssistedInject
+    constructor(
+        @Assisted appContext: Context,
+        @Assisted workerParams: WorkerParameters,
+    ) : CoroutineWorker(appContext, workerParams) {
+        companion object {
+            private const val TAG = "WidgetMetricsWorker"
+            private const val WORK_NAME = "widget_metrics_rollup"
+            private const val PREFS = "widget_metrics"
+            private const val KEY_LAST_RUN = "last_run_millis"
+            private const val KEY_SEEN = "seen_events"
+
+            // Daily cadence; overlap the previous window so events finalizing near the boundary
+            // aren't dropped, and dedup by identity so the overlap never double-counts.
+            private val DEFAULT_WINDOW_MS = TimeUnit.HOURS.toMillis(24)
+            private val OVERLAP_MS = TimeUnit.HOURS.toMillis(6)
+
+            // Caps query cost + seen-set size. An outage longer than this drops the excess window
+            // — an accepted lossy bound for best-effort daily metrics.
+            private val MAX_LOOKBACK_MS = TimeUnit.HOURS.toMillis(48)
+
+            @ChecksSdkIntAtLeast(api = 37)
+            fun isSupported(): Boolean = Build.VERSION.SDK_INT >= 37
+
+            /** Idempotent (KEEP) — also called from onUpdate so existing installs self-heal. */
+            fun enqueueDaily(context: Context) {
+                if (!isSupported()) return
+                val request =
+                    PeriodicWorkRequestBuilder<WidgetMetricsWorker>(1, TimeUnit.DAYS).build()
+                WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                    WORK_NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    request,
+                )
+            }
+
+            fun cancel(context: Context) {
+                WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+            }
+        }
+
+        override suspend fun doWork(): Result {
+            if (!isSupported()) return Result.success()
+            return try {
+                val context = applicationContext
+                val appWidgetManager =
+                    AppWidgetManager.getInstance(context) ?: return Result.success()
+                val glanceManager = GlanceAppWidgetManager(context)
+                val glanceIds = glanceManager.getGlanceIds(TeamTrackingWidget::class.java)
+                if (glanceIds.isEmpty()) return Result.success()
+
+                // appWidgetId -> (widget_state, size_tier) for the widgets present right now.
+                val meta = HashMap<Int, Pair<String, String>>()
+                for (glanceId in glanceIds) {
+                    try {
+                        val appWidgetId = glanceManager.getAppWidgetId(glanceId)
+                        val state =
+                            getAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId)
+                        val widgetState =
+                            state[TeamTrackingWidgetKeys.WIDGET_STATE]
+                                ?: WidgetAnalytics.STATE_UNKNOWN
+                        val options = appWidgetManager.getAppWidgetOptions(appWidgetId)
+                        val minWidth = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH)
+                        val maxHeight = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT)
+                        val tier =
+                            if (minWidth <= 0 || maxHeight <= 0) {
+                                // Launcher hasn't reported size yet — don't pollute the "tiny" bucket.
+                                WidgetSizeTier.UNKNOWN
+                            } else {
+                                WidgetSizeTier.classify(minWidth, maxHeight)
+                            }
+                        meta[appWidgetId] = widgetState to tier
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to resolve widget meta for $glanceId", e)
+                    }
+                }
+
+                val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                val now = System.currentTimeMillis()
+                val lastRun = prefs.getLong(KEY_LAST_RUN, now - DEFAULT_WINDOW_MS)
+                val start = (lastRun - OVERLAP_MS).coerceAtLeast(now - MAX_LOOKBACK_MS)
+
+                val events = appWidgetManager.queryAppWidgetEvents(start, now)
+                val seen = HashSet(prefs.getStringSet(KEY_SEEN, emptySet()).orEmpty())
+                val snapshots = ArrayList<WidgetEventSnapshot>()
+                for (event in events) {
+                    // Identity over the overlapping window: a re-seen (id, start, end) is skipped.
+                    val key = "${event.appWidgetId}:${event.start.toEpochMilli()}:${event.end.toEpochMilli()}"
+                    if (!seen.add(key)) continue
+                    snapshots.add(
+                        WidgetEventSnapshot(
+                            appWidgetId = event.appWidgetId,
+                            visibleMillis = event.visibleDuration.toMillis(),
+                        ),
+                    )
+                }
+
+                // Persist dedup bookkeeping BEFORE emitting, so a crash mid-emit can't replay the
+                // window — losing one window (under-count) is safer than double-counting. Prune the
+                // seen-set to the lookback horizon (key suffix is the end epoch millis).
+                val cutoff = now - MAX_LOOKBACK_MS
+                val pruned =
+                    seen
+                        .filter { (it.substringAfterLast(':').toLongOrNull() ?: 0L) >= cutoff }
+                        .toSet()
+                prefs.edit {
+                    putLong(KEY_LAST_RUN, now)
+                    putStringSet(KEY_SEEN, pruned)
+                }
+
+                val analytics = Firebase.analytics
+                for (group in WidgetAnalytics.foldEngagement(snapshots) { meta[it] }) {
+                    analytics.logEvent(WidgetAnalytics.EVENT_WIDGET_ENGAGEMENT) {
+                        param(WidgetAnalytics.PARAM_WIDGET_STATE, group.widgetState)
+                        param(WidgetAnalytics.PARAM_WIDGET_SIZE_TIER, group.tier)
+                        param(
+                            WidgetAnalytics.PARAM_VISIBLE_WINDOW_COUNT,
+                            group.visibleWindowCount.toLong(),
+                        )
+                        param(WidgetAnalytics.PARAM_IMPRESSION_MS, group.impressionMillis)
+                    }
+                }
+                Result.success()
+            } catch (e: Exception) {
+                // Best-effort metrics: a missed window self-heals via the next run's overlap, so
+                // don't retry — retrying risks re-emitting events already counted this run.
+                Log.e(TAG, "Failed to roll up widget metrics", e)
+                Result.success()
+            }
+        }
+    }

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/WidgetSizeTier.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/WidgetSizeTier.kt
@@ -1,0 +1,34 @@
+package com.thebluealliance.android.widget
+
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Single source of truth for the widget's size-tier classification, shared by the renderer
+ * ([TeamTrackingWidget], which classifies the snapped `LocalSize`) and the metrics rollup
+ * ([WidgetMetricsWorker], which classifies the portrait box from `getAppWidgetOptions`). The
+ * two inputs can disagree slightly at breakpoint boundaries — fine for an approximate tier
+ * dimension.
+ */
+object WidgetSizeTier {
+    /** Tier when the launcher hasn't reported size options yet (empty options Bundle). */
+    const val UNKNOWN = "unknown"
+
+    fun classify(
+        widthDp: Int,
+        heightDp: Int,
+    ): String =
+        when {
+            widthDp >= 250 && heightDp >= 110 -> "full"
+            widthDp >= 250 -> "compact"
+            widthDp >= 110 && heightDp >= 110 -> "square"
+            widthDp >= 110 -> "minimal"
+            else -> "tiny"
+        }
+
+    // floor() preserves the `>=` integer-threshold semantics exactly (x >= T <=> floor(x) >= T
+    // for integer T, x >= 0), so this matches the renderer's Dp comparisons.
+    fun classify(
+        width: Dp,
+        height: Dp,
+    ): String = classify(width.value.toInt(), height.value.toInt())
+}

--- a/app/src/main/kotlin/com/thebluealliance/android/widget/WidgetState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/widget/WidgetState.kt
@@ -1,0 +1,19 @@
+package com.thebluealliance.android.widget
+
+/**
+ * The three states the Team Tracking widget renders (see [TeamTrackingWidget] subtitle logic),
+ * persisted by [TeamTrackingWorker] as the analytics `widget_state` dimension so usage can be
+ * sliced by what the widget was actually showing.
+ */
+enum class WidgetState(
+    val value: String,
+) {
+    /** "No upcoming events" — nothing tracked coming up. */
+    NO_UPCOMING("no_upcoming"),
+
+    /** "Upcoming events" — a future event is scheduled but not happening now. */
+    UPCOMING("upcoming"),
+
+    /** The tracked team is at — or just finished (within ~a day) — a live event (EVENT_KEY set). */
+    CURRENT_EVENT("current_event"),
+}

--- a/app/src/test/kotlin/com/thebluealliance/android/widget/WidgetAnalyticsTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/widget/WidgetAnalyticsTest.kt
@@ -1,0 +1,65 @@
+package com.thebluealliance.android.widget
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class WidgetAnalyticsTest {
+    @Test
+    fun `tier classify matches the renderer breakpoints`() {
+        assertEquals("tiny", WidgetSizeTier.classify(60, 60))
+        assertEquals("minimal", WidgetSizeTier.classify(110, 60))
+        assertEquals("square", WidgetSizeTier.classify(110, 110))
+        assertEquals("compact", WidgetSizeTier.classify(250, 60))
+        assertEquals("full", WidgetSizeTier.classify(250, 110))
+        // Just below each boundary
+        assertEquals("tiny", WidgetSizeTier.classify(109, 109))
+        assertEquals("compact", WidgetSizeTier.classify(250, 109))
+        assertEquals("minimal", WidgetSizeTier.classify(249, 109))
+    }
+
+    @Test
+    fun `fold groups by state x tier and sums each metric`() {
+        val snapshots =
+            listOf(
+                WidgetEventSnapshot(appWidgetId = 1, visibleMillis = 1_000),
+                WidgetEventSnapshot(appWidgetId = 1, visibleMillis = 500),
+                WidgetEventSnapshot(appWidgetId = 2, visibleMillis = 250),
+            )
+        val meta =
+            mapOf(
+                1 to ("current_event" to "full"),
+                2 to ("upcoming" to "minimal"),
+            )
+
+        val groups = WidgetAnalytics.foldEngagement(snapshots) { meta[it] }
+
+        assertEquals(2, groups.size)
+        val full = groups.first { it.tier == "full" }
+        assertEquals("current_event", full.widgetState)
+        assertEquals(2, full.visibleWindowCount)
+        assertEquals(1_500L, full.impressionMillis)
+        val minimal = groups.first { it.tier == "minimal" }
+        assertEquals("upcoming", minimal.widgetState)
+        assertEquals(1, minimal.visibleWindowCount)
+        assertEquals(250L, minimal.impressionMillis)
+    }
+
+    @Test
+    fun `fold drops snapshots whose widget is gone`() {
+        val snapshots = listOf(WidgetEventSnapshot(appWidgetId = 99, visibleMillis = 9_999))
+        val groups = WidgetAnalytics.foldEngagement(snapshots) { null }
+        assertEquals(0, groups.size)
+    }
+
+    @Test
+    fun `same state different tiers stay separate groups`() {
+        val snapshots =
+            listOf(
+                WidgetEventSnapshot(appWidgetId = 1, visibleMillis = 100),
+                WidgetEventSnapshot(appWidgetId = 2, visibleMillis = 200),
+            )
+        val meta = mapOf(1 to ("current_event" to "full"), 2 to ("current_event" to "square"))
+        val groups = WidgetAnalytics.foldEngagement(snapshots) { meta[it] }
+        assertEquals(2, groups.size)
+    }
+}


### PR DESCRIPTION
## What

Lean usage metrics for the Team Tracking widget → Firebase Analytics, so we can answer **how much do people use the widget** — DAU, views, clicks — sliced by **widget state** (`no_upcoming` / `upcoming` / `current_event`).

Closes #1227.

## Events

| Event | When | Coverage | Params |
|---|---|---|---|
| `widget_click` | in-process, every tap | **all devices** | `surface` (open/settings/refresh), `widget_state` |
| `widget_engagement` | daily rollup from `queryAppWidgetEvents` | **Android 17+** | `widget_state`, `widget_size_tier`, `visible_window_count`, `impression_ms` |

## Coverage reality

Clicks log on every device. Views/visible-time come from `AppWidgetManager.queryAppWidgetEvents`, which only exists on Android 16 QPR2+ — we gate on `SDK_INT >= 37` (Android 17), a safe major-version check that avoids the API-36-only `SDK_INT_FULL` field on older devices. So view metrics grow as 17 rolls out, while clicks are universal today. (GA4's built-in Active Users counts app *opens*; these events are what give widget DAU.)

## Design notes

- `widget_state` is read straight from what `TeamTrackingWorker` already computes (EVENT_KEY / UPCOMING_EVENTS presence); the worker persists a 3-valued `WIDGET_STATE` pref that the click sites + rollup read.
- The rollup worker dedups `AppWidgetEvent`s by identity (`appWidgetId:start:end`) across an overlapping window and **persists the seen-set before emitting**, so a crash mid-emit can't replay/double-count.
- Self-heals existing widget installs via an `onUpdate` schedule (idempotent `ExistingPeriodicWorkPolicy.KEEP`) — owners who added the widget before this shipped won't re-fire `onEnabled`.
- The 15-min fast refresh is **unchanged** — freshness during events is the point.
- No PII; honors the existing Firebase analytics collection toggle (disabled in debug builds).
- Renderer + rollup share one `WidgetSizeTier` classifier (no duplicated breakpoints).

## Not in scope (deferred)

Multi-widget-per-device count (→ first-class multi-team config UI), fast-refresh cadence tuning, scroll metrics (nothing scrollable yet).

## Review

Design was spec'd through a 5-seat panel; the implementation went through a 3-lens adversarial review (correctness / Android-platform / analytics-privacy). Confirmed findings folded in:
- **Honest metric naming** — an `AppWidgetEvent` is a ~hourly *reporting window*, not a discrete view, so `impression_count` → `visible_window_count`, and the collapsed (≤1/hr) `clicked_count` was dropped in favor of the authoritative in-process `widget_click`.
- **Persist-before-emit** to defeat retry double-counting; `Result.success()` (best-effort) on failure.
- `unknown`-tier guard for an empty launcher options bundle; `NO_UPCOMING` stamped at widget creation to shrink the `unknown`-state window.

## Verification

- `:app:testDebugUnitTest` ✅ (incl. new `WidgetAnalyticsTest`)
- `:app:lintDebug` ✅ under `warningsAsErrors` — the `@ChecksSdkIntAtLeast(api = 37)` gate satisfies `NewApiFull`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
