### PR TITLE
fix: week filter chip hover state

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/EventsScreen.kt
@@ -29,10 +29,12 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -343,6 +345,13 @@ private fun WeekFilterChips(
         }
     }
 
+    // Flat chips drawn straight onto the blue app bar. Their transparent container has two
+    // consequences the call sites below opt out of:
+    //  - a shadow shows through it, so the chips pass `elevation = null` — M3's default 1.dp
+    //    hover elevation otherwise renders as a dark blotch across the chip;
+    //  - `contentColorFor(Color.Transparent)` is unspecified, so the hover/press state layers
+    //    inherit the ambient content color (near-black onSurface) and darken the chip. The
+    //    white LocalContentColor below makes them lighten it, as TBATabRow's tabs do.
     val weekChipColors =
         FilterChipDefaults.filterChipColors(
             containerColor = Color.Transparent,
@@ -358,94 +367,98 @@ private fun WeekFilterChips(
             selectedBorderColor = Color.Transparent,
         )
 
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .background(TBABlue)
-                .layout { measurable, constraints ->
-                    val placeable = measurable.measure(constraints)
-                    val overlapPx = 4.dp.roundToPx()
-                    layout(placeable.width, (placeable.height - overlapPx).coerceAtLeast(0)) {
-                        placeable.placeRelative(0, -overlapPx)
-                    }
-                },
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (hasFavorites) {
-            FilterChip(
-                selected = isFavoritesSelected,
-                onClick = onFavoritesSelected,
-                label = {
-                    Icon(
-                        Icons.Filled.Star,
-                        contentDescription = "Favorites",
-                        modifier = Modifier.size(18.dp),
-                    )
-                },
-                modifier = Modifier.padding(start = 12.dp, bottom = 4.dp),
-                colors = weekChipColors,
-                border = weekChipBorder,
-            )
-            // Vertical divider between pinned star and scrollable chips
-            Box(
-                modifier =
-                    Modifier
-                        .padding(start = 8.dp, bottom = 4.dp)
-                        .height(24.dp)
-                        .width(1.dp)
-                        .background(Color.White.copy(alpha = 0.3f)),
-            )
-        }
-        val fadeWidth = 24.dp
-        LazyRow(
-            state = chipRowState,
+    CompositionLocalProvider(LocalContentColor provides Color.White) {
+        Row(
             modifier =
                 Modifier
-                    .weight(1f)
-                    .then(
-                        if (hasFavorites) {
-                            Modifier.drawWithContent {
-                                drawContent()
-                                if (chipRowState.canScrollBackward) {
-                                    val solidZone = 4.dp.toPx()
-                                    val totalWidth = fadeWidth.toPx()
-                                    drawRect(
-                                        brush =
-                                            Brush.horizontalGradient(
-                                                colorStops =
-                                                    arrayOf(
-                                                        0f to TBABlue,
-                                                        solidZone / totalWidth to TBABlue,
-                                                        1f to Color.Transparent,
-                                                    ),
-                                                endX = totalWidth,
-                                            ),
-                                        size = size.copy(width = totalWidth),
-                                    )
-                                }
-                            }
-                        } else {
-                            Modifier
-                        },
-                    ),
-            contentPadding =
-                PaddingValues(
-                    start = 8.dp,
-                    end = 12.dp,
-                    bottom = 4.dp,
-                ),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    .fillMaxWidth()
+                    .background(TBABlue)
+                    .layout { measurable, constraints ->
+                        val placeable = measurable.measure(constraints)
+                        val overlapPx = 4.dp.roundToPx()
+                        layout(placeable.width, (placeable.height - overlapPx).coerceAtLeast(0)) {
+                            placeable.placeRelative(0, -overlapPx)
+                        }
+                    },
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            items(weekLabels.size) { index ->
-                val label = weekLabels[index]
+            if (hasFavorites) {
                 FilterChip(
-                    selected = selectedLabel == label && !isFavoritesSelected,
-                    onClick = { onWeekSelected(label) },
-                    label = { Text(label) },
+                    selected = isFavoritesSelected,
+                    onClick = onFavoritesSelected,
+                    label = {
+                        Icon(
+                            Icons.Filled.Star,
+                            contentDescription = "Favorites",
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                    modifier = Modifier.padding(start = 12.dp, bottom = 4.dp),
                     colors = weekChipColors,
+                    elevation = null,
                     border = weekChipBorder,
                 )
+                // Vertical divider between pinned star and scrollable chips
+                Box(
+                    modifier =
+                        Modifier
+                            .padding(start = 8.dp, bottom = 4.dp)
+                            .height(24.dp)
+                            .width(1.dp)
+                            .background(Color.White.copy(alpha = 0.3f)),
+                )
+            }
+            val fadeWidth = 24.dp
+            LazyRow(
+                state = chipRowState,
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .then(
+                            if (hasFavorites) {
+                                Modifier.drawWithContent {
+                                    drawContent()
+                                    if (chipRowState.canScrollBackward) {
+                                        val solidZone = 4.dp.toPx()
+                                        val totalWidth = fadeWidth.toPx()
+                                        drawRect(
+                                            brush =
+                                                Brush.horizontalGradient(
+                                                    colorStops =
+                                                        arrayOf(
+                                                            0f to TBABlue,
+                                                            solidZone / totalWidth to TBABlue,
+                                                            1f to Color.Transparent,
+                                                        ),
+                                                    endX = totalWidth,
+                                                ),
+                                            size = size.copy(width = totalWidth),
+                                        )
+                                    }
+                                }
+                            } else {
+                                Modifier
+                            },
+                        ),
+                contentPadding =
+                    PaddingValues(
+                        start = 8.dp,
+                        end = 12.dp,
+                        bottom = 4.dp,
+                    ),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(weekLabels.size) { index ->
+                    val label = weekLabels[index]
+                    FilterChip(
+                        selected = selectedLabel == label && !isFavoritesSelected,
+                        onClick = { onWeekSelected(label) },
+                        label = { Text(label) },
+                        colors = weekChipColors,
+                        elevation = null,
+                        border = weekChipBorder,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
The week filter chips on the Events screen have a broken hover state: hovering darkens the chip's perimeter but not the area behind its label, and the "highlight" goes the wrong direction on the blue bar.

Both defects trace back to one thing — these are flat `FilterChip`s with `containerColor = Color.Transparent`, drawn straight onto the blue app bar.

### 1. A shadow rendering through the transparent container

`FilterChipDefaults.filterChipElevation()` defaults `hoveredElevation` to `FilterChipTokens.FlatSelectedHoverContainerElevation` (1.dp), and applies it regardless of whether the chip is selected. `Surface` turns that into `graphicsLayer(shadowElevation = …, clip = false)`. With an opaque container you'd never notice, but here the container is transparent, so the shadow renders *through* the chip's interior — a dark blotch across the whole chip except behind the label, whose own layer masks it. That's the reported "darkens everything but the text".

Pressed and focused already resolve to `Level0`, and drag doesn't apply, so `elevation = null` is the simplest expression of "flat chips here never cast a shadow" and covers every state at once.

### 2. The state layer inheriting a near-black content color

A chip derives its content color from its container color: `Surface(contentColor = contentColorFor(color))`. `contentColorFor(Color.Transparent)` finds no match in the color scheme and falls back to `LocalContentColor.current` — the ambient near-black `onSurface`. `ripple()` reads `LocalContentColor` for its state layer, so hover/press applied a ~6% *darkening* on a blue bar: the wrong direction given the chips' white border and label, and nearly invisible.

Providing white `LocalContentColor` around the row fixes it. This is the same contract `TBATabRow` already gives its tabs (`contentColor = Color.White`), which is why the tabs hover correctly today and the chips don't.

### Diff size

Most of the diff is reindentation from wrapping the row in `CompositionLocalProvider`. `git diff -w` shows the four real lines: two `elevation = null` arguments, the provider, and the explanatory comment.

### Verification

`:app:assembleDebug`, `:app:testDebugUnitTest` and `ktlintCheck` all pass. `:app:lintDebug` reports zero issues in `EventsScreen.kt`; it does fail, but only on two pre-existing `AndroidGradlePluginVersion` errors in `gradle/libs.versions.toml` (AGP 9.4.0 is out) that are unrelated to this change and present on `main` — the lint config already disables `GradleDependency` and `NewerVersionAvailable` for this reason but not that third issue ID.

Before/after hover screenshots will be added as a follow-up — hover verification is happening in a separate consolidated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Week filter chip hover** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/main/1523_weekchips_before-b8fdf2f8.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/main/1523_weekchips_after-97a29a42.png" width="300"> |
<!-- screenshots:end -->