### PR TITLE
fix(scripts): surface adb errors in `emu logcat`

### DIFF
--- a/scripts/emu
+++ b/scripts/emu
@@ -159,13 +159,12 @@ def cmd_tap_xy(args):
 
 
 def cmd_logcat(args):
-    cmd = ["adb"]
-    if _serial:
-        cmd += ["-s", _serial]
-    cmd += ["logcat", "-d"]
+    # adb_check appends these after any `-s <serial>`, so logcat's own `-s <tag>`
+    # filter doesn't collide with the device selector.
+    logcat_args = ["logcat", "-d"]
     if args.tag:
-        cmd += ["-s", args.tag]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+        logcat_args += ["-s", args.tag]
+    result = adb_check(*logcat_args)
     lines = result.stdout.splitlines()
     if args.grep:
         pattern = args.grep.lower()


### PR DESCRIPTION
## The bug

`cmd_logcat` in `scripts/emu` ran adb through a hand-rolled `subprocess.run(...)` and used only `result.stdout` — it never checked `result.returncode` and never forwarded `result.stderr`.

So whenever adb itself failed (multiple devices attached without a serial, no device connected, an adb server hiccup), `emu logcat` printed **nothing at all and exited 0**. That's indistinguishable from "no matching log lines", and it has already misled automation — an agent concluded `--grep` was broken when in fact adb was erroring out before any log line was ever read.

## The fix

Route the call through the script's existing `adb_check` helper, which already prints adb's stderr and exits non-zero — the same error style as every other subcommand. `adb_check` appends its positional args *after* any `-s <serial>`, so logcat's own `-s <tag>` filter still composes correctly (`adb -s <serial> logcat -d -s <tag>`), which is why the hand-rolled command is no longer needed at all.

## Before / after

Failure path, reproduced with two emulators attached and no `$ANDROID_SERIAL`:

**Before** — silent, and a success exit code:
```
$ scripts/emu logcat -n 5

exit=0
```

**After** — adb's real error on stderr, non-zero exit:
```
$ scripts/emu logcat -n 5
adb error: - waiting for device -
error: more than one device/emulator
exit=1
```

## Verification

Success paths re-checked against a live emulator (`ANDROID_SERIAL=emulator-5554`), all still working and exiting 0:

- `scripts/emu logcat -n 5`
- `scripts/emu logcat --grep ActivityManager -n 3`
- `scripts/emu logcat --tag Finsky -n 3`
- `scripts/emu logcat --tag Finsky --grep cache -n 3` (confirms `-s <tag>` and the device selector still coexist)

Scope is limited to `cmd_logcat`; tap/swipe/coordinate logic is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)