### PR TITLE
refactor(wear): model alliance as an enum, extract Alliance.of() helper

### DIFF
--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/Alliance.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/Alliance.kt
@@ -1,0 +1,34 @@
+package com.thebluealliance.android.wear.tracker
+
+import com.thebluealliance.android.data.remote.dto.MatchDto
+
+/**
+ * Which alliance a team competes on in a match.
+ *
+ * TBA encodes this as the raw strings "red"/"blue" at the API and SharedPreferences edges;
+ * [key] is that wire/storage form. Everything above those edges works with the enum so the
+ * codebase never compares bare "red"/"blue" literals.
+ */
+enum class Alliance(
+    val key: String,
+) {
+    RED("red"),
+    BLUE("blue"),
+    ;
+
+    companion object {
+        /** Parse a raw TBA/pref value; returns null for blank or anything unrecognized. */
+        fun fromKey(raw: String?): Alliance? = entries.firstOrNull { it.key == raw }
+
+        /** The alliance [teamKey] competes on in [match], or null if it is on neither. */
+        fun of(
+            match: MatchDto,
+            teamKey: String,
+        ): Alliance? =
+            when (teamKey) {
+                in (match.alliances?.red?.teamKeys ?: emptyList()) -> RED
+                in (match.alliances?.blue?.teamKeys ?: emptyList()) -> BLUE
+                else -> null
+            }
+    }
+}

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -116,15 +116,15 @@ class TeamTrackerActivity : ComponentActivity() {
                 lastMatchBlueTeams = trackerPrefs.lastMatchBlueTeams,
                 lastMatchRedScore = trackerPrefs.lastMatchRedScore,
                 lastMatchBlueScore = trackerPrefs.lastMatchBlueScore,
-                lastMatchWinningAlliance = trackerPrefs.lastMatchWinningAlliance,
-                lastAlliance = trackerPrefs.lastAlliance,
+                lastMatchWinningAlliance = Alliance.fromKey(trackerPrefs.lastMatchWinningAlliance),
+                lastAlliance = Alliance.fromKey(trackerPrefs.lastAlliance),
                 lastMatchBonusRp = trackerPrefs.lastMatchBonusRp,
                 nextMatchLabel = trackerPrefs.nextMatchLabel,
                 nextMatchRedTeams = trackerPrefs.nextMatchRedTeams,
                 nextMatchBlueTeams = trackerPrefs.nextMatchBlueTeams,
                 nextMatchTime = trackerPrefs.nextMatchTime,
                 nextMatchTimeIsEstimate = trackerPrefs.nextMatchTimeIsEstimate,
-                nextAlliance = trackerPrefs.nextAlliance,
+                nextAlliance = Alliance.fromKey(trackerPrefs.nextAlliance),
                 upcomingEvents =
                     trackerPrefs.upcomingEvents
                         .split("|")
@@ -151,15 +151,15 @@ data class TeamTrackerState(
     val lastMatchBlueTeams: String = "",
     val lastMatchRedScore: Int = -1,
     val lastMatchBlueScore: Int = -1,
-    val lastMatchWinningAlliance: String = "",
-    val lastAlliance: String = "",
+    val lastMatchWinningAlliance: Alliance? = null,
+    val lastAlliance: Alliance? = null,
     val lastMatchBonusRp: Int = 0,
     val nextMatchLabel: String = "",
     val nextMatchRedTeams: String = "",
     val nextMatchBlueTeams: String = "",
     val nextMatchTime: String = "",
     val nextMatchTimeIsEstimate: Boolean = false,
-    val nextAlliance: String = "",
+    val nextAlliance: Alliance? = null,
     val upcomingEvents: List<String> = emptyList(),
 )
 
@@ -167,6 +167,9 @@ private val AllianceRed = Color(0xFFF2B8B5)
 private val AllianceBlue = Color(0xFF9FA8DA)
 private val AllianceRedBg = Color(0xFFC62828)
 private val AllianceBlueBg = Color(0xFF1565C0)
+
+/** Avatar backdrop when the tracked alliance is unknown — a neutral, not an arbitrary color. */
+private val AllianceNeutralBg = Color(0xFF424242)
 
 @Composable
 private fun TeamTrackerScreen(
@@ -310,10 +313,10 @@ private fun TeamHeader(state: TeamTrackerState) {
     ) {
         if (bitmap != null) {
             val bgColor =
-                when (state.nextAlliance.ifBlank { state.lastAlliance }) {
-                    "red" -> AllianceRedBg
-                    "blue" -> AllianceBlueBg
-                    else -> AllianceBlueBg
+                when (state.nextAlliance ?: state.lastAlliance) {
+                    Alliance.RED -> AllianceRedBg
+                    Alliance.BLUE -> AllianceBlueBg
+                    null -> AllianceNeutralBg
                 }
             Box(
                 modifier =
@@ -391,9 +394,9 @@ private fun MatchSection(
     blueTeams: String,
     redScore: Int? = null,
     blueScore: Int? = null,
-    winningAlliance: String = "",
+    winningAlliance: Alliance? = null,
     trackedTeam: String,
-    trackedAlliance: String = "",
+    trackedAlliance: Alliance? = null,
     bonusRp: Int = 0,
     timeText: String? = null,
 ) {
@@ -417,17 +420,17 @@ private fun MatchSection(
                     color = AllianceRed,
                     teams = redTeams,
                     score = redScore,
-                    isWinner = winningAlliance == "red",
+                    isWinner = winningAlliance == Alliance.RED,
                     trackedTeam = trackedTeam,
-                    bonusRp = if (trackedAlliance == "red") bonusRp else 0,
+                    bonusRp = if (trackedAlliance == Alliance.RED) bonusRp else 0,
                 )
                 AllianceRow(
                     color = AllianceBlue,
                     teams = blueTeams,
                     score = blueScore,
-                    isWinner = winningAlliance == "blue",
+                    isWinner = winningAlliance == Alliance.BLUE,
                     trackedTeam = trackedTeam,
-                    bonusRp = if (trackedAlliance == "blue") bonusRp else 0,
+                    bonusRp = if (trackedAlliance == Alliance.BLUE) bonusRp else 0,
                 )
             }
             if (timeText != null) {

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
@@ -19,6 +19,7 @@ import com.thebluealliance.android.data.remote.dto.MatchDto
 import com.thebluealliance.android.wear.complication.TeamTrackingComplicationPreferences
 import com.thebluealliance.android.wear.complication.TeamTrackingComplicationService
 import com.thebluealliance.android.wear.data.WearTbaApi
+import com.thebluealliance.android.wear.tracker.Alliance
 import com.thebluealliance.android.wear.tracker.TeamTrackerPreferences
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -329,17 +330,10 @@ class TeamTrackingComplicationWorker
             var losses = 0
             var ties = 0
             for (match in qualMatches) {
-                val alliance =
-                    if (teamKey in
-                        (match.alliances?.red?.teamKeys ?: emptyList())
-                    ) {
-                        "red"
-                    } else {
-                        "blue"
-                    }
+                val teamAlliance = Alliance.of(match, teamKey)
                 when {
-                    match.winningAlliance == alliance -> wins++
                     match.winningAlliance.isNullOrBlank() -> ties++
+                    Alliance.fromKey(match.winningAlliance) == teamAlliance -> wins++
                     else -> losses++
                 }
             }
@@ -354,15 +348,8 @@ class TeamTrackingComplicationWorker
                 prefs.lastMatchRedScore = lastMatch.alliances?.red?.score ?: -1
                 prefs.lastMatchBlueScore = lastMatch.alliances?.blue?.score ?: -1
                 prefs.lastMatchWinningAlliance = lastMatch.winningAlliance ?: ""
-                val lastAlliance =
-                    if (teamKey in
-                        (lastMatch.alliances?.red?.teamKeys ?: emptyList())
-                    ) {
-                        "red"
-                    } else {
-                        "blue"
-                    }
-                prefs.lastAlliance = lastAlliance
+                val lastAlliance = Alliance.of(lastMatch, teamKey)
+                prefs.lastAlliance = lastAlliance?.key ?: ""
                 prefs.lastMatchBonusRp = extractBonusRp(lastMatch, lastAlliance)
             } else {
                 clearLastMatch(prefs)
@@ -376,14 +363,7 @@ class TeamTrackingComplicationWorker
                 prefs.nextMatchBlueTeams = teamKeysToNumbers(nextMatch.alliances?.blue?.teamKeys)
                 prefs.nextMatchTimeIsEstimate = nextMatch.predictedTime != null
                 prefs.nextMatchTime = formatMatchTime(nextMatch, includeEstimatePrefix = false)
-                prefs.nextAlliance =
-                    if (teamKey in
-                        (nextMatch.alliances?.red?.teamKeys ?: emptyList())
-                    ) {
-                        "red"
-                    } else {
-                        "blue"
-                    }
+                prefs.nextAlliance = Alliance.of(nextMatch, teamKey)?.key ?: ""
             } else {
                 clearNextMatch(prefs)
             }
@@ -405,13 +385,14 @@ class TeamTrackingComplicationWorker
         /** Extract bonus RPs (total minus win/tie RPs) from score_breakdown. */
         private fun extractBonusRp(
             match: MatchDto,
-            alliance: String,
+            alliance: Alliance?,
         ): Int {
-            val breakdown = match.scoreBreakdown?.get(alliance)?.jsonObject ?: return 0
+            if (alliance == null) return 0
+            val breakdown = match.scoreBreakdown?.get(alliance.key)?.jsonObject ?: return 0
             val totalRp = breakdown["rp"]?.jsonPrimitive?.intOrNull ?: return 0
             val winRp =
                 when {
-                    match.winningAlliance == alliance -> 2
+                    Alliance.fromKey(match.winningAlliance) == alliance -> 2
                     match.winningAlliance.isNullOrBlank() -> 1
                     else -> 0
                 }


### PR DESCRIPTION
## What

The "which alliance is the tracked team on" expression was **copy-pasted 3×** in `TeamTrackingComplicationWorker`, and raw `"red"`/`"blue"` string literals were compared at **~12 sites** across the worker and `TeamTrackerActivity` — contradicting the repo's convention of establishing enums for domain codes and keeping raw codes only at the API/DB edge. The avatar-background `when()` also silently defaulted **any unexpected value to blue**.

## Fix

- New `Alliance` enum (`RED`/`BLUE`) with:
  - `fromKey(raw): Alliance?` — parse a raw TBA/pref value; null for blank/unknown.
  - `of(match, teamKey): Alliance?` — the single extracted helper; null if the team is on neither alliance.
- **Worker** routes all comparisons through the enum; prefs still store the raw `"red"`/`"blue"` string (the persistence edge stays raw). `extractBonusRp` now takes `Alliance?`.
- **State** parses the raw pref once via `fromKey` at the read edge; composables compare `== Alliance.RED/BLUE`.
- **Correctness fix:** an unknown alliance now paints a neutral avatar backdrop instead of blue — so a team **not currently at an event** (a common case: the worker clears match data, leaving alliance unknown) is no longer misrepresented as "on blue".

Behavior is otherwise unchanged: `Alliance.of` is non-null for a team's own matches (`teamMatches` is pre-filtered to matches the team plays), so persisted values and win/loss/tie tallies are identical.

**Follow-ups (out of scope):** hoist `Alliance` to `core-network` to also cover the phone app's ~12 raw red/blue sites; unit-test the enum + record loop (see the wear-tests PR).

## Evidence

- `:wear:assembleDebug` + `:wear:lintDebug` green; all raw `"red"`/`"blue"` literals now confined to `Alliance.kt`.
- Tracker renders correctly (screenshot below). The visual delta (neutral vs blue backdrop) only appears with an avatar present but no current match.
- A Fable subagent produced a full record-loop/persistence/bonus-RP equivalence proof and confirmed the neutral-background change is correct and legible on Wear.

<!-- screenshots:start -->
## Screenshots

**Tracker renders correctly after the enum refactor**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/pr5_tracker_after-02a908fb.png" width="320">
<!-- screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)