### PR TITLE
feat(wear): apply TBA brand theme + string extraction + debug launcher tint

### DIFF
--- a/wear/src/debug/res/values/colors.xml
+++ b/wear/src/debug/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="launcher_background">#770000</color>
+</resources>

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationConfigActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationConfigActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
@@ -30,7 +31,9 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
 import androidx.wear.watchface.complications.datasource.ComplicationDataSourceUpdateRequester
+import com.thebluealliance.android.wear.R
 import com.thebluealliance.android.wear.tracker.TeamTrackerPreferences
+import com.thebluealliance.android.wear.ui.TbaWearTheme
 import com.thebluealliance.android.wear.worker.TeamTrackingComplicationWorker
 
 class TeamTrackingComplicationConfigActivity : ComponentActivity() {
@@ -54,7 +57,7 @@ class TeamTrackingComplicationConfigActivity : ComponentActivity() {
         val existingTeam = TeamTrackerPreferences(this).teamNumber
 
         setContent {
-            MaterialTheme {
+            TbaWearTheme {
                 AppScaffold {
                     ScreenScaffold {
                         ConfigScreen(
@@ -121,7 +124,12 @@ private fun ConfigScreen(
         verticalArrangement = Arrangement.Center,
     ) {
         Text(
-            text = if (initialTeam.isNotBlank()) "Change Team" else "Team Number",
+            text =
+                if (initialTeam.isNotBlank()) {
+                    stringResource(R.string.change_team)
+                } else {
+                    stringResource(R.string.team_number)
+                },
             style = MaterialTheme.typography.titleSmall,
             modifier = Modifier.padding(bottom = 8.dp),
         )
@@ -164,7 +172,7 @@ private fun ConfigScreen(
         )
         FilledTonalButton(
             onClick = { save() },
-            label = { Text("Save") },
+            label = { Text(stringResource(R.string.save)) },
             modifier =
                 Modifier
                     .fillMaxWidth()

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -54,6 +54,7 @@ import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
 import com.thebluealliance.android.wear.R
 import com.thebluealliance.android.wear.complication.TeamTrackingComplicationConfigActivity
+import com.thebluealliance.android.wear.ui.TbaWearTheme
 import com.thebluealliance.android.wear.worker.TeamTrackingComplicationWorker
 
 class TeamTrackerActivity : ComponentActivity() {
@@ -80,7 +81,7 @@ class TeamTrackerActivity : ComponentActivity() {
         }
 
         setContent {
-            MaterialTheme {
+            TbaWearTheme {
                 AppScaffold {
                     val currentState by state
                     TeamTrackerScreen(

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/ui/TbaWearTheme.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/ui/TbaWearTheme.kt
@@ -1,0 +1,28 @@
+package com.thebluealliance.android.wear.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.material3.ColorScheme
+import androidx.wear.compose.material3.MaterialTheme
+
+/**
+ * TBA brand theme for Wear. Wear renders dark-only, so this is the STYLE_GUIDE.md
+ * dark-scheme mapping; other roles stay at the Wear M3 defaults. Dynamic color
+ * (Material You) is disabled repo-wide — the app always uses TBA brand colors.
+ */
+private val TbaWearColorScheme =
+    ColorScheme(
+        primary = Color(0xFF9FA8DA), // Indigo 200
+        primaryDim = Color(0xFF7986CB), // Indigo 300
+        onPrimary = Color(0xFF00174D),
+        primaryContainer = Color(0xFF303F9F), // Indigo 700
+        onPrimaryContainer = Color(0xFFC5CAE9), // Indigo 100
+    )
+
+@Composable
+fun TbaWearTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = TbaWearColorScheme,
+        content = content,
+    )
+}

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
     <string name="app_name">The Blue Alliance</string>
     <string name="complication_label">Next match</string>
     <string name="change_team">Change team</string>
+    <string name="team_number">Team number</string>
+    <string name="save">Save</string>
     <string name="last_match">Last match</string>
     <string name="next_match">Next match</string>
     <string name="set_tracked_team">Set team</string>


### PR DESCRIPTION
## Summary

- **TBA brand theme on Wear**: adds `TbaWearTheme`, which wraps Wear Compose M3 `MaterialTheme` with the STYLE_GUIDE.md indigo dark-scheme mapping (primary Indigo 200, primaryDim Indigo 300, primaryContainer Indigo 700). Both wear activities (`TeamTrackerActivity`, `TeamTrackingComplicationConfigActivity`) now use it instead of the default `MaterialTheme`. Wear renders dark-only, so only the dark scheme is mapped; other color roles stay at Wear M3 defaults.
- **String extraction**: the complication config screen's hardcoded "Team Number" / "Change Team" / "Save" move to string resources ("Change team" now reuses the existing `change_team` resource, picking up sentence case per the style guide).
- **Debug launcher tint**: debug builds override `launcher_background` to dark red so the debug wear app icon is distinguishable from release on the watch launcher.

## Test plan

- [x] `:wear:assembleDebug`, `:wear:lintDebug`, `:wear:ktlintCheck` pass
- [x] Verified on Wear OS Small Round emulator — screenshots below

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Team tracker (settings button tonal color)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/1479_tracker_before-d1a62af0.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/1479_tracker_after-f0c252a7.png" width="300"> |
| **Complication config (title casing via string resource)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/1479_config_before-41b8d566.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/1479_config_after-e7b12798.png" width="300"> |
| **Debug launcher icon (dark red background)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/1479_launcher_before-4b4d72f5.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/1479_launcher_after-619ae828.png" width="300"> |
<!-- screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)