### PR TITLE
feat(webcasts): open Twitch webcasts in the Twitch app

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInfoTab.kt
@@ -33,6 +33,8 @@ import com.thebluealliance.android.ui.common.LoadingBox
 import com.thebluealliance.android.ui.components.formatEventDateRange
 import com.thebluealliance.android.ui.events.weekLabel
 import com.thebluealliance.android.util.openUrl
+import com.thebluealliance.android.util.openWebcast
+import com.thebluealliance.android.util.webcastUrl
 
 @Composable
 fun EventInfoTab(
@@ -225,7 +227,7 @@ fun EventInfoTab(
                             Modifier
                                 .padding(top = 4.dp)
                                 .clickable {
-                                    context.openUrl(url)
+                                    context.openWebcast(webcast, url)
                                 },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
@@ -247,15 +249,6 @@ fun EventInfoTab(
         }
     }
 }
-
-private fun webcastUrl(webcast: Webcast): String? =
-    when (webcast.type) {
-        "twitch" -> "https://twitch.tv/${webcast.channel}"
-        "youtube" -> "https://youtube.com/watch?v=${webcast.channel}"
-        "livestream" ->
-            "https://livestream.com/accounts/${webcast.channel}/events/${webcast.file ?: ""}"
-        else -> null
-    }
 
 private fun webcastLabel(webcast: Webcast): String {
     val base =

--- a/app/src/main/kotlin/com/thebluealliance/android/util/WebcastLinks.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/util/WebcastLinks.kt
@@ -1,0 +1,55 @@
+package com.thebluealliance.android.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+import com.thebluealliance.android.domain.model.Webcast
+
+/** The web URL for a webcast, or `null` for types we don't know how to link out to. */
+fun webcastUrl(webcast: Webcast): String? =
+    when (webcast.type) {
+        "twitch" -> "https://twitch.tv/${webcast.channel}"
+        "youtube" -> "https://youtube.com/watch?v=${webcast.channel}"
+        "livestream" ->
+            "https://livestream.com/accounts/${webcast.channel}/events/${webcast.file ?: ""}"
+        else -> null
+    }
+
+/**
+ * A native-app deep link for a webcast, or `null` when we have none for the type.
+ *
+ * Twitch only, for now. Handing the browser `https://twitch.tv/<channel>` shows an "open in the
+ * Twitch app" interstitial that drops the channel path and lands the user on the Twitch home
+ * screen — verified on a Quest 3, and the same interstitial runs on phones with Twitch installed.
+ * `twitch://stream/<channel>` opens the app straight to the channel.
+ */
+fun webcastAppUri(webcast: Webcast): String? =
+    when {
+        webcast.type == "twitch" && webcast.channel.isNotBlank() ->
+            "twitch://stream/${webcast.channel}"
+        else -> null
+    }
+
+/**
+ * Opens a webcast, preferring its native app (see [webcastAppUri]) and falling back to the web URL
+ * when no app handles the deep link.
+ *
+ * `startActivity` doesn't require package visibility, so catching [ActivityNotFoundException] is
+ * enough here — no `<queries>` entry needed.
+ */
+fun Context.openWebcast(
+    webcast: Webcast,
+    url: String,
+) {
+    val appUri = webcastAppUri(webcast)
+    if (appUri != null) {
+        try {
+            startActivity(Intent(Intent.ACTION_VIEW, appUri.toUri()))
+            return
+        } catch (_: ActivityNotFoundException) {
+            // No native app installed — fall through to the browser.
+        }
+    }
+    openUrl(url)
+}

--- a/app/src/test/kotlin/com/thebluealliance/android/util/WebcastLinksTest.kt
+++ b/app/src/test/kotlin/com/thebluealliance/android/util/WebcastLinksTest.kt
@@ -1,0 +1,68 @@
+package com.thebluealliance.android.util
+
+import com.thebluealliance.android.domain.model.Webcast
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class WebcastLinksTest {
+    private fun webcast(
+        type: String,
+        channel: String,
+        file: String? = null,
+    ) = Webcast(type = type, channel = channel, file = file, date = null)
+
+    // ── webcastUrl ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `twitch webcast url uses the channel`() {
+        assertEquals(
+            "https://twitch.tv/firstinspires",
+            webcastUrl(webcast("twitch", "firstinspires")),
+        )
+    }
+
+    @Test
+    fun `youtube webcast url uses the video id`() {
+        assertEquals(
+            "https://youtube.com/watch?v=abc123",
+            webcastUrl(webcast("youtube", "abc123")),
+        )
+    }
+
+    @Test
+    fun `livestream webcast url uses account and file`() {
+        assertEquals(
+            "https://livestream.com/accounts/12345/events/678",
+            webcastUrl(webcast("livestream", "12345", file = "678")),
+        )
+    }
+
+    @Test
+    fun `unknown webcast type has no url`() {
+        assertNull(webcastUrl(webcast("direct_link", "https://example.com/stream")))
+    }
+
+    // ── webcastAppUri ────────────────────────────────────────────────────────
+
+    @Test
+    fun `twitch webcast deep links into the twitch app`() {
+        assertEquals(
+            "twitch://stream/firstinspires",
+            webcastAppUri(webcast("twitch", "firstinspires")),
+        )
+    }
+
+    @Test
+    fun `twitch webcast with a blank channel has no deep link`() {
+        assertNull(webcastAppUri(webcast("twitch", "")))
+        assertNull(webcastAppUri(webcast("twitch", "   ")))
+    }
+
+    @Test
+    fun `non-twitch webcasts have no deep link`() {
+        assertNull(webcastAppUri(webcast("youtube", "abc123")))
+        assertNull(webcastAppUri(webcast("livestream", "12345", file = "678")))
+        assertNull(webcastAppUri(webcast("direct_link", "https://example.com/stream")))
+    }
+}


