### PR TITLE
fix(wear): bound avatar decoding, catch Throwable, cache the alpha mask

### DIFF
--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/AvatarConverter.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/complication/AvatarConverter.kt
@@ -5,8 +5,10 @@ import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.graphics.drawable.Icon
 import android.util.Base64
+import android.util.Log
 import androidx.core.graphics.createBitmap
 import androidx.wear.watchface.complications.data.MonochromaticImage
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Converts a color avatar bitmap (base64-encoded PNG) into an alpha mask
@@ -18,19 +20,65 @@ import androidx.wear.watchface.complications.data.MonochromaticImage
  * RGB is set to white so the tint color applies uniformly.
  */
 object AvatarConverter {
+    private const val TAG = "AvatarConverter"
+
+    /** FRC avatars are 40x40; cap the decode so a malformed/huge PNG can't blow up memory. */
+    private const val MAX_AVATAR_PX = 96
+
+    /**
+     * Single-entry memo of the last conversion. Only one team is tracked at a time, so the same
+     * avatar is requested on every complication render; caching avoids re-running the decode +
+     * two-pass luminance scan each time. Keyed by the source base64 so it self-invalidates when
+     * the avatar changes. A failed decode caches null (skips re-attempting a corrupt image); the
+     * complication process is short-lived, so a transient failure recovers on the next rebind.
+     */
+    private val cached = AtomicReference<Pair<String, MonochromaticImage?>?>(null)
+
     fun toMonochromaticImage(base64: String): MonochromaticImage? {
-        val bitmap = decodeBase64(base64) ?: return null
-        val mask = toAlphaMask(bitmap)
-        return MonochromaticImage.Builder(Icon.createWithBitmap(mask)).build()
+        cached.get()?.let { (key, image) -> if (key == base64) return image }
+        val image =
+            decodeBoundedBitmap(base64)?.let { bitmap ->
+                MonochromaticImage.Builder(Icon.createWithBitmap(toAlphaMask(bitmap))).build()
+            }
+        cached.set(base64 to image)
+        return image
     }
 
-    private fun decodeBase64(base64: String): Bitmap? =
+    /**
+     * Decode a base64 PNG, downsampling an oversized image toward [MAX_AVATAR_PX] (via a
+     * power-of-two [BitmapFactory.Options.inSampleSize]) so it never allocates at full resolution.
+     * Catches [Throwable] (not just [Exception]) so an OutOfMemoryError from a hostile/oversized
+     * image returns null instead of crashing the complication service or tracker.
+     */
+    fun decodeBoundedBitmap(base64: String): Bitmap? =
         try {
             val bytes = Base64.decode(base64, Base64.DEFAULT)
-            BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-        } catch (e: Exception) {
+            val bounds =
+                BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+            val options =
+                BitmapFactory.Options().apply {
+                    inSampleSize = calculateInSampleSize(bounds.outWidth, bounds.outHeight)
+                }
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)
+        } catch (e: Throwable) {
+            Log.w(TAG, "Failed to decode avatar", e)
             null
         }
+
+    /** Largest power-of-two sample size that keeps both dimensions >= [MAX_AVATAR_PX]. */
+    private fun calculateInSampleSize(
+        width: Int,
+        height: Int,
+    ): Int {
+        var sampleSize = 1
+        while (width / (sampleSize * 2) >= MAX_AVATAR_PX &&
+            height / (sampleSize * 2) >= MAX_AVATAR_PX
+        ) {
+            sampleSize *= 2
+        }
+        return sampleSize
+    }
 
     /**
      * Convert a color bitmap to a white-on-transparent alpha mask.

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -2,9 +2,7 @@ package com.thebluealliance.android.wear.tracker
 
 import android.content.Intent
 import android.content.SharedPreferences
-import android.graphics.BitmapFactory
 import android.os.Bundle
-import android.util.Base64
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
@@ -53,6 +51,7 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
 import com.thebluealliance.android.wear.R
+import com.thebluealliance.android.wear.complication.AvatarConverter
 import com.thebluealliance.android.wear.complication.TeamTrackingComplicationConfigActivity
 import com.thebluealliance.android.wear.worker.TeamTrackingComplicationWorker
 
@@ -304,14 +303,7 @@ private fun EmptyState(onChangeTeam: () -> Unit) {
 private fun TeamHeader(state: TeamTrackerState) {
     val bitmap =
         remember(state.avatarBase64) {
-            state.avatarBase64?.let { base64 ->
-                try {
-                    val bytes = Base64.decode(base64, Base64.DEFAULT)
-                    BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-                } catch (_: Exception) {
-                    null
-                }
-            }
+            state.avatarBase64?.let { AvatarConverter.decodeBoundedBitmap(it) }
         }
 
     Row(


### PR DESCRIPTION
## What

Two problems on the avatar path:

1. **Unbounded decode + `catch(Exception)`.** Both decode sites — `AvatarConverter` (complication) and the tracker's `TeamHeader` — called `BitmapFactory.decodeByteArray(bytes, 0, size)` with no size bounds and caught only `Exception`. An `OutOfMemoryError` (a subclass of `Error`) from a malformed/oversized PNG escapes and can **crash the complication service or the activity**.
2. **Per-request pixel scan.** `AvatarConverter.toAlphaMask` ran a full decode + two-pass per-pixel luminance scan on **every** `onComplicationRequest`, re-deriving the identical mask and allocating two `IntArray`s + a `Bitmap` each render.

## Fix

- New `decodeBoundedBitmap()`: decodes bounds first (`inJustDecodeBounds`), downsamples an oversized image toward `MAX_AVATAR_PX` (96) via a power-of-two `inSampleSize`, and catches `Throwable` (returns null, logs). Both decode sites now use it — the tracker's inline unbounded decode is gone.
- `toMonochromaticImage` memoizes a **single entry keyed by the source base64**, so the decode + luminance scan runs once per distinct avatar instead of once per request. (Only one team is tracked, so all complication instances converge on one key.)

A normal 40×40 FRC avatar decodes at `inSampleSize = 1` → byte-identical output; only oversized images are downsampled.

## Evidence

- `:wear:assembleDebug` + `:wear:lintDebug` green; tracker renders with no regression (screenshot below).
- A Fable subagent verified: `calculateInSampleSize` returns 1 for 40×40 (no visual change), bounds a 4000×4000 to ~125px, and degrades safely on a failed bounds decode (`-1` dims → sampleSize 1 → null); catching `Throwable` in this non-suspend decode is safe (no `CancellationException` concern); the `AtomicReference` memo has only benign races and never returns a wrong-key image; and `toAlphaMask` output is byte-for-byte unchanged.

_Screenshot: team 254's avatar, fetched from prod and decoded through the new bounded/`Throwable`-guarded path, rendering in the tracker header._

<!-- screenshots:start -->
## Screenshots

**Real avatar (team 254) decoded via the hardened decodeBoundedBitmap and rendered in TeamHeader**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/pr8_tracker_avatar-6950d0d8.png" width="320">
<!-- screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
