### PR TITLE
fix(wear): only honor team_number config intent in debug builds

### DIFF
--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationConfigActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/TeamTrackingComplicationConfigActivity.kt
@@ -31,6 +31,7 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
 import androidx.wear.watchface.complications.datasource.ComplicationDataSourceUpdateRequester
+import com.thebluealliance.android.wear.BuildConfig
 import com.thebluealliance.android.wear.R
 import com.thebluealliance.android.wear.tracker.TeamTrackerPreferences
 import com.thebluealliance.android.wear.ui.TbaWearTheme
@@ -47,11 +48,16 @@ class TeamTrackingComplicationConfigActivity : ComponentActivity() {
             -1,
         ) ?: -1
 
-        // Support passing team number directly via intent (for ADB configuration)
-        val intentTeam = intent?.getStringExtra("team_number")
-        if (intentTeam != null) {
-            saveAndFinish(intentTeam)
-            return
+        // Support passing team number directly via intent (debug-only, for ADB configuration).
+        // Never honored in release builds: this activity is exported, so any app could otherwise
+        // silently repoint the tracked team. Normalize to digits so the intent path cannot bypass
+        // the validation the on-screen field applies.
+        if (BuildConfig.DEBUG) {
+            val intentTeam = intent?.getStringExtra("team_number")?.let(::normalizeTeamNumber)
+            if (!intentTeam.isNullOrBlank()) {
+                saveAndFinish(intentTeam)
+                return
+            }
         }
 
         val existingTeam = TeamTrackerPreferences(this).teamNumber
@@ -103,6 +109,9 @@ class TeamTrackingComplicationConfigActivity : ComponentActivity() {
     }
 }
 
+/** Strip everything but digits, matching what the on-screen team-number field accepts. */
+private fun normalizeTeamNumber(raw: String): String = raw.filter { it.isDigit() }
+
 @Composable
 private fun ConfigScreen(
     initialTeam: String,
@@ -111,7 +120,7 @@ private fun ConfigScreen(
     val textFieldState = rememberTextFieldState()
 
     fun save() {
-        val value = textFieldState.text.toString().filter { it.isDigit() }
+        val value = normalizeTeamNumber(textFieldState.text.toString())
         onSave(value.ifBlank { initialTeam })
     }
 


### PR DESCRIPTION
## What

`TeamTrackingComplicationConfigActivity` is `exported=true` (required by the complication `PROVIDER_CONFIG` contract). The `onCreate` path accepted a `team_number` intent extra and persisted it in **all build types**, with **no user confirmation** and **no validation** — so any installed app or an ADB command could silently repoint the tracked team. Because the value bypassed the digit filter the on-screen field applies, a non-numeric string could be stored and interpolated straight into API paths (`frc$team`).

## Fix

- Gate the intent path on `BuildConfig.DEBUG` so it only exists as an ADB/testing affordance; R8 strips the branch from release builds entirely.
- Route both the intent path and the on-screen field through a single `normalizeTeamNumber()` helper, so the intent can't bypass the field's digit validation.
- **Manifest intentionally unchanged.** `exported=true` + `category.DEFAULT` is the platform-mandated shape for a complication config activity (the system picker launches it via an implicit intent, which requires `DEFAULT`). Hardening the *code* to treat the intent as untrusted is the correct layer.

## Evidence

- `:wear:assembleDebug` + `:wear:lintDebug` both green.
- Debug affordance preserved: `am start … -e team_number 254` still sets the team; the tracker renders team 254 (screenshot below).
- Release behavior: the `team_number` branch is compiled out, so a launched activity only shows the config UI, which requires a physical Save tap.

Reviewed for design correctness by a Fable subagent (approach + manifest reasoning verified against the complication data-source platform contract).

<!-- screenshots:start -->
## Screenshots

**Debug intent path preserved — tracker renders team 254 after `am start -e team_number 254`**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/pr1_tracker_after-f009f6aa.png" width="320">
<!-- screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)