### PR TITLE
refactor(wear): remove dead teamNickname data flow + its per-refresh network call

### DIFF
--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/data/WearTbaApi.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/data/WearTbaApi.kt
@@ -3,7 +3,6 @@ package com.thebluealliance.android.wear.data
 import com.thebluealliance.android.data.remote.dto.EventDto
 import com.thebluealliance.android.data.remote.dto.MatchDto
 import com.thebluealliance.android.data.remote.dto.MediaDto
-import com.thebluealliance.android.data.remote.dto.TeamDto
 import retrofit2.http.GET
 import retrofit2.http.Path
 
@@ -24,9 +23,4 @@ interface WearTbaApi {
         @Path("team_key") teamKey: String,
         @Path("year") year: Int,
     ): List<MediaDto>
-
-    @GET("api/v3/team/{team_key}")
-    suspend fun getTeam(
-        @Path("team_key") teamKey: String,
-    ): TeamDto
 }

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -106,7 +106,6 @@ class TeamTrackerActivity : ComponentActivity() {
         state.value =
             TeamTrackerState(
                 teamNumber = trackerPrefs.teamNumber,
-                teamNickname = trackerPrefs.teamNickname,
                 avatarBase64 = trackerPrefs.avatarBase64,
                 eventName = trackerPrefs.eventName,
                 record = trackerPrefs.record,
@@ -142,7 +141,6 @@ class TeamTrackerActivity : ComponentActivity() {
 
 data class TeamTrackerState(
     val teamNumber: String = "",
-    val teamNickname: String = "",
     val avatarBase64: String? = null,
     val eventName: String = "",
     val record: String = "",

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerPreferences.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerPreferences.kt
@@ -23,10 +23,6 @@ class TeamTrackerPreferences(
         get() = prefs.getBoolean(KEY_IS_LOADING, false)
         set(value) = prefs.edit { putBoolean(KEY_IS_LOADING, value) }
 
-    var teamNickname: String
-        get() = prefs.getString(KEY_TEAM_NICKNAME, "") ?: ""
-        set(value) = prefs.edit { putString(KEY_TEAM_NICKNAME, value) }
-
     var avatarBase64: String?
         get() = prefs.getString(KEY_AVATAR_BASE64, null)
         set(value) = prefs.edit { putString(KEY_AVATAR_BASE64, value) }
@@ -135,7 +131,6 @@ class TeamTrackerPreferences(
     companion object {
         private const val KEY_TEAM_NUMBER = "team_number"
         private const val KEY_IS_LOADING = "is_loading"
-        private const val KEY_TEAM_NICKNAME = "team_nickname"
         private const val KEY_AVATAR_BASE64 = "avatar_base64"
         private const val KEY_EVENT_NAME = "event_name"
         private const val KEY_RECORD = "record"

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
@@ -291,15 +291,6 @@ class TeamTrackingComplicationWorker
         ): Boolean {
             val teamKey = "frc$teamNumber"
 
-            // Fetch team nickname — keep existing on failure
-            prefs.teamNickname =
-                try {
-                    api.getTeam(teamKey).nickname ?: prefs.teamNickname
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to fetch team info for $teamKey", e)
-                    prefs.teamNickname
-                }
-
             if (data.avatarBase64 != null) prefs.avatarBase64 = data.avatarBase64
 
             if (data.currentEvent == null) {


### PR DESCRIPTION
## What

`TeamTrackingComplicationWorker.updateAppTracker` made a dedicated `api.getTeam(teamKey)` network call on **every refresh** solely to populate `prefs.teamNickname`. That value was copied into `TeamTrackerState`, but **no composable ever reads it** — `TeamHeader` renders only the team number. So the field, the pref, and the extra network round-trip produced nothing visible (and on a watch, that round-trip is often proxied over Bluetooth — real battery cost).

## Fix (delete, not render)

Removed the whole dead flow:
- Worker: the `prefs.teamNickname = try { api.getTeam(...) … }` block (`teamKey` stays — still used for alliance-membership checks).
- `TeamTrackerActivity`: `teamNickname` from `loadState` and from `TeamTrackerState`.
- `TeamTrackerPreferences`: the `teamNickname` var + `KEY_TEAM_NICKNAME`.
- `WearTbaApi`: the now-unused `getTeam()` method + `TeamDto` import.

**Delete vs render:** the finding flagged these as mutually exclusive. The phone app's `TeamTrackingWidget` *does* render `"$teamNumber — $teamNickname"`, so showing it on the watch is plausible — but that's a deliberate UX feature (subtitle placement/truncation on a round display, and it would compete with the record/event subtitle already there), not something to ship silently under a cleanup. Deleting is the conservative, reversible win; a follow-up feature PR can restore it using the widget as a template if desired.

Orphaned `team_nickname` pref on existing installs is harmless (never read) and self-heals via `clearCachedData()`'s full `clear()` on the next reconfigure.

## Evidence

- `:wear:assembleDebug` + `:wear:lintDebug` green.
- Tracker renders identically (it never showed the nickname) — screenshot below.
- Fable subagent reviewed the delete-vs-render fork and the deletion's completeness (grep-clean, `TeamDto` still used by the phone app, no migration needed); approved delete.

<!-- screenshots:start -->
## Screenshots

**Tracker renders identically — nickname was never displayed**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/pr4_tracker_after-9191e5bc.png" width="320">
<!-- screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)