### PR TITLE
fix: inline text-link hover padding

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -129,7 +130,9 @@ private fun AdvancementPointsItem(
                 Modifier
                     .fillMaxWidth()
                     .clickable { expanded = !expanded }
-                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                    // 8.dp here + 2.dp inside the team-number tap target below keeps the
+                    // row's overall height unchanged while the nested target grows.
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -142,7 +145,12 @@ private fun AdvancementPointsItem(
                     text = points.teamKey.teamNumber,
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.clickable { onTeamClick(points.teamKey) },
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(MaterialTheme.shapes.small)
+                            .clickable { onTeamClick(points.teamKey) }
+                            .padding(vertical = 2.dp),
                 )
                 if (teamName != null) {
                     Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Alliance
 import com.thebluealliance.android.domain.model.displayTitle
@@ -58,10 +59,12 @@ fun EventAlliancesTab(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                        // 8.dp here + 8.dp on each child keeps content on the 16.dp margin
+                        // while letting the pick slots' tap targets absorb the other half.
+                        .padding(horizontal = 8.dp, vertical = 8.dp),
             ) {
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
@@ -85,7 +88,9 @@ fun EventAlliancesTab(
                 }
                 FlowRow(
                     modifier = Modifier.padding(top = 4.dp),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    // Slots carry their own 8.dp horizontal padding inside their tap target,
+                    // which supplies the 16.dp gap that used to come from the arrangement.
+                    horizontalArrangement = Arrangement.spacedBy(0.dp),
                 ) {
                     alliance.picks.forEachIndexed { index, teamKey ->
                         AllianceSlot(
@@ -115,7 +120,11 @@ private fun AllianceSlot(
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.clickable { onTeamClick(teamKey) },
+        modifier =
+            Modifier
+                .clip(MaterialTheme.shapes.small)
+                .clickable { onTeamClick(teamKey) }
+                .padding(horizontal = 8.dp, vertical = 4.dp),
     ) {
         Text(
             text = label,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
@@ -290,7 +291,9 @@ private fun RankingItem(
                 Modifier
                     .fillMaxWidth()
                     .clickable { expanded = !expanded }
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    // 8.dp here + 4.dp inside the team cell below keeps the row's height and
+                    // every child's position unchanged while the nested tap target grows.
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -304,7 +307,9 @@ private fun RankingItem(
                 modifier =
                     Modifier
                         .weight(0.22f)
-                        .clickable { onTeamClick(ranking.teamKey) },
+                        .clip(MaterialTheme.shapes.small)
+                        .clickable { onTeamClick(ranking.teamKey) }
+                        .padding(vertical = 4.dp),
                 color = MaterialTheme.colorScheme.primary,
             )
             Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -246,14 +247,20 @@ private fun EventInfo(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 4.dp),
+                .padding(vertical = 4.dp),
     ) {
         if (eventName != null && eventKey != null) {
+            // Full-width tap target (EventRow idiom) so hover/ripple reads as a row rather
+            // than hugging the text; the 16.dp inset keeps the text where it was.
             Text(
                 text = eventName,
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.clickable { onNavigateToEvent(eventKey) },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable { onNavigateToEvent(eventKey) }
+                        .padding(horizontal = 16.dp, vertical = 2.dp),
             )
         }
         if (formattedTime != null) {
@@ -261,7 +268,7 @@ private fun EventInfo(
                 text = formattedTime,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 2.dp),
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 2.dp),
             )
         }
     }
@@ -406,8 +413,9 @@ private fun AllianceTeams(
                     color = MaterialTheme.colorScheme.error,
                     modifier =
                         Modifier
+                            .clip(MaterialTheme.shapes.small)
                             .clickable { onTeamClick(key) }
-                            .padding(top = 2.dp),
+                            .padding(horizontal = 12.dp, vertical = 4.dp),
                 )
             }
         }
@@ -431,8 +439,9 @@ private fun AllianceTeams(
                     color = MaterialTheme.colorScheme.primary,
                     modifier =
                         Modifier
+                            .clip(MaterialTheme.shapes.small)
                             .clickable { onTeamClick(key) }
-                            .padding(top = 2.dp),
+                            .padding(horizontal = 12.dp, vertical = 4.dp),
                 )
             }
         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.BuildConfig
@@ -81,23 +82,34 @@ fun MoreScreen(
 
             Spacer(modifier = Modifier.weight(1f))
 
-            Row(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)) {
+            // Each link carries its own 8.dp inset inside the tap target, so the row's own
+            // padding drops by the same amount and the separator's spaces are no longer needed.
+            Row(modifier = Modifier.padding(start = 8.dp, end = 8.dp, top = 12.dp)) {
                 Text(
                     text = "About",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.clickable(onClick = onNavigateToAbout),
+                    modifier =
+                        Modifier
+                            .clip(MaterialTheme.shapes.small)
+                            .clickable(onClick = onNavigateToAbout)
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
                 )
                 Text(
-                    text = " · ",
+                    text = "·",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 4.dp),
                 )
                 Text(
                     text = "Thanks",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.clickable(onClick = onNavigateToThanks),
+                    modifier =
+                        Modifier
+                            .clip(MaterialTheme.shapes.small)
+                            .clickable(onClick = onNavigateToThanks)
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
                 )
             }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -219,11 +220,11 @@ private fun RegionalRankingRow(
                     style = MaterialTheme.typography.bodyMedium,
                     modifier =
                         Modifier
-                            .weight(
-                                0.15f,
-                            ).clickable {
+                            .weight(0.15f)
+                            .clip(MaterialTheme.shapes.small)
+                            .clickable {
                                 onNavigateToEvent(sortedEvents[0].eventKey)
-                            },
+                            }.padding(vertical = 6.dp),
                 )
             } else {
                 Text(
@@ -239,11 +240,11 @@ private fun RegionalRankingRow(
                     style = MaterialTheme.typography.bodyMedium,
                     modifier =
                         Modifier
-                            .weight(
-                                0.15f,
-                            ).clickable {
+                            .weight(0.15f)
+                            .clip(MaterialTheme.shapes.small)
+                            .clickable {
                                 onNavigateToEvent(sortedEvents[1].eventKey)
-                            },
+                            }.padding(vertical = 6.dp),
                 )
             } else {
                 Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -106,14 +107,21 @@ fun TeamEventDetailScreen(
                                 modifier = Modifier.fillMaxWidth(),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
+                                // Both halves of the title are links: each gets a clipped,
+                                // padded tap target. Their 6.dp insets replace the spaces
+                                // that used to surround the "@" separator.
                                 Text(
                                     text = "${team.number}",
                                     maxLines = 1,
-                                    modifier = Modifier.clickable { onNavigateToTeam(team.key) },
+                                    modifier =
+                                        Modifier
+                                            .clip(MaterialTheme.shapes.small)
+                                            .clickable { onNavigateToTeam(team.key) }
+                                            .padding(horizontal = 6.dp, vertical = 4.dp),
                                     style = MaterialTheme.typography.titleLarge,
                                 )
                                 Text(
-                                    text = " @ ",
+                                    text = "@",
                                     maxLines = 1,
                                     style = MaterialTheme.typography.titleLarge,
                                 )
@@ -123,14 +131,14 @@ fun TeamEventDetailScreen(
                                     overflow = TextOverflow.Ellipsis,
                                     modifier =
                                         Modifier
-                                            .weight(
-                                                1f,
-                                            ).clickable {
+                                            .weight(1f)
+                                            .clip(MaterialTheme.shapes.small)
+                                            .clickable {
                                                 onNavigateToEvent(
                                                     event.key,
                                                     EventDetailTab.INFO,
                                                 )
-                                            },
+                                            }.padding(horizontal = 6.dp, vertical = 4.dp),
                                     style = MaterialTheme.typography.titleLarge,
                                 )
                             }
@@ -591,11 +599,14 @@ private fun StatsTab(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary,
                 modifier =
-                    Modifier.clickable {
-                        context.openUrl(
-                            "https://www.thebluealliance.com/opr",
-                        )
-                    },
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(MaterialTheme.shapes.small)
+                        .clickable {
+                            context.openUrl(
+                                "https://www.thebluealliance.com/opr",
+                            )
+                        }.padding(vertical = 4.dp),
             )
         }
 


### PR DESCRIPTION
## Problem

A pixel-verified hover audit found a cluster of hand-rolled text links built as
`Modifier.clickable { }` on a wrap-content `Text`, with no padding inside the clickable and no
`clip`. On a mouse/trackpad (Android 17 desktop windowing, ChromeOS, emulator with a pointer) the
hover highlight and the press ripple are drawn over the clickable's own bounds — so they trace the
glyph box exactly, producing a tight rectangle glued to the text instead of a deliberate target.
The same bounds are the touch target, so several of these were also well under 48dp.

## Mechanism / fix

The repo already has the correct idiom in `EventRow.kt`: size first, `clickable` next, `padding`
last — the padding is *inside* the clickable, so it becomes part of the hover/ripple/touch surface.
For elements that do not span a full row, the shape has to be clipped before `clickable` or the
indication paints a hard-edged rectangle.

Two shapes of fix, applied per context:

- **Block-level links** (event name on Match Detail, "Learn more about OPR" on Team@Event Stats):
  `fillMaxWidth()` → `clickable` → `padding`, i.e. a row-style hover band, with the horizontal
  inset moved from the parent into the clickable so the text does not move.
- **Inline links and table cells** (More footer links, Match Detail alliance team numbers,
  Team@Event top-bar title halves, alliance pick slots, Regional Advancement point cells, team
  numbers nested inside already-clickable rows): `clip(shapes.small)` → `clickable` → `padding`,
  so hover reads as a rounded chip around the label. Where a cell is already `weight(...)`-sized,
  only vertical padding is added — the weight already gives it the full column width.

Nested navigation is preserved everywhere. Where a team number sits inside an already-clickable
row (Rankings, Advancement), the inner target keeps its own clipped, padded surface so the two
hover states read as intentionally nested rather than as one band bleeding into another.

Wherever possible, the padding added *inside* the clickable is taken back out of the enclosing
container, so the rest state is unchanged:

- `EventRankingsTab` ranking row: row padding 12dp → 8dp vertical, team cell gains 4dp vertical →
  row height and every child's position are identical.
- `EventAdvancementTab` row: row padding 10dp → 8dp vertical, team-number target gains 2dp → same
  row height.
- `EventAlliancesTab`: the alliance block's 16dp horizontal padding is split 8dp on the block +
  8dp on each child, and `FlowRow`'s 16dp arrangement gap is now supplied by the two slots'
  8dp insets — content stays on the 16dp margin, gaps between picks stay 16dp, and the wrap
  threshold is arithmetically unchanged.
- `MoreScreen` footer: row padding 16dp → 8dp and the separator's surrounding spaces (`" · "` →
  `"·"`) are replaced by the links' own 8dp insets, so "About" still starts on the 16dp margin
  and the gap around the dot is about the same.
- `TeamEventDetailScreen` title: the spaces around `" @ "` are likewise replaced by the two
  halves' 6dp insets.

## Rest-state changes (disclosed)

These could not be fully compensated:

- **Match Detail, event name**: text sits 2dp lower; the time line below it 4dp lower; the block
  is 4dp taller.
- **Match Detail, alliance team numbers**: each team number's target grows from 26dp to 32dp tall
  (+6dp per team, ~18dp per alliance column) and gains a 12dp horizontal inset. Text stays
  horizontally centered, so it does not move sideways.
- **Team@Event top bar**: the title starts ~6dp further right (the team-number link's leading
  inset). Bar height is unchanged.
- **Team@Event Stats, "Learn more about OPR"**: 4dp taller; text position unchanged.
- **More footer**: the version/build line sits ~4dp lower.
- **Regional Advancement rows**: the two event-point cells become 32dp tall. Rows whose
  advancement badge already wraps to two lines are unchanged; rows with a short badge grow by up
  to 8dp. Rows never shrink.

Before/after hover screenshots for this cluster will come in a later consolidated screenshot pass
across all the hover PRs.

## Verification

`:app:assembleDebug`, `:app:testDebugUnitTest`, `:app:lintDebug` all run locally. Lint reports only
the two pre-existing `AndroidGradlePluginVersion` errors that are already failing on clean `main`
(an AGP bump PR is in flight); no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **More screen link hover** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/main/1526_more_links_before-219fbaa2.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/main/1526_more_links_after-18df5b22.png" width="300"> |
<!-- screenshots:end -->