### PR TITLE
fix(mytba): render + remove event_team (model_type 3) subscriptions

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/domain/model/ModelType.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/domain/model/ModelType.kt
@@ -4,4 +4,9 @@ object ModelType {
     const val EVENT = 0
     const val TEAM = 1
     const val MATCH = 2
+
+    // myTBA also models these; the old app / website can create them even though the new app
+    // doesn't yet, so they must render + be removable here (#1460).
+    const val EVENT_TEAM = 3 // key is "{eventKey}_{teamKey}", e.g. 2024micmp4_frc2471
+    const val DISTRICT = 4
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAScreen.kt
@@ -337,6 +337,8 @@ private fun FavoritesTab(
                         ModelType.TEAM -> onNavigateToTeam(favorite.modelKey)
                         ModelType.EVENT -> onNavigateToEvent(favorite.modelKey)
                         ModelType.MATCH -> onNavigateToMatch(favorite.modelKey)
+                        ModelType.EVENT_TEAM ->
+                            onNavigateToEvent(favorite.modelKey.substringBefore('_'))
                     }
                 },
                 canPinShortcuts = canPinShortcuts,
@@ -380,6 +382,8 @@ private fun FavoriteItem(
             ModelType.EVENT -> "Event"
             ModelType.TEAM -> "Team"
             ModelType.MATCH -> "Match"
+            ModelType.EVENT_TEAM -> "Team @ Event"
+            ModelType.DISTRICT -> "District"
             else -> "Other"
         }
     var menuExpanded by remember { mutableStateOf(false) }
@@ -473,6 +477,8 @@ private fun NotificationsTab(
                         ModelType.TEAM -> onNavigateToTeam(subscription.modelKey)
                         ModelType.EVENT -> onNavigateToEvent(subscription.modelKey)
                         ModelType.MATCH -> onNavigateToMatch(subscription.modelKey)
+                        ModelType.EVENT_TEAM ->
+                            onNavigateToEvent(subscription.modelKey.substringBefore('_'))
                     }
                 },
                 onRemove = { onRemoveSubscription(subscription) },
@@ -493,6 +499,8 @@ private fun SubscriptionItem(
             ModelType.EVENT -> "Event"
             ModelType.TEAM -> "Team"
             ModelType.MATCH -> "Match"
+            ModelType.EVENT_TEAM -> "Team @ Event"
+            ModelType.DISTRICT -> "District"
             else -> "Other"
         }
     var menuExpanded by remember { mutableStateOf(false) }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/mytba/MyTBAViewModel.kt
@@ -53,13 +53,28 @@ class MyTBAViewModel
             }.distinctUntilChanged().flatMapLatest { keyedTypes ->
                 fun keysOf(type: Int) = keyedTypes.filter { it.second == type }.map { it.first }
                 val matchKeys = keysOf(ModelType.MATCH)
+                // event_team keys are "{eventKey}_{teamKey}" — observe both halves so the row
+                // resolves to a friendly "team @ event" name instead of the raw key (#1460).
+                val eventTeamKeys = keysOf(ModelType.EVENT_TEAM)
+                val teamKeys =
+                    (
+                        keysOf(
+                            ModelType.TEAM,
+                        ) + eventTeamKeys.map { it.substringAfter('_') }
+                    ).distinct()
                 val eventKeys =
-                    (keysOf(ModelType.EVENT) + matchKeys.map { it.substringBefore('_') }).distinct()
+                    (
+                        keysOf(ModelType.EVENT) +
+                            matchKeys.map { it.substringBefore('_') } +
+                            eventTeamKeys.map { it.substringBefore('_') }
+                    ).distinct()
                 combine(
-                    teamRepository.observeTeams(keysOf(ModelType.TEAM)),
+                    teamRepository.observeTeams(teamKeys),
                     eventRepository.observeEvents(eventKeys),
                     matchRepository.observeMatches(matchKeys),
-                ) { teams, events, matches -> buildMyTBADisplayNames(teams, events, matches) }
+                ) { teams, events, matches ->
+                    buildMyTBADisplayNames(teams, events, matches, eventTeamKeys)
+                }
             }
 
         val uiState: StateFlow<MyTBAUiState> =
