### PR TITLE
fix(wear): cap targetSdk at 36 until Wear OS 7 ships

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -60,7 +60,11 @@ android {
     defaultConfig {
         applicationId = "com.thebluealliance.androidclient"
         minSdk = 30
-        targetSdk = 37
+        // Wear OS 7 (API 37) is still in Developer Preview, so the Play Wear
+        // track rejects bundles targeting it ("SDK version used by APK is too
+        // high"). Cap at 36 (Wear OS 6.1 / Android 16) until Wear OS 7 ships.
+        // compileSdk stays at 37 — Play only checks the manifest's targetSdk.
+        targetSdk = 36
         versionCode = computedVersionCode
         versionName = computedVersionName
 


### PR DESCRIPTION
## What

Cap the **wear** module's `targetSdk` at **36** (Wear OS 6.1 / Android 16). `compileSdk` stays at 37; phone and TV are untouched (still targetSdk 37).

## Why

Wear OS 7 (API 37) is still in **Developer Preview**, so the Play Console Wear track rejects any bundle targeting it. This broke the wear leg of the `v11.10.0` alpha release:

```
403 Forbidden
PUT .../bundles
"message": "SDK version used by APK is too high.",
"reason": "forbidden"
```

Phone (`11100000`) and TV (`211100000`), both at targetSdk 37, published to alpha fine — only the wear bundle was rejected. Capping wear at the latest *production* Wear OS API (36) fixes it. Play only validates the manifest's `targetSdkVersion`, so leaving `compileSdk` at 37 means no dependency or source changes.

The v11.10.0 wear bundle (`111100000`) was already published to `wear:alpha` from this same change applied to the working tree; this PR lands it on `main` so the next release doesn't regress.

## Follow-up

Revert to 37 once Wear OS 7 reaches production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)