### PR TITLE
fix: year picker hover target shape and padding

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/TopBarYearPicker.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/TopBarYearPicker.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -20,7 +22,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+
+private val HORIZONTAL_TARGET_PADDING = 12.dp
 
 @Composable
 fun TopBarYearPicker(
@@ -37,9 +42,16 @@ fun TopBarYearPicker(
     var yearDropdownExpanded by remember { mutableStateOf(false) }
     val contentColor = LocalContentColor.current.copy(alpha = 0.85f)
 
-    Box {
+    // The padding below grows the touch/hover target around the text; the matching negative
+    // offset cancels its horizontal contribution so the title keeps the same left edge as
+    // plain-Text top bar titles on other screens.
+    Box(modifier = Modifier.offset(x = -HORIZONTAL_TARGET_PADDING)) {
         Column(
-            modifier = Modifier.clickable { yearDropdownExpanded = true },
+            modifier =
+                Modifier
+                    .clip(MaterialTheme.shapes.small)
+                    .clickable { yearDropdownExpanded = true }
+                    .padding(horizontal = HORIZONTAL_TARGET_PADDING, vertical = 4.dp),
         ) {
             title()
             Row(


### PR DESCRIPTION
## Problem

`TopBarYearPicker`'s `Column` was `Modifier.clickable { … }` with no clip, no shape, and no padding. On hover (and on press) the indication draws as a hard-cornered grey rectangle at exactly the wrap-content text bounds — so it crops the descenders of both the title ("Events") and the year row ("2026 ▾"), and reads as a raw rectangle right next to the clean rounded 48dp `IconButton` in the same top bar.

## Fix

```kotlin
Modifier
    .clip(MaterialTheme.shapes.small)
    .clickable { yearDropdownExpanded = true }
    .padding(horizontal = 12.dp, vertical = 4.dp)
```

- `clip` **before** `clickable` so the ripple/hover indication is shaped (8dp rounded, matching M3 `shapes.small`).
- `padding` **after** `clickable` so the target grows around the text instead of shrinking the content — descenders no longer get cropped.

### Keeping the title where it was

The horizontal padding would otherwise push the title 12dp right, breaking the shared left edge that `TBATopAppBar` deliberately maintains across screens (see the comment on its lamp `IconButton`). A matching `Modifier.offset(x = -12.dp)` on the wrapping `Box` cancels the layout contribution, so the text renders exactly where it did before and the enlarged hover target simply extends into the existing gutter. Vertical padding needs no compensation — the top app bar centers the title vertically.

Diff is confined to `TopBarYearPicker.kt`; no call site changes were needed. All five call sites (`EventsScreen`, `DistrictsScreen`, `DistrictDetailScreen`, `TeamDetailScreen`, `RegionalAdvancementScreen`) place it in the `TBATopAppBar` title slot and are unaffected.

## Verification

- `:app:assembleDebug` — green
- `:app:testDebugUnitTest` — green
- `ktlintCheck` — green
- `:app:lintDebug` — fails on a **pre-existing, unrelated** issue: `AndroidGradlePluginVersion` on `gradle/libs.versions.toml:2` (AGP 9.4.0 is now out; `warningsAsErrors` promotes it). Reproduced identically on unmodified `origin/main`. No lint issues attributable to this diff.

Before/after hover screenshots are intentionally not included here — they're coming in a later consolidated screenshot pass, so no emulator was booted for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Top-bar year picker hover** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/main/1521_yearpicker_before-4d27b166.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/main/1521_yearpicker_after-fad61050.png" width="300"> |
<!-- screenshots:end -->