### PR TITLE
style(wear): make the brand theme drive components + unify the palette

### DIFF
--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/tracker/TeamTrackerActivity.kt
@@ -53,6 +53,7 @@ import androidx.wear.compose.material3.Text
 import com.thebluealliance.android.wear.R
 import com.thebluealliance.android.wear.complication.AvatarConverter
 import com.thebluealliance.android.wear.complication.TeamTrackingComplicationConfigActivity
+import com.thebluealliance.android.wear.ui.TbaColors
 import com.thebluealliance.android.wear.ui.TbaWearTheme
 import com.thebluealliance.android.wear.worker.TeamTrackingComplicationWorker
 
@@ -172,14 +173,6 @@ data class TeamTrackerState(
     val nextAlliance: Alliance? = null,
     val upcomingEvents: List<String> = emptyList(),
 )
-
-private val AllianceRed = Color(0xFFF2B8B5)
-private val AllianceBlue = Color(0xFF9FA8DA)
-private val AllianceRedBg = Color(0xFFC62828)
-private val AllianceBlueBg = Color(0xFF1565C0)
-
-/** Avatar backdrop when the tracked alliance is unknown — a neutral, not an arbitrary color. */
-private val AllianceNeutralBg = Color(0xFF424242)
 
 @Composable
 private fun TeamTrackerScreen(
@@ -332,9 +325,9 @@ private fun TeamHeader(state: TeamTrackerState) {
         if (bitmap != null) {
             val bgColor =
                 when (state.nextAlliance ?: state.lastAlliance) {
-                    Alliance.RED -> AllianceRedBg
-                    Alliance.BLUE -> AllianceBlueBg
-                    null -> AllianceNeutralBg
+                    Alliance.RED -> TbaColors.AllianceRedBg
+                    Alliance.BLUE -> TbaColors.AllianceBlueBg
+                    null -> TbaColors.AllianceNeutralBg
                 }
             Box(
                 modifier =
@@ -455,7 +448,7 @@ private fun MatchSection(
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 AllianceRow(
-                    color = AllianceRed,
+                    color = TbaColors.AllianceRed,
                     teams = redTeams,
                     score = redScore,
                     isWinner = winningAlliance == Alliance.RED,
@@ -463,7 +456,7 @@ private fun MatchSection(
                     bonusRp = if (trackedAlliance == Alliance.RED) bonusRp else 0,
                 )
                 AllianceRow(
-                    color = AllianceBlue,
+                    color = TbaColors.AllianceBlue,
                     teams = blueTeams,
                     score = blueScore,
                     isWinner = winningAlliance == Alliance.BLUE,

--- a/wear/src/main/kotlin/com/thebluealliance/android/wear/ui/TbaWearTheme.kt
+++ b/wear/src/main/kotlin/com/thebluealliance/android/wear/ui/TbaWearTheme.kt
@@ -6,9 +6,26 @@ import androidx.wear.compose.material3.ColorScheme
 import androidx.wear.compose.material3.MaterialTheme
 
 /**
- * TBA brand theme for Wear. Wear renders dark-only, so this is the STYLE_GUIDE.md
- * dark-scheme mapping; other roles stay at the Wear M3 defaults. Dynamic color
- * (Material You) is disabled repo-wide — the app always uses TBA brand colors.
+ * TBA brand + alliance colors — a single source shared by the theme and the tracker UI, so the
+ * palette isn't duplicated across files.
+ */
+object TbaColors {
+    // Alliance accents used in match sections (light fill / strong avatar backdrop).
+    val AllianceRed = Color(0xFFF2B8B5)
+    val AllianceBlue = Color(0xFF9FA8DA) // same indigo as the brand primary
+    val AllianceRedBg = Color(0xFFC62828) // Red 800
+    val AllianceBlueBg = Color(0xFF1565C0) // Blue 800
+
+    /** Avatar backdrop when the tracked alliance is unknown — a neutral, not an arbitrary color. */
+    val AllianceNeutralBg = Color(0xFF424242)
+}
+
+/**
+ * TBA brand theme for Wear. Wear renders dark-only, so this is the STYLE_GUIDE.md dark-scheme
+ * mapping. Beyond the primary (indigo) family — which fills the EdgeButton — the secondary/tertiary
+ * accents and the surface-container family are brand-tinted so the components that draw from
+ * surface roles (FilledTonalButton and the config text field) carry the TBA indigo instead of a
+ * neutral grey. Dynamic color (Material You) is disabled repo-wide.
  */
 private val TbaWearColorScheme =
     ColorScheme(
@@ -17,6 +34,21 @@ private val TbaWearColorScheme =
         onPrimary = Color(0xFF00174D),
         primaryContainer = Color(0xFF303F9F), // Indigo 700
         onPrimaryContainer = Color(0xFFC5CAE9), // Indigo 100
+        // Secondary: muted indigo accent for tonal surfaces.
+        secondary = Color(0xFFB4B9E0),
+        secondaryDim = Color(0xFF8C93C4),
+        secondaryContainer = Color(0xFF283593), // Indigo 800
+        onSecondaryContainer = Color(0xFFC5CAE9), // Indigo 100
+        // Tertiary: TBA blue, complementary to the indigo primary.
+        tertiary = Color(0xFF90CAF9), // Blue 200
+        tertiaryDim = Color(0xFF64B5F6), // Blue 300
+        onTertiary = Color(0xFF002E5C),
+        tertiaryContainer = Color(0xFF1565C0), // Blue 800
+        onTertiaryContainer = Color(0xFFE3EEFF),
+        // Brand-tinted dark surfaces so buttons/fields read as indigo, not grey.
+        surfaceContainerLow = Color(0xFF15161F),
+        surfaceContainer = Color(0xFF232538),
+        surfaceContainerHigh = Color(0xFF2E3149),
     )
 
 @Composable


### PR DESCRIPTION
## What

The TBA brand theme was **barely visible**: `TbaWearColorScheme` overrode only the primary (indigo) family, but the visible components draw from **surface roles** — so the indigo only tinted the spinner, cursor, and empty-state lamp. The alliance colors (`AllianceRed/Blue/RedBg/BlueBg`) were also file-private vals in `TeamTrackerActivity`, fragmenting the palette across two files.

## Fix

- **Unify the palette:** move the alliance colors into a shared `TbaColors` object in the `ui` package; `TeamTrackerActivity` references it (its file-private vals are gone).
- **Drive components from the theme:** extend `TbaWearColorScheme` with secondary/tertiary accents and a brand-tinted **surface-container family** (`0xFF15161F`/`0xFF232538`/`0xFF2E3149`), so the config text field and `FilledTonalButton`s carry the TBA indigo instead of neutral grey. (The `EdgeButton` is already primary-filled — indigo.)

## Evidence

**Config screen — the field + Save button go from neutral grey to indigo-tinted** (before → after). **Tracker** — the avatar sits on the alliance-blue backdrop from `TbaColors` and the EdgeButton is indigo (real data, team 254):

- `:wear:assembleDebug` + `:wear:lintDebug` green; no `Color(0x…)` literals remain in the wear module outside `TbaWearTheme.kt`.
- A Fable subagent reviewed the color choices: computed WCAG contrast for every new pairing (all pass; text on the new surface is 13:1), confirmed the `ColorScheme` roles are valid and unset `on*` defaults don't clash, verified the single-source move is complete, and judged the surface tint tasteful/perceptible (a quiet indigo shift, not garish) — matching the finding's intent. Its notes (KDoc EdgeButton wording, a sub-AA `onTertiaryContainer`, future-proofing `tertiaryDim`/`onTertiary`) were applied.

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Config screen (field + Save button)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/pr9_config_before-5dc46966.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/pr9_config_after-ae07517e.png" width="300"> |

**Tracker: avatar on the alliance-blue backdrop from TbaColors; indigo EdgeButton (team 254)**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/wear-tba-brand-theme/pr9_tracker_avatar-0754e829.png" width="320">
<!-- screenshots:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