@@ -178,8 +193,10 @@ internal fun buildMyTBADisplayNames(
     teams: List<Team>,
     events: List<Event>,
     matches: List<Match>,
+    eventTeamKeys: List<String> = emptyList(),
 ): Map<String, String> {
     val eventsByKey = events.associateBy { it.key }
+    val teamsByKey = teams.associateBy { it.key }
     return buildMap {
         teams.forEach { team ->
             val label = team.nickname ?: team.name
@@ -193,6 +210,15 @@ internal fun buildMyTBADisplayNames(
             val event = eventsByKey[match.eventKey] ?: return@forEach
             val label = match.getFullLabel(event.playoffType)
             put(match.key, "$label - ${event.year} ${event.name}")
+        }
+        // event_team ("{eventKey}_{teamKey}") → "2471 @ 2024 <Event>", falling back to the
+        // parsed key parts when the team/event aren't cached locally (#1460).
+        eventTeamKeys.forEach { key ->
+            val eventKey = key.substringBefore('_')
+            val teamKey = key.substringAfter('_')
+            val teamLabel = teamsByKey[teamKey]?.number?.toString() ?: teamKey.removePrefix("frc")
+            val eventLabel = eventsByKey[eventKey]?.let { "${it.year} ${it.name}" } ?: eventKey
+            put(key, "$teamLabel @ $eventLabel")
         }
     }
 }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/settings/SettingsScreen.kt
@@ -151,6 +151,16 @@ fun SettingsScreen(
                 ) {
                     Text("Test: Event update notification")
                 }
+
+                Button(
+                    onClick = { viewModel.seedDebugEventTeamSubscription() },
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                ) {
+                    Text("Test: Seed event_team subscription (myTBA)")
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/settings/SettingsViewModel.kt
@@ -3,6 +3,9 @@ package com.thebluealliance.android.ui.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.thebluealliance.android.config.ThemePreferences
+import com.thebluealliance.android.data.local.dao.SubscriptionDao
+import com.thebluealliance.android.data.local.entity.SubscriptionEntity
+import com.thebluealliance.android.domain.model.ModelType
 import com.thebluealliance.android.ui.theme.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
@@ -16,6 +19,7 @@ class SettingsViewModel
     @Inject
     constructor(
         private val themePreferences: ThemePreferences,
+        private val subscriptionDao: SubscriptionDao,
     ) : ViewModel() {
         val themeMode: StateFlow<ThemeMode> =
             themePreferences.themeModeFlow
@@ -24,6 +28,23 @@ class SettingsViewModel
         fun setThemeMode(mode: ThemeMode) {
             viewModelScope.launch {
                 themePreferences.setThemeMode(mode)
+            }
+        }
+
+        // Debug-only: seed an orphaned event_team (model_type 3) subscription — the kind the new
+        // app can't create — to verify #1460 renders + removes it. Called only from the DEBUG
+        // section of SettingsScreen.
+        fun seedDebugEventTeamSubscription() {
+            viewModelScope.launch {
+                subscriptionDao.insertAll(
+                    listOf(
+                        SubscriptionEntity(
+                            modelKey = "2024micmp4_frc2471",
+                            modelType = ModelType.EVENT_TEAM,
+                            notifications = "upcoming_match,match_score",
+                        ),
+                    ),
+                )
             }
         }
     }

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/mytba/MyTBADisplayNamesTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/mytba/MyTBADisplayNamesTest.kt
@@ -135,4 +135,30 @@ class MyTBADisplayNamesTest {
 
         assertNull(names["2026casj_qm42"])
     }
+
+    @Test
+    fun `event_team with cached team and event maps to "team at event"`() {
+        val names =
+            buildMyTBADisplayNames(
+                teams = listOf(makeTeam(key = "frc254", number = 254)),
+                events = listOf(makeEvent(key = "2026casj")),
+                matches = emptyList(),
+                eventTeamKeys = listOf("2026casj_frc254"),
+            )
+
+        assertEquals("254 @ 2026 Silicon Valley Regional", names["2026casj_frc254"])
+    }
+
+    @Test
+    fun `event_team without cached data falls back to parsed key parts`() {
+        val names =
+            buildMyTBADisplayNames(
+                teams = emptyList(),
+                events = emptyList(),
+                matches = emptyList(),
+                eventTeamKeys = listOf("2026casj_frc254"),
+            )
+
+        assertEquals("254 @ 2026casj", names["2026casj_frc254"])
+    }
 }


### PR DESCRIPTION
## What

Closes #1460. myTBA can hold **event_team** subscriptions (a team @ a specific event), created by the old app / website. The new app couldn't surface them — `ModelType` only knew EVENT/TEAM/MATCH, so they rendered as **"Other"** with the **raw key** (`2024micmp4_frc2471`) and weren't recognizable, leaving users unable to tell what they were to remove them ([Chief Delphi](https://www.chiefdelphi.com/t/the-blue-alliance-2026-site-updates-features/515744/31)).

## Fix

- `ModelType` gains `EVENT_TEAM` (3) and `DISTRICT` (4).
- The myTBA ViewModel resolves the composite `{eventKey}_{teamKey}` key to a friendly **"team @ event"** name (observes both halves; falls back to the parsed key parts when the team/event aren't cached).
- `SubscriptionItem` / `FavoriteItem` give them a real type label ("Team @ Event" / "District") instead of "Other"; tapping an event_team row opens its event.
- Removal is already type-agnostic, so the orphaned subscription is now both **identifiable and removable** (the ⋮ → Remove).

## Visual evidence

Signed in locally via the Firebase Auth emulator (no real Google account — see #1465) and seeded an `event_team` subscription with a **debug-only** harness button. Before → after below.

## Verification

- Unit tests — `MyTBADisplayNamesTest`: event_team resolves to "team @ event", and falls back to parsed key parts when uncached.
- `:app:lintDebug` ✅ (warningsAsErrors) and `:app:testDebugUnitTest` ✅
- On-device (phone emulator, signed in): **before** = raw key + "Other"; **after** = "2471 @ 2024micmp4" / "Team @ Event", removable via ⋮.

## Follow-up

Refresh-on-screen-open (so a long-signed-in user's list isn't stale) is a related secondary fix left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **myTBA → Notifications (orphaned event_team subscription)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/fix-mytba-event-team-subscriptions/1460_mytba_before-6c489951.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/fix-mytba-event-team-subscriptions/1460_mytba_after-140a3755.png" width="300"> |
<!-- screenshots:end -->