### PR TITLE
feat(events): show the event code on the Event Info tab (tap to copy)

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.PlayCircle
+import androidx.compose.material.icons.outlined.Tag
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -32,6 +34,7 @@ import com.thebluealliance.android.domain.model.Webcast
 import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.components.formatEventDateRange
 import com.thebluealliance.android.ui.events.weekLabel
+import com.thebluealliance.android.util.copyToClipboard
 import com.thebluealliance.android.util.openUrl
 
 @Composable
@@ -113,6 +116,39 @@ fun EventInfoTab(
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(top = 4.dp),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        // Event code / key — tap to copy (needed for scouting tools, the API, and URLs)
+        item {
+            Row(
+                modifier =
+                    Modifier
+                        .padding(top = 8.dp)
+                        .clickable {
+                            context.copyToClipboard("Event code", event.key)
+                        },
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Outlined.Tag,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = event.key,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(Modifier.width(8.dp))
+                Icon(
+                    Icons.Outlined.ContentCopy,
+                    contentDescription = "Copy event code",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(14.dp),
                 )
             }
         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -120,14 +120,15 @@ fun EventInfoTab(
             }
         }
 
-        // Event code / key — tap to copy (needed for scouting tools, the API, and URLs)
+        // Event key — tap to copy (needed for scouting tools, the API, and URLs).
+        // This is the full TBA key (e.g. 2026casf); the short FIRST code is event.eventCode.
         item {
             Row(
                 modifier =
                     Modifier
                         .padding(top = 8.dp)
                         .clickable {
-                            context.copyToClipboard("Event code", event.key)
+                            context.copyToClipboard("Event key", event.key)
                         },
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -139,14 +140,14 @@ fun EventInfoTab(
                 )
                 Spacer(Modifier.width(8.dp))
                 Text(
-                    text = event.key,
+                    text = "Event key: ${event.key}",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.primary,
                 )
                 Spacer(Modifier.width(8.dp))
                 Icon(
                     Icons.Outlined.ContentCopy,
-                    contentDescription = "Copy event code",
+                    contentDescription = "Copy event key",
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(14.dp),
                 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -120,40 +120,6 @@ fun EventInfoTab(
             }
         }
 
-        // Event key — tap to copy (needed for scouting tools, the API, and URLs).
-        // This is the full TBA key (e.g. 2026casf); the short FIRST code is event.eventCode.
-        item {
-            Row(
-                modifier =
-                    Modifier
-                        .padding(top = 8.dp)
-                        .clickable {
-                            context.copyToClipboard("Event key", event.key)
-                        },
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    Icons.Outlined.Tag,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(18.dp),
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    text = "Event key: ${event.key}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                Spacer(Modifier.width(8.dp))
-                Icon(
-                    Icons.Outlined.ContentCopy,
-                    contentDescription = "Copy event key",
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(14.dp),
-                )
-            }
-        }
-
         // Address (tappable → opens Google Maps)
         if (event.address != null) {
             item {
@@ -280,6 +246,40 @@ fun EventInfoTab(
                         )
                     }
                 }
+            }
+        }
+
+        // Event key — last, below the address/contact info. Tap to copy (needed for scouting
+        // tools, the API, and URLs). Full TBA key (e.g. 2026casf); short FIRST code is eventCode.
+        item {
+            Row(
+                modifier =
+                    Modifier
+                        .padding(top = 8.dp)
+                        .clickable {
+                            context.copyToClipboard("Event key", event.key)
+                        },
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Outlined.Tag,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = "Event key: ${event.key}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(Modifier.width(8.dp))
+                Icon(
+                    Icons.Outlined.ContentCopy,
+                    contentDescription = "Copy event key",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(14.dp),
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/util/UrlUtils.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/util/UrlUtils.kt
@@ -1,8 +1,11 @@
 package com.thebluealliance.android.util
 
 import android.content.ActivityNotFoundException
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.widget.Toast
 import androidx.core.net.toUri
 
@@ -14,5 +17,20 @@ fun Context.openUrl(url: String) {
         startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
     } catch (_: ActivityNotFoundException) {
         Toast.makeText(this, "No app available to open this link", Toast.LENGTH_SHORT).show()
+    }
+}
+
+/**
+ * Copies [text] to the clipboard under [label]. Shows a confirmation Toast on Android < 13;
+ * Android 13+ surfaces its own system copy confirmation, so we skip the Toast there.
+ */
+fun Context.copyToClipboard(
+    label: String,
+    text: String,
+) {
+    getSystemService(ClipboardManager::class.java)
+        ?.setPrimaryClip(ClipData.newPlainText(label, text))
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        Toast.makeText(this, "Copied $text", Toast.LENGTH_SHORT).show()
     }
 }


### PR DESCRIPTION
## What

Closes #1462. Adds a tap-to-copy **event code** row to the Event Info tab.

People frequently need an event's code/key — for scouting tools, the TBA API, and sharing URLs — but the app never displayed it anywhere. And because the website deep-links into the app, users who started on `thebluealliance.com` had no way to grab it. Reported on [Chief Delphi](https://www.chiefdelphi.com/t/the-blue-alliance-2026-site-updates-features/515744/32) (@Nick.kremer).

## Change

- New row on the Event Info tab showing the full event key (e.g. `2026cmptx`), **tap to copy**, with a `#` tag icon + a copy affordance — styled to match the existing address/website rows.
- New `Context.copyToClipboard(label, text)` helper in `UrlUtils.kt` (Android 13+ shows the system copy confirmation; older versions get a Toast).
- The data was already present end-to-end (`Event.key`) — no model/DB/API changes.

## Visual evidence

_(before/after below)_

## Verification

- `:app:lintDebug` ✅ (under `warningsAsErrors`) and `:app:testDebugUnitTest` ✅
- Verified on the phone emulator against prod data (event `2026cmptx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Event Info tab** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/feat-event-code-info-tab/1462_eventinfo_before-1ea718f6.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/feat-event-code-info-tab/1462_eventinfo_after-7e354199.png" width="300"> |
<!-- screenshots:end -->