### PR TITLE
fix: ranking/insight table column gutters + right-aligned numeric Rankings columns

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
@@ -56,6 +56,16 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.int
 
+/**
+ * Half of the gutter between two table columns, applied inside every cell of both the header and
+ * the data rows so the columns stay aligned. The rows carry [TABLE_ROW_PADDING] instead of the
+ * usual 16.dp so the outermost cells' content still lands on the screen's 16.dp margin.
+ */
+private val COLUMN_GUTTER = 4.dp
+
+/** Row inset that, plus [COLUMN_GUTTER] inside the end cells, restores the 16.dp screen margin. */
+private val TABLE_ROW_PADDING = 12.dp
+
 sealed class StatType {
     object StandardOPRs : StatType()
 
@@ -597,7 +607,7 @@ private fun StandardOPRsView(
                     Modifier
                         .fillMaxWidth()
                         .background(TBAIndigo400)
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                        .padding(horizontal = TABLE_ROW_PADDING, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 OprHeaderItem(
@@ -658,7 +668,9 @@ private fun StandardOPRsView(
                 )
                 IconButton(
                     onClick = onShowStatSelector,
-                    modifier = Modifier.padding(0.dp),
+                    // Keeps the button's outer edge on the 16.dp screen margin now that the row
+                    // itself only insets by TABLE_ROW_PADDING.
+                    modifier = Modifier.padding(end = COLUMN_GUTTER),
                 ) {
                     Icon(
                         imageVector = Icons.Default.MoreVert,
@@ -675,27 +687,27 @@ private fun StandardOPRsView(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .padding(16.dp),
+                            .padding(horizontal = TABLE_ROW_PADDING, vertical = 16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
                         text = teamKey.teamNumber,
-                        modifier = Modifier.weight(1.2f),
+                        modifier = Modifier.weight(1.2f).padding(horizontal = COLUMN_GUTTER),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
                         text = "%.2f".format(oprs.oprs[teamKey] ?: 0.0),
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier.weight(1f).padding(horizontal = COLUMN_GUTTER),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
                         text = "%.2f".format(oprs.dprs[teamKey] ?: 0.0),
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier.weight(1f).padding(horizontal = COLUMN_GUTTER),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
                         text = "%.2f".format(oprs.ccwms[teamKey] ?: 0.0),
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier.weight(1f).padding(horizontal = COLUMN_GUTTER),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     Box(modifier = Modifier.weight(0.4f))
@@ -758,7 +770,7 @@ private fun COPRView(
                     Modifier
                         .fillMaxWidth()
                         .background(TBAIndigo400)
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                        .padding(horizontal = TABLE_ROW_PADDING, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 CoprHeaderItem(
@@ -791,7 +803,9 @@ private fun COPRView(
                 )
                 IconButton(
                     onClick = onShowStatSelector,
-                    modifier = Modifier.padding(0.dp),
+                    // Keeps the button's outer edge on the 16.dp screen margin now that the row
+                    // itself only insets by TABLE_ROW_PADDING.
+                    modifier = Modifier.padding(end = COLUMN_GUTTER),
                 ) {
                     Icon(
                         imageVector = Icons.Default.MoreVert,
@@ -808,17 +822,17 @@ private fun COPRView(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .padding(16.dp),
+                            .padding(horizontal = TABLE_ROW_PADDING, vertical = 16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
                         text = teamKey.teamNumber,
-                        modifier = Modifier.weight(1.2f),
+                        modifier = Modifier.weight(1.2f).padding(horizontal = COLUMN_GUTTER),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
                         text = "%.2f".format(coprData[teamKey] ?: 0.0),
-                        modifier = Modifier.weight(2f),
+                        modifier = Modifier.weight(2f).padding(horizontal = COLUMN_GUTTER),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                 }
@@ -850,14 +864,16 @@ private fun OprHeaderItem(
     onSortClick: () -> Unit,
 ) {
     Row(
-        // Clip + padding inside the clickable so the sort target is a rounded band across the
-        // column instead of a highlight glued to the label. The header row's height is set by
-        // its 48.dp icon button, so this does not change the header's layout.
+        // Clip + clickable outside the cell's own COLUMN_GUTTER, so the sort target is a rounded
+        // band spanning the whole column with the label inset from both its edges, instead of a
+        // highlight glued to the glyphs. The data cells carry the same gutter, so the label stays
+        // in line with the column below it; the header row's height is set by its 48.dp icon
+        // button, so the vertical padding does not change the header's layout either.
         modifier =
             modifier
                 .clip(MaterialTheme.shapes.small)
                 .clickable { onSortClick() }
-                .padding(vertical = 8.dp),
+                .padding(horizontal = COLUMN_GUTTER, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -892,7 +908,7 @@ private fun CoprHeaderItem(
             modifier
                 .clip(MaterialTheme.shapes.small)
                 .clickable { onSortClick() }
-                .padding(vertical = 8.dp),
+                .padding(horizontal = COLUMN_GUTTER, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventInsightsTab.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -849,7 +850,14 @@ private fun OprHeaderItem(
     onSortClick: () -> Unit,
 ) {
     Row(
-        modifier = modifier.clickable { onSortClick() },
+        // Clip + padding inside the clickable so the sort target is a rounded band across the
+        // column instead of a highlight glued to the label. The header row's height is set by
+        // its 48.dp icon button, so this does not change the header's layout.
+        modifier =
+            modifier
+                .clip(MaterialTheme.shapes.small)
+                .clickable { onSortClick() }
+                .padding(vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -879,7 +887,12 @@ private fun CoprHeaderItem(
     onSortClick: () -> Unit,
 ) {
     Row(
-        modifier = modifier.clickable { onSortClick() },
+        // Same treatment as OprHeaderItem above.
+        modifier =
+            modifier
+                .clip(MaterialTheme.shapes.small)
+                .clickable { onSortClick() }
+                .padding(vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
@@ -192,7 +193,9 @@ private fun RankingHeaderRow(
             Modifier
                 .fillMaxWidth()
                 .background(TBAIndigo400)
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                // 6.dp here + 6.dp inside each sortable cell below: the sort targets get a
+                // full-height hover band without changing the header's height.
+                .padding(horizontal = 16.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -246,7 +249,11 @@ private fun RankingHeaderItem(
     onSortClick: () -> Unit,
 ) {
     Row(
-        modifier = modifier.clickable { onSortClick() },
+        modifier =
+            modifier
+                .clip(MaterialTheme.shapes.small)
+                .clickable { onSortClick() }
+                .padding(vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Ranking
@@ -59,6 +61,9 @@ private val COLUMN_GUTTER = 4.dp
 
 /** Row inset that, plus [COLUMN_GUTTER] inside the end cells, restores the 16.dp screen margin. */
 private val TABLE_ROW_PADDING = 12.dp
+
+/** OpenType tabular figures: every digit takes the same advance, so numeric columns grid up. */
+private const val TABULAR_FIGURES = "tnum"
 
 enum class RankingSortColumn {
     TEAM,
@@ -213,7 +218,7 @@ private fun RankingHeaderRow(
             text = "Rank",
             style = MaterialTheme.typography.titleSmall,
             color = Color.White,
-            modifier = Modifier.weight(0.12f).padding(horizontal = COLUMN_GUTTER),
+            modifier = Modifier.weight(0.11f).padding(horizontal = COLUMN_GUTTER),
         )
         RankingHeaderItem(
             text = "Team",
@@ -227,11 +232,12 @@ private fun RankingHeaderRow(
             text = "Record",
             style = MaterialTheme.typography.titleSmall,
             color = Color.White,
-            modifier = Modifier.weight(0.22f).padding(horizontal = COLUMN_GUTTER),
+            modifier = Modifier.weight(0.15f).padding(horizontal = COLUMN_GUTTER),
         )
         RankingHeaderItem(
             text = primaryLabel,
-            modifier = Modifier.weight(0.18f),
+            modifier = Modifier.weight(0.23f),
+            numeric = true,
             sortColumn = RankingSortColumn.PRIMARY,
             currentSort = sortState.column,
             ascending = sortState.ascending,
@@ -239,14 +245,15 @@ private fun RankingHeaderRow(
         )
         RankingHeaderItem(
             text = secondaryLabel,
-            modifier = Modifier.weight(0.14f),
+            modifier = Modifier.weight(0.19f),
+            numeric = true,
             sortColumn = RankingSortColumn.SECONDARY,
             currentSort = sortState.column,
             ascending = sortState.ascending,
             onSortClick = { onSortSelected(RankingSortColumn.SECONDARY) },
         )
         // Spacer for chevron alignment
-        Spacer(modifier = Modifier.weight(0.12f))
+        Spacer(modifier = Modifier.weight(0.10f))
     }
 }
 
@@ -254,40 +261,92 @@ private fun RankingHeaderRow(
 private fun RankingHeaderItem(
     text: String,
     modifier: Modifier = Modifier,
+    numeric: Boolean = false,
     sortColumn: RankingSortColumn,
     currentSort: RankingSortColumn,
     ascending: Boolean,
     onSortClick: () -> Unit,
 ) {
-    Row(
-        // Clip + clickable outside the cell's own COLUMN_GUTTER, so the sort target is a rounded
-        // band spanning the whole column with the label inset from both its edges, instead of a
-        // highlight glued to the glyphs. The data cells carry the same gutter, so the label stays
-        // in line with the column below it.
-        modifier =
-            modifier
-                .clip(MaterialTheme.shapes.small)
-                .clickable { onSortClick() }
-                .padding(horizontal = COLUMN_GUTTER, vertical = 6.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.titleSmall,
-            color = Color.White,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
-        if (currentSort == sortColumn) {
-            Icon(
-                imageVector =
-                    if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
-                contentDescription =
-                    if (ascending) "Sorted Ascending" else "Sorted Descending",
-                tint = Color.White,
+    val sorted = currentSort == sortColumn
+    // Clip + clickable outside the cell's own COLUMN_GUTTER, so the sort target is a rounded band
+    // spanning the whole column with the label inset from both its edges, instead of a highlight
+    // glued to the glyphs. The data cells carry the same gutter, so the label stays in line with
+    // the column below it.
+    val cellModifier =
+        modifier
+            .clip(MaterialTheme.shapes.small)
+            .clickable { onSortClick() }
+            .padding(horizontal = COLUMN_GUTTER, vertical = 6.dp)
+    if (numeric) {
+        // Numeric column: right-align the label onto the values' shared right edge, with the sort
+        // carat leading it (Material data-table convention — a leading carat keeps the numeric
+        // header's right edge in line with the digits below). A hand layout, because this column
+        // is narrow and its label ("Ranking Score") wraps to two lines: the label (child 0) is
+        // measured at the cell's full width so it never ellipsizes, then right-anchored; the carat
+        // (child 1) is placed just left of the label, spilling into the column's left slack rather
+        // than stealing width from the label.
+        Layout(
+            modifier = cellModifier,
+            content = {
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.End,
+                )
+                if (sorted) {
+                    SortCaret(ascending)
+                }
+            },
+        ) { measurables, constraints ->
+            val loose = constraints.copy(minWidth = 0, minHeight = 0)
+            // Reserve the carat's width up front, then measure the label in what's left, so a
+            // right-aligned (full-width) two-line label can't swallow the whole column and clip
+            // the carat off the cell's leading edge.
+            val caret = measurables.getOrNull(1)?.measure(loose)
+            val caretWidth = caret?.width ?: 0
+            val width = constraints.maxWidth
+            val labelMax = (width - caretWidth).coerceAtLeast(0)
+            val label = measurables[0].measure(loose.copy(maxWidth = labelMax))
+            val height = maxOf(label.height, caret?.height ?: 0)
+            // Right-anchor the label on the cell's right edge (the values' shared edge), then seat
+            // the carat directly to its left.
+            val labelLeft = (width - label.width).coerceAtLeast(caretWidth)
+            layout(width, height) {
+                label.place(labelLeft, (height - label.height) / 2)
+                caret?.place((labelLeft - caretWidth).coerceAtLeast(0), (height - caret.height) / 2)
+            }
+        }
+    } else {
+        Row(
+            modifier = cellModifier,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.titleSmall,
+                color = Color.White,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
             )
+            if (sorted) {
+                SortCaret(ascending)
+            }
         }
     }
+}
+
+@Composable
+private fun SortCaret(ascending: Boolean) {
+    Icon(
+        imageVector =
+            if (ascending) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
+        contentDescription =
+            if (ascending) "Sorted Ascending" else "Sorted Descending",
+        tint = Color.White,
+    )
 }
 
 @Composable
@@ -321,7 +380,7 @@ private fun RankingItem(
             Text(
                 text = "#${ranking.rank}",
                 style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.weight(0.12f).padding(horizontal = COLUMN_GUTTER),
+                modifier = Modifier.weight(0.11f).padding(horizontal = COLUMN_GUTTER),
             )
             Text(
                 text = ranking.teamKey.teamNumber,
@@ -337,7 +396,7 @@ private fun RankingItem(
             Text(
                 text = "${ranking.wins}-${ranking.losses}-${ranking.ties}",
                 style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.weight(0.22f).padding(horizontal = COLUMN_GUTTER),
+                modifier = Modifier.weight(0.15f).padding(horizontal = COLUMN_GUTTER),
             )
 
             // Show first two sort order values (without labels, header has them)
@@ -349,8 +408,11 @@ private fun RankingItem(
 
             Text(
                 text = primarySortValue,
-                style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.weight(0.18f).padding(horizontal = COLUMN_GUTTER),
+                style =
+                    MaterialTheme.typography.labelLarge
+                        .copy(fontFeatureSettings = TABULAR_FIGURES),
+                textAlign = TextAlign.End,
+                modifier = Modifier.weight(0.23f).padding(horizontal = COLUMN_GUTTER),
             )
 
             val secondarySortValue =
@@ -361,8 +423,11 @@ private fun RankingItem(
 
             Text(
                 text = secondarySortValue,
-                style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.weight(0.14f).padding(horizontal = COLUMN_GUTTER),
+                style =
+                    MaterialTheme.typography.labelLarge
+                        .copy(fontFeatureSettings = TABULAR_FIGURES),
+                textAlign = TextAlign.End,
+                modifier = Modifier.weight(0.19f).padding(horizontal = COLUMN_GUTTER),
             )
 
             Icon(
@@ -371,7 +436,7 @@ private fun RankingItem(
                 modifier =
                     Modifier
                         .rotate(rotationAngle)
-                        .weight(0.12f)
+                        .weight(0.10f)
                         .padding(horizontal = COLUMN_GUTTER),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventRankingsTab.kt
@@ -50,6 +50,16 @@ import com.thebluealliance.android.ui.theme.TBAMotionTokens
 import com.thebluealliance.android.util.teamNumber
 import java.util.Locale
 
+/**
+ * Half of the gutter between two table columns, applied inside every cell of both the header and
+ * the data rows so the columns stay aligned. The rows carry [TABLE_ROW_PADDING] instead of the
+ * usual 16.dp so the outermost cells' content still lands on the screen's 16.dp margin.
+ */
+private val COLUMN_GUTTER = 4.dp
+
+/** Row inset that, plus [COLUMN_GUTTER] inside the end cells, restores the 16.dp screen margin. */
+private val TABLE_ROW_PADDING = 12.dp
+
 enum class RankingSortColumn {
     TEAM,
     PRIMARY,
@@ -193,16 +203,17 @@ private fun RankingHeaderRow(
             Modifier
                 .fillMaxWidth()
                 .background(TBAIndigo400)
-                // 6.dp here + 6.dp inside each sortable cell below: the sort targets get a
-                // full-height hover band without changing the header's height.
-                .padding(horizontal = 16.dp, vertical = 6.dp),
+                // 6.dp vertical here + 6.dp inside each sortable cell below: the sort targets get
+                // a full-height hover band without changing the header's height. The horizontal
+                // inset is the screen margin minus the cells' own COLUMN_GUTTER.
+                .padding(horizontal = TABLE_ROW_PADDING, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = "Rank",
             style = MaterialTheme.typography.titleSmall,
             color = Color.White,
-            modifier = Modifier.weight(0.12f),
+            modifier = Modifier.weight(0.12f).padding(horizontal = COLUMN_GUTTER),
         )
         RankingHeaderItem(
             text = "Team",
@@ -216,7 +227,7 @@ private fun RankingHeaderRow(
             text = "Record",
             style = MaterialTheme.typography.titleSmall,
             color = Color.White,
-            modifier = Modifier.weight(0.22f),
+            modifier = Modifier.weight(0.22f).padding(horizontal = COLUMN_GUTTER),
         )
         RankingHeaderItem(
             text = primaryLabel,
@@ -249,11 +260,15 @@ private fun RankingHeaderItem(
     onSortClick: () -> Unit,
 ) {
     Row(
+        // Clip + clickable outside the cell's own COLUMN_GUTTER, so the sort target is a rounded
+        // band spanning the whole column with the label inset from both its edges, instead of a
+        // highlight glued to the glyphs. The data cells carry the same gutter, so the label stays
+        // in line with the column below it.
         modifier =
             modifier
                 .clip(MaterialTheme.shapes.small)
                 .clickable { onSortClick() }
-                .padding(vertical = 6.dp),
+                .padding(horizontal = COLUMN_GUTTER, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -297,13 +312,13 @@ private fun RankingItem(
                 Modifier
                     .fillMaxWidth()
                     .clickable { expanded = !expanded }
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .padding(horizontal = TABLE_ROW_PADDING, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 text = "#${ranking.rank}",
                 style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.weight(0.12f),
+                modifier = Modifier.weight(0.12f).padding(horizontal = COLUMN_GUTTER),
             )
             Text(
                 text = ranking.teamKey.teamNumber,
@@ -311,13 +326,14 @@ private fun RankingItem(
                 modifier =
                     Modifier
                         .weight(0.22f)
-                        .clickable { onTeamClick(ranking.teamKey) },
+                        .clickable { onTeamClick(ranking.teamKey) }
+                        .padding(horizontal = COLUMN_GUTTER),
                 color = MaterialTheme.colorScheme.primary,
             )
             Text(
                 text = "${ranking.wins}-${ranking.losses}-${ranking.ties}",
                 style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.weight(0.22f),
+                modifier = Modifier.weight(0.22f).padding(horizontal = COLUMN_GUTTER),
             )
 
             // Show first two sort order values (without labels, header has them)
@@ -330,7 +346,7 @@ private fun RankingItem(
             Text(
                 text = primarySortValue,
                 style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.weight(0.18f),
+                modifier = Modifier.weight(0.18f).padding(horizontal = COLUMN_GUTTER),
             )
 
             val secondarySortValue =
@@ -342,7 +358,7 @@ private fun RankingItem(
             Text(
                 text = secondarySortValue,
                 style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.weight(0.14f),
+                modifier = Modifier.weight(0.14f).padding(horizontal = COLUMN_GUTTER),
             )
 
             Icon(
@@ -351,7 +367,8 @@ private fun RankingItem(
                 modifier =
                     Modifier
                         .rotate(rotationAngle)
-                        .weight(0.12f),
+                        .weight(0.12f)
+                        .padding(horizontal = COLUMN_GUTTER),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }


### PR DESCRIPTION
## Problem

The sortable column headers in the event **Rankings** table and the **Insights** OPR/COPR tables
were `Row(modifier = modifier.clickable { onSortClick() })` — no padding inside the clickable, no
clip — so the hover/press highlight was a tight rectangle glued to the label text, floating inside a
much wider column. The root cause was one level down: **these tables had no column gutters**, so
cells butted straight against each other.

On top of that, in the Rankings table the two quantitative columns (*Ranking Score* and
*Avg Coop*) were **left-aligned** with a **trailing** sort carat, so their values never lined up on
a shared right edge and did not read as a column of numbers.

## Fix

**Column gutters.** Every cell in both tables — header cells and data cells alike — now carries
`COLUMN_GUTTER` (4.dp) of horizontal padding (an 8.dp gutter between adjacent columns); the rows
inset by `TABLE_ROW_PADDING` (12.dp) so the outermost content still lands on the screen's usual
16.dp margin. The sort headers apply `clip` + `clickable` *outside* that padding, so the hover band
is a rounded shape spanning the whole column with the label inset from both edges. Because header
and data cells receive the *same* gutter, column alignment is preserved by construction.

**Right-aligned numeric columns (Rankings).** *Ranking Score* and *Avg Coop* are quantitative, so:

- their **values** are right-aligned in **tabular figures** (`fontFeatureSettings = "tnum"`) so the
  digits are equal-width and stack on the decimal point (matching the Insights table);
- their **headers** are right-aligned onto the values' shared right edge, with the sort **carat
  leading** the label (sitting to its *left*) so it does not disrupt that right edge. A small hand
  `Layout` reserves the carat's width and right-anchors the label, so the two-line "Ranking Score"
  label never ellipsizes and the carat seats cleanly to its left;
- the numeric column weights were widened slightly (taken from the over-wide *Record* column and the
  chevron spacer) to give the leading carat room without wrapping "Rank" or clipping records.

*Rank* (`#12`), *Team* (a team number) and *Record* (`11-1-0`) stay **left-aligned** — they are
ordinal / identifier / text columns, not pure numbers. In particular, the **team number stays
left-aligned: it's an identifier (nominal), not a quantitative value** — the numeric-right-align
rule applies to measured quantities (Ranking Score, Avg Coop), not ID columns (a team number is
like a zip code or jersey number, composed of digits but not scanned by magnitude).

## Why this alignment (spec)

This app is built on **Material 3, which has no data-table component** — it was never ported from
Material 2 (material-web tracks it as "not started", and there is no data-tables page on
m3.material.io). The most recent official Material spec that documents data tables is **Material 2 —
Data tables, "Text alignment": "Right-aligned numeric columns / Left-aligned text columns"**
(https://m2.material.io/components/data-tables). This rule is unchanged from Material 1 and is
standard data-table / typography practice. Placing the sort icon to the **left of the label on
numeric (right-aligned) columns** follows Material Components' numeric header-cell + sort-button
handling (material-components-web commit `2139200`, "fix(data-table): Fixed alignment of numeric
header cell with sort button").

## Verification

Measured on live 2024micmp4 data on the Meta Spatial Simulator: each numeric header cell and its
data column now share an exact right edge — *Ranking Score* header and values both end at
`x=1265`, *Avg Coop* at `x=1487`. No new wrapping or ellipsis (the "Ranking Score" and "Avg Coop"
labels render in full, with the sort carat leading), and data-row density is unchanged.

`:app:assembleDebug`, `:app:testDebugUnitTest`, `ktlintCheck` and `:app:lintDebug` all pass with
zero findings.

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Rankings table — rest state (numeric columns right-aligned, tabular figures)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/HEAD/1527_rankings_table_rest_before-1bfb98f4.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/HEAD/1527_rankings_table_rest_after-2aeff082.png" width="300"> |
| **Insights (OPR) table — rest state (column gutters)** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/HEAD/1527_insights_table_rest_before-8dcfb30f-8dcfb30f.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/HEAD/1527_insights_table_rest_after-3fa4e84a-3fa4e84a.png" width="300"> |

**Rankings — 'Ranking Score' hovered: right-aligned header, leading sort carat**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/HEAD/1527_rankings_table_hover_after-672b6e60.png" width="320">

**Insights (OPR) — 'DPR' hovered**

<img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/HEAD/1527_insights_table_hover_after-6d8e12f9-6d8e12f9.png" width="320">
<!-- screenshots:end -->