### PR TITLE
refactor(wear): drop unused teamNumber param from updateComplication

### DIFF
--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/worker/TeamTrackingComplicationWorker.kt
@@ -133,7 +133,7 @@ class TeamTrackingComplicationWorker
                                     applicationContext,
                                     complicationId,
                                 )
-                            val hasActive = updateComplication(prefs, trackerTeam, data)
+                            val hasActive = updateComplication(prefs, data)
                             if (hasActive) anyActiveEvent = true
                         } catch (e: Exception) {
                             Log.e(TAG, "Failed to update complication $complicationId", e)
@@ -242,7 +242,6 @@ class TeamTrackingComplicationWorker
         /** Returns true if the team has an active event. */
         private fun updateComplication(
             prefs: TeamTrackingComplicationPreferences,
-            teamNumber: String,
             data: TeamEventData,
         ): Boolean {
             if (data.currentEvent == null) {


### PR DESCRIPTION
## What

`TeamTrackingComplicationWorker.updateComplication` declared a `teamNumber: String` parameter that its body never referenced — it reads only `prefs` and the already-team-scoped `TeamEventData`. Team identity is baked into the fetched data upstream (`doWork` builds `teamKey = "frc$trackerTeam"` before fetching), so the parameter was residual plumbing, likely left over from before the `TeamEventData` extraction.

Removed the parameter and the `trackerTeam` argument at the single call site. No behavior change.

## Evidence

- `:wear:assembleDebug` + `:wear:lintDebug` green; tracker renders unchanged (screenshot below).
- A Fable subagent confirmed the parameter was genuinely unused, the single call site maps correctly by position, and no information is lost (the sibling `updateAppTracker` correctly keeps its own `teamNumber`, which it does use).

<!-- screenshots:start -->
## Screenshots

**Tracker renders unchanged after dropping the unused parameter**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/pr11_tracker_after-339b63bb.png" width="320">
<!-- screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)