### PR TITLE
chore(deps): bump agp from 9.3.2 to 9.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.3.2"
+agp = "9.4.0"
 kotlin = "2.4.10"
 ksp = "2.3.11"
 


### PR DESCRIPTION
Bumps the Android Gradle Plugin from 9.3.2 to 9.4.0 (the newest stable on Google's Maven; 9.5.0 is still alpha). This is a CI unblocker rather than a routine dependency bump: lint's `AndroidGradlePluginVersion` check fires whenever the pinned AGP falls behind the latest release, and because the project sets `warningsAsErrors`, that warning is promoted to an error — `:app:lintDebug` currently fails on clean `main` with 2 errors on `gradle/libs.versions.toml:2`, which blocks CI for every open PR until the pin catches up. AGP 9.4 is a minor release with nothing breaking for this repo: it requires Gradle 9.6+ (we're on 9.7.1) and JDK 17, supports up to API 37 (our `compileSdk`/`targetSdk`), and its one new behavior change — strict flavor-dimension parity between app and dynamic-feature modules — doesn't apply here since `main` is unflavored and has no dynamic features. Worth noting for later: AGP 10 will make the new Variant API mandatory. `agp` is the only catalog entry coupled to the plugin (it feeds `android-application` and `android-library`), so no other versions needed to move.

Verified locally with `:app:assembleDebug :app:testDebugUnitTest :app:lintDebug :tv:assembleDebug :tv:lintDebug :wear:assembleDebug :wear:lintDebug ktlintCheck` — all green, unit tests additionally re-run with `--rerun-tasks`, and the lint reports for all three modules no longer contain any `AndroidGradlePluginVersion` finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)