### PR TITLE
fix(events): sort event sections chronologically

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsUiState.kt
@@ -25,8 +25,21 @@ data class EventsData(
     val districtNames: Map<String, String> = emptyMap(),
 )
 
+/**
+ * Coarse ordering buckets for event sections. Within [DATED], sections sort
+ * chronologically by their earliest event, so a delayed "Week 17" lands after
+ * Championship just like on the website.
+ */
+private enum class SectionRank {
+    ACTIVE_PRESEASON,
+    DATED,
+    FINISHED_PRESEASON,
+    OFFSEASON,
+    OTHER,
+}
+
 private data class SectionKey(
-    val sortOrder: Int,
+    val rank: SectionRank,
     val label: String,
 )
 
@@ -54,22 +67,26 @@ private fun eventSectionKey(
 ): SectionKey {
     return when (event.type) {
         EventType.PRESEASON ->
-            if (preseasonOver) SectionKey(1500, "Preseason") else SectionKey(-1, "Preseason")
+            if (preseasonOver) {
+                SectionKey(SectionRank.FINISHED_PRESEASON, "Preseason")
+            } else {
+                SectionKey(SectionRank.ACTIVE_PRESEASON, "Preseason")
+            }
         EventType.REGIONAL, EventType.DISTRICT, EventType.DISTRICT_CHAMPIONSHIP,
         EventType.DISTRICT_CHAMPIONSHIP_DIVISION,
         -> {
-            val week = event.week ?: return SectionKey(9999, "Other events")
-            SectionKey(week, weekLabel(event.year, week))
+            val week = event.week ?: return SectionKey(SectionRank.OTHER, "Other events")
+            SectionKey(SectionRank.DATED, weekLabel(event.year, week))
         }
         EventType.CHAMPIONSHIP_DIVISION, EventType.CHAMPIONSHIP_FINALS ->
-            SectionKey(1000, "Championship")
-        EventType.OFFSEASON -> SectionKey(2000, "Offseason")
+            SectionKey(SectionRank.DATED, "Championship")
+        EventType.OFFSEASON -> SectionKey(SectionRank.OFFSEASON, "Offseason")
         else -> {
             // Unknown type but has a week — group with regular weeks
             if (event.week != null) {
-                SectionKey(event.week, weekLabel(event.year, event.week))
+                SectionKey(SectionRank.DATED, weekLabel(event.year, event.week))
             } else {
-                SectionKey(9999, "Other events")
+                SectionKey(SectionRank.OTHER, "Other events")
             }
         }
     }
@@ -93,8 +110,14 @@ fun buildEventSections(
     return events
         .groupBy { eventSectionKey(it, preseasonOver) }
         .entries
-        .sortedBy { it.key.sortOrder }
-        .map { (key, sectionEvents) ->
+        .sortedWith(
+            compareBy(
+                { it.key.rank },
+                { entry ->
+                    entry.value.mapNotNull { parseDate(it.startDate) }.minOrNull() ?: LocalDate.MAX
+                },
+            ),
+        ).map { (key, sectionEvents) ->
             val sortedEvents = sectionEvents.sortedWith(eventComparator)
             val subSections = buildSubSections(sortedEvents, districtNames)
             EventSection(key.label, subSections)

--- a/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/ui/events/EventsUiStateTest.kt
@@ -310,6 +310,58 @@ class EventsUiStateTest {
         )
     }
 
+    @Test
+    fun `weeks delayed past championship sort chronologically after it`() {
+        // 2026 Israel events were postponed to weeks 17-19, after FIRST Championship.
+        val today = LocalDate.of(2026, 3, 10)
+        val events =
+            listOf(
+                makeEvent(
+                    key = "2026wk1",
+                    type = EventType.REGIONAL,
+                    week = 0,
+                    startDate = "2026-03-04",
+                    endDate = "2026-03-07",
+                ),
+                makeEvent(
+                    key = "2026isde1",
+                    type = EventType.DISTRICT,
+                    week = 16,
+                    district = "2026isr",
+                    startDate = "2026-06-29",
+                    endDate = "2026-07-01",
+                ),
+                makeEvent(
+                    key = "2026iscmp",
+                    type = EventType.DISTRICT_CHAMPIONSHIP,
+                    week = 18,
+                    district = "2026isr",
+                    startDate = "2026-07-15",
+                    endDate = "2026-07-17",
+                ),
+                makeEvent(
+                    key = "2026cmp",
+                    type = EventType.CHAMPIONSHIP_DIVISION,
+                    startDate = "2026-04-15",
+                    endDate = "2026-04-18",
+                ),
+                makeEvent(
+                    key = "2026off1",
+                    type = EventType.OFFSEASON,
+                    startDate = "2026-06-20",
+                    endDate = "2026-06-21",
+                ),
+            )
+
+        val sections = buildEventSections(events, today)
+
+        // Offseason stays pinned last even though it starts before Week 19.
+        assertEquals(
+            listOf("Week 1", "Championship", "Week 17", "Week 19", "Offseason"),
+            sections.map { it.label },
+        )
+    }
+
     // --- computeThisWeekEvents (used by DistrictDetailScreen) ---
 
     @Test


### PR DESCRIPTION
## Problem

The 2026 Israel district events were postponed to weeks 17–19 — after FIRST Championship. The events list orders week sections by week number and pins Championship at a fixed sort rank, so those delayed weeks render **above** FIRST Championship:

> …Week 6, Week 7, Week 17, Week 18, Week 19, **FIRST Championship**, Preseason, Offseason

The website (jinja `EventHelper.group_by_week`) orders sections chronologically instead, putting Championship between Week 7 and Week 17.

## Fix

Replace the magic-int `sortOrder` on `SectionKey` with a coarse `SectionRank` enum, and sort sections within the dated rank (numbered weeks + Championship) by the earliest event start date in the section. Championship now lands at its chronological position purely from its dates:

> …Week 6, Week 7, **FIRST Championship**, Week 17, Week 18, Week 19, Preseason, Offseason

Pinned buckets keep their existing behavior:
- Preseason: first while active, after the season once it's over
- Offseason: always last, even though June offseason events start before the delayed weeks
- "Other events" (weekless): at the very bottom

Side benefit: sections with duplicate labels but different week numbers (2021's "Awards" catch-all) now merge into one section instead of producing duplicate headers.

## Testing

- New unit test with the delayed Israel-week shape asserts `Week 1, Championship, Week 17, Week 19, Offseason`
- Existing ordering tests (preseason active/finished) pass unchanged
- `:app:testDebugUnitTest` and `:app:lintDebug` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Events list at launch (auto-scrolled to current week)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/fix-wear-targetsdk-36/1470_events_before-bb708164.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/fix-wear-targetsdk-36/1470_events_after-13d293d7.png" width="300"> |

**After: Championship now sits between Week 7 and Week 17**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/fix-wear-targetsdk-36/1470_events_after_boundary-2f98fb81.png" width="320">
<!-- screenshots:end -->