### PR TITLE
feat(wear): distinct error state with retry on failed tracker refresh

### DIFF
--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -86,6 +86,7 @@ class TeamTrackerActivity : ComponentActivity() {
                     TeamTrackerScreen(
                         state = currentState,
                         onChangeTeam = { launchConfigActivity() },
+                        onRetry = { retryRefresh() },
                     )
                 }
             }
@@ -111,6 +112,7 @@ class TeamTrackerActivity : ComponentActivity() {
                 record = trackerPrefs.record,
                 hasActiveEvent = trackerPrefs.hasActiveEvent,
                 isLoading = trackerPrefs.isLoading,
+                lastRefreshFailed = trackerPrefs.lastRefreshFailed,
                 lastMatchLabel = trackerPrefs.lastMatchLabel,
                 lastMatchRedTeams = trackerPrefs.lastMatchRedTeams,
                 lastMatchBlueTeams = trackerPrefs.lastMatchBlueTeams,
@@ -137,6 +139,13 @@ class TeamTrackerActivity : ComponentActivity() {
             Intent(this, TeamTrackingComplicationConfigActivity::class.java),
         )
     }
+
+    /** Re-run the fetch after a failed refresh; shows the spinner immediately for feedback. */
+    private fun retryRefresh() {
+        trackerPrefs.lastRefreshFailed = false
+        trackerPrefs.isLoading = true
+        TeamTrackingComplicationWorker.enqueueImmediateRefresh(this)
+    }
 }
 
 data class TeamTrackerState(
@@ -146,6 +155,7 @@ data class TeamTrackerState(
     val record: String = "",
     val hasActiveEvent: Boolean = false,
     val isLoading: Boolean = false,
+    val lastRefreshFailed: Boolean = false,
     val lastMatchLabel: String = "",
     val lastMatchRedTeams: String = "",
     val lastMatchBlueTeams: String = "",
@@ -175,6 +185,7 @@ private val AllianceNeutralBg = Color(0xFF424242)
 private fun TeamTrackerScreen(
     state: TeamTrackerState,
     onChangeTeam: () -> Unit,
+    onRetry: () -> Unit,
 ) {
     if (state.teamNumber.isBlank()) {
         EmptyState(onChangeTeam)
@@ -213,6 +224,11 @@ private fun TeamTrackerScreen(
 
             val hasMatchData =
                 state.lastMatchLabel.isNotBlank() || state.nextMatchLabel.isNotBlank()
+            val hasAnyData =
+                hasMatchData || state.hasActiveEvent || state.upcomingEvents.isNotEmpty()
+            // A failed refresh only surfaces an error when there's nothing cached to fall back on;
+            // otherwise the (stale) data keeps showing.
+            val showError = state.lastRefreshFailed && !hasAnyData
             val sparseContent = !hasMatchData && state.upcomingEvents.size <= 1
             if (!state.isLoading && sparseContent) {
                 item { Spacer(modifier = Modifier.height(4.dp)) }
@@ -227,6 +243,8 @@ private fun TeamTrackerScreen(
                         CircularProgressIndicator()
                     }
                 }
+            } else if (showError) {
+                item { ErrorState(onRetry) }
             } else {
                 item { EventSubtitle(state) }
             }
@@ -337,6 +355,26 @@ private fun TeamHeader(state: TeamTrackerState) {
         Text(
             text = state.teamNumber,
             style = MaterialTheme.typography.titleLarge,
+        )
+    }
+}
+
+@Composable
+private fun ErrorState(onRetry: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(vertical = 2.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.refresh_failed),
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        FilledTonalButton(
+            onClick = onRetry,
+            label = { Text(stringResource(R.string.retry)) },
+            modifier = Modifier.padding(top = 6.dp),
         )
     }
 }

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerPreferences.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerPreferences.kt
@@ -23,6 +23,10 @@ class TeamTrackerPreferences(
         get() = prefs.getBoolean(KEY_IS_LOADING, false)
         set(value) = prefs.edit { putBoolean(KEY_IS_LOADING, value) }
 
+    /** True when the most recent refresh threw before completing (network/API failure). */
+    var lastRefreshFailed: Boolean
+        get() = prefs.getBoolean(KEY_LAST_REFRESH_FAILED, false)
+        set(value) = prefs.edit { putBoolean(KEY_LAST_REFRESH_FAILED, value) }
     var avatarBase64: String?
         get() = prefs.getString(KEY_AVATAR_BASE64, null)
         set(value) = prefs.edit { putString(KEY_AVATAR_BASE64, value) }
@@ -131,6 +135,7 @@ class TeamTrackerPreferences(
     companion object {
         private const val KEY_TEAM_NUMBER = "team_number"
         private const val KEY_IS_LOADING = "is_loading"
+        private const val KEY_LAST_REFRESH_FAILED = "last_refresh_failed"
         private const val KEY_AVATAR_BASE64 = "avatar_base64"
         private const val KEY_EVENT_NAME = "event_name"
         private const val KEY_RECORD = "record"

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
@@ -162,9 +162,11 @@ class TeamTrackingComplicationWorker
                 // Request complication data update from the watch face
                 requestComplicationUpdate()
 
+                trackerPrefs.lastRefreshFailed = false
                 Result.success()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to update complications", e)
+                trackerPrefs.lastRefreshFailed = true
                 Result.retry()
             } finally {
                 trackerPrefs.isLoading = false

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="next_match">Next match</string>
     <string name="set_tracked_team">Set team</string>
     <string name="no_upcoming_events">No upcoming events</string>
+    <string name="refresh_failed">Couldn\'t refresh</string>
+    <string name="retry">Retry</string>
 </resources>


### PR DESCRIPTION
## What

`TeamTrackerState` tracked `isLoading` but had **no error field**, and `doWork` cleared `isLoading` in its `finally` even when it returned `Result.retry()` after an exception. So a newly-set team whose first fetch **failed** showed only the header + "No upcoming events" — indistinguishable from a team that genuinely has no events, and with no way to retry.

## Fix

- New `lastRefreshFailed` pref; the worker sets it `false` right before `Result.success()` and `true` in `doWork`'s `catch` (the fetch — `fetchTeamEventData` — is deliberately outside the inner try/catch blocks, so its failure reaches the outer catch).
- `TeamTrackerState.lastRefreshFailed` drives a distinct **"Couldn't refresh" + Retry** state, shown only when a refresh failed **and** there's no cached data to fall back on. Cached (stale) data still takes precedence over the error.
- `retryRefresh()` clears the flag, shows the spinner, and re-enqueues an immediate refresh. `clearCachedData()`'s full `clear()` resets the flag on team change so a new team never inherits a stale error.

## Evidence

Before/after below, captured on the Wear emulator. (The debug build's placeholder API key makes the team-254 fetch fail with 401 — a real instance of the exact bug: the old UI reports "No upcoming events" for what is actually a failed fetch.)

- `:wear:assembleDebug` + `:wear:lintDebug` green.
- A Fable subagent verified the flag is set for the right failure (fetch throw → outer catch), the `showError` gating never hides cached data, `clearCachedData` resets it on team change, and the mid-list Retry button doesn't compete with the bottom Change-Team EdgeButton. Noted follow-up (out of scope): an offline retry leaves the spinner up until the network-constrained worker can run — consistent with the screen's existing team-change loading model.

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Failed first fetch (team 254, 401)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/pr6_tracker_before-165f8efc.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/pr6_tracker_after-83d8e28a.png" width="300"> |
<!-- screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)