### PR TITLE
fix: point .git-blame-ignore-revs at the real bulk-ktlint commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,5 +2,5 @@
 # Configure locally with: git config blame.ignoreRevsFile .git-blame-ignore-revs
 # GitHub respects this file automatically in its blame UI.
 
-# chore: apply ktlint formatting to entire codebase (#1069)
-47b2061d6a1a17b5da2822c799243200fa46064e
+# chore: set up ktlint formatting and CI lint job (#1297)
+31723a4465650ef02af53f9799feaed610992cb0


### PR DESCRIPTION
## What

`.git-blame-ignore-revs` listed `47b2061d…`, which **does not resolve in this repo** (`git rev-parse --verify` fails) — so GitHub's blame-skip silently never applied. The real mass-reformat commit is **`31723a446`** ("chore: set up ktlint formatting and CI lint job", #1297), which mechanically reformatted **162 files (+9353 / −6386)**. This corrects the SHA and the stale comment.

## Verification

- `git rev-parse --verify 31723a446^{commit}` ✅ resolves
- `git rev-parse --verify 47b2061d` ✅ fails (confirmed dead)
- `git show --shortstat 31723a446` → 162 files changed (confirms it's the bulk reformat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