### PR DESCRIPTION
## Motivation

Tapping a Twitch webcast on the event Info tab handed `https://twitch.tv/<channel>` straight to the browser. **Verified on a real Quest 3:** the browser's "open in the Twitch app" interstitial *drops the channel path* — you get dumped on the Twitch home screen, not the stream you asked for. Firing `twitch://stream/<channel>` instead opens the Twitch app directly on the correct channel. The same interstitial runs on phones with Twitch installed, so phone users get the fix too.

## What changed

- When a webcast is a Twitch channel, try `ACTION_VIEW twitch://stream/<channel>` first.
- If nothing handles it (no Twitch app installed → `ActivityNotFoundException`), fall back to the existing https browser behavior, unchanged.
- Non-Twitch webcasts (YouTube, Livestream, unknown types) are completely unchanged.

`startActivity()` does not require package visibility to launch another app's activity ([docs](https://developer.android.com/training/package-visibility/use-cases)), so catching `ActivityNotFoundException` is sufficient — **no `<queries>` entry and no `QUERY_ALL_PACKAGES` needed** on API 30+.

This is a per-type special case at the link-out site, not a new webcast framework. `webcastUrl` moved out of `EventInfoTab.kt` into `util/WebcastLinks.kt` next to the new `webcastAppUri` so both are pure and unit-testable; the label formatting stays in the tab.

## Testing

- New `WebcastLinksTest` (7 tests) covering URL building for each type and the Twitch deep-link choice, including blank-channel and non-Twitch cases.
- `:app:testDebugUnitTest` — pass.
- `:app:ktlintCheck` — pass.
- `:app:lintDebug` — only the 2 pre-existing `AndroidGradlePluginVersion` errors already on `main`; zero new findings.
- On-device Twitch behavior verified on a Quest 3 (see Motivation).

`:tv` (which has its own `WebcastLauncher` for the TV fallback chain) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
