### PR TITLE
fix: route deep links to a running activity via onNewIntent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.TBA">
             <intent-filter>

--- a/app/src/main/kotlin/com/thebluealliance/android/MainActivity.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/MainActivity.kt
@@ -30,6 +30,10 @@ import com.thebluealliance.android.navigation.Screen
 import com.thebluealliance.android.ui.TBAApp
 import com.thebluealliance.android.widget.TeamTrackingWidgetOpenAction
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
@@ -45,6 +49,20 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var themePreferences: ThemePreferences
 
     private val deepLinkHandler = DeeplinkMatcher()
+
+    /**
+     * Destinations from intents delivered to an already-running Activity (see [onNewIntent]).
+     *
+     * [onCreate] can only route the intent the Activity was launched with, so warm deep links —
+     * browser links, notification taps, `am start` — need their own channel into the navigation
+     * that [com.thebluealliance.android.navigation.TBANavigation] collects.
+     */
+    private val newIntentRoutes =
+        MutableSharedFlow<NavKey>(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+    val intentRoutes: SharedFlow<NavKey> = newIntentRoutes.asSharedFlow()
 
     private val notificationPermissionLauncher =
         registerForActivityResult(
@@ -64,10 +82,7 @@ class MainActivity : ComponentActivity() {
             flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0 &&
                 flags and Intent.FLAG_ACTIVITY_CLEAR_TASK != 0
 
-        val startRoute =
-            getNotificationDestination()
-                ?: getDeeplinkDestination()
-                ?: Screen.Events()
+        val startRoute = intent.destination() ?: Screen.Events()
 
         setContent {
             TBAApp(
@@ -84,41 +99,51 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch { dataSyncManager.syncIfNeeded() }
     }
 
-    private fun getNotificationDestination(): NavKey? {
-        val matchKey = intent.getStringExtra(NotificationBuilder.EXTRA_MATCH_KEY)
-        val eventKey = intent.getStringExtra(NotificationBuilder.EXTRA_EVENT_KEY)
-        val teamKey = intent.getStringExtra(NotificationBuilder.EXTRA_TEAM_KEY)
+    /** The destination this intent targets: a notification/widget extra, or a deeplink URI. */
+    private fun Intent.destination(): NavKey? = notificationDestination() ?: deeplinkDestination()
 
-        val destination =
-            when {
-                matchKey != null -> Screen.MatchDetail(matchKey)
-                teamKey != null && eventKey != null -> Screen.TeamEventDetail(teamKey, eventKey)
-                eventKey != null -> Screen.EventDetail(eventKey)
-                teamKey != null -> {
-                    val initialTab =
-                        intent.getIntExtra(
-                            TeamTrackingWidgetOpenAction.EXTRA_INITIAL_TAB,
-                            0,
-                        )
-                    Screen.TeamDetail(teamKey, initialTab)
-                }
-                else -> null
+    private fun Intent.notificationDestination(): NavKey? {
+        val matchKey = getStringExtra(NotificationBuilder.EXTRA_MATCH_KEY)
+        val eventKey = getStringExtra(NotificationBuilder.EXTRA_EVENT_KEY)
+        val teamKey = getStringExtra(NotificationBuilder.EXTRA_TEAM_KEY)
+
+        return when {
+            matchKey != null -> Screen.MatchDetail(matchKey)
+            teamKey != null && eventKey != null -> Screen.TeamEventDetail(teamKey, eventKey)
+            eventKey != null -> Screen.EventDetail(eventKey)
+            teamKey != null -> {
+                val initialTab =
+                    getIntExtra(
+                        TeamTrackingWidgetOpenAction.EXTRA_INITIAL_TAB,
+                        0,
+                    )
+                Screen.TeamDetail(teamKey, initialTab)
             }
-
-        return destination
+            else -> null
+        }
     }
 
-    private fun getDeeplinkDestination(): NavKey? {
-        val data = intent.data ?: return null
-        return deepLinkHandler.match(data)
+    private fun Intent.deeplinkDestination(): NavKey? {
+        val uri = data ?: return null
+        return deepLinkHandler.match(uri)
     }
 
+    /**
+     * Routes intents that arrive while this Activity is already running.
+     *
+     * The Activity is `singleTop`, so a deeplink or notification tap aimed at the running app is
+     * delivered here instead of through a fresh [onCreate]. Publishing the destination on
+     * [intentRoutes] navigates the live back stack, rather than dropping the intent.
+     */
     override fun onNewIntent(
         intent: Intent,
         caller: ComponentCaller,
     ) {
         super.onNewIntent(intent, caller)
-        Log.d("MainActivity", "Received new intent: $intent")
+        val destination = intent.destination()
+        Log.d("MainActivity", "New intent: $intent -> $destination")
+        if (destination == null) return
+        newIntentRoutes.tryEmit(destination)
     }
 
     fun requestNotificationPermission() {

--- a/app/src/main/kotlin/com/thebluealliance/android/messaging/NotificationBuilder.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/messaging/NotificationBuilder.kt
@@ -51,9 +51,9 @@ class NotificationBuilder
         ): Notification {
             val intent =
                 Intent(context, MainActivity::class.java).apply {
-                    // NEW_TASK + CLEAR_TASK routes the tap through onCreate (with the
-                    // synthetic back stack) even when the app is already running —
-                    // SINGLE_TOP landed in onNewIntent, which dropped the tap. Same
+                    // NEW_TASK + CLEAR_TASK opens the tap on a synthetic back stack when
+                    // the app is not already running. When it is running, the tap reaches
+                    // MainActivity.onNewIntent, which navigates the live back stack. Same
                     // pattern as TeamTrackingWidgetOpenAction.
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                     // Unique data URI so PendingIntents for different notifications never

--- a/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/navigation/TBANavigation.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -61,6 +62,13 @@ fun TBANavigation(
 ) {
     val activity = LocalActivity.current as MainActivity
     val navigator = remember { Navigator(navState, activity) }
+
+    // Deeplinks and notification taps that arrive while the app is already running reach
+    // MainActivity.onNewIntent rather than onCreate, so they navigate the live back stack here
+    // instead of setting a start route.
+    LaunchedEffect(navigator) {
+        activity.intentRoutes.collect { navigator.navigate(it) }
+    }
 
     val showBottomBar =
         TOP_LEVEL_DESTINATIONS.any { it.key.isSameTab(navState.currentRoute) } ||


### PR DESCRIPTION
## The bug

A deep link aimed at an **already-running** app does nothing:

```bash
adb shell am start -a android.intent.action.VIEW \
  -d "https://www.thebluealliance.com/event/2026mogw" \
  -n <pkg>/com.thebluealliance.android.MainActivity
# -> "Activity not started, intent has been delivered to
#     currently running top-most instance."
```

The app stays on whatever screen it was on. Force-stop first and the exact same
command routes correctly. This hits browser-clicked TBA links and notification taps,
not just `adb`.

## Root cause

`MainActivity` resolved its destination **only in `onCreate`**, from the intent the
Activity happened to launch with:

```kotlin
val startRoute = getNotificationDestination() ?: getDeeplinkDestination() ?: Screen.Events()
```

`onNewIntent` — the callback for intents delivered to a *running* Activity — only logged:

```kotlin
override fun onNewIntent(intent: Intent, caller: ComponentCaller) {
    super.onNewIntent(intent, caller)
    Log.d("MainActivity", "Received new intent: $intent")
}
```

So the destination was computed once, at creation, and every later intent was discarded.

Two things made that reachable:

1. **The intent was dropped.** Whenever the platform delivers to the running instance
   (`SINGLE_TOP` senders, the task being reused), routing never ran. `NotificationBuilder`
   had already been bitten by this — its comment read *"SINGLE_TOP landed in onNewIntent,
   which dropped the tap"*, and it worked around the gap with `NEW_TASK|CLEAR_TASK`.
2. **`MainActivity` was `launchMode=standard`.** When the platform *didn't* reuse the
   instance it stacked a **second** `MainActivity` on the task for each warm deep link
   (verified: task `sz=1` -> `sz=2`), duplicating the activity, its ViewModels and its
   nav state instead of navigating.

## The fix

- `android:launchMode="singleTop"` on `MainActivity`, so an intent for the running app is
  delivered to the existing instance instead of stacking a duplicate.
- One `Intent.destination()` resolver (notification/widget extras, then deeplink URI) shared
  by `onCreate` and `onNewIntent` — one routing path, not two.
- `onNewIntent` publishes the destination on a `SharedFlow` that `TBANavigation` collects and
  hands to the existing `Navigator`, so the intent navigates the **live** back stack rather
  than setting a start route.

### Behavior note

Notification and widget taps (`NEW_TASK|CLEAR_TASK`) still open on a synthetic back stack on a
cold start. While the app is running they now navigate in place instead of clearing the task,
so back returns the user where they were rather than to the Events list. Comment in
`NotificationBuilder` updated to match.

## Verification

Emulator: Medium_Phone, API 37, debug build pointed at prod data.

| Step | Before | After |
| --- | --- | --- |
| App running on another tab, then warm deep link to `/event/2026mogw` | stays on Teams, intent dropped (logcat: `Received new intent: …` and nothing else) | Event page opens, same Activity instance (`sz=1`, no restart) |
| Warm deep link with the default `am start` flags | stacked a 2nd `MainActivity` (`sz` 1 -> 2) | `"delivered to currently running top-most instance"`, `sz` stays 1 |
| Back after a warm deep link | n/a | returns to the tab the user was on (Districts), not a restarted app |
| Cold deep link (`/event/…`, `/team/frc254`) | works | still works |
| Plain relaunch, no VIEW intent | no-op | no-op (resolves to `null`, screen unchanged) |
| App backgrounded, then deep link `/match/…` | — | task brought to front and routed to Match |
| Notification-style intent (`NEW_TASK\|CLEAR_TASK` + `event_key`) | recreated via onCreate | routed in place to the event |

`:app:testDebugUnitTest` and `:app:ktlintCheck` pass. `:app:lintDebug` reports only the 2
pre-existing `AndroidGradlePluginVersion` errors already on `main` — no new findings.

<!-- screenshots -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **Warm deep link to /event/2026mogw while the app is on the Teams tab** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/fix-warm-deep-links/before_warm_deeplink_dropped-84e413f0.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/fix-warm-deep-links/after_warm_02_event_routed-5499e70a.png" width="300"> |
<!-- screenshots:end -->