### PR TITLE
refactor: extract paddedClickable modifier for interactive text

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/InteractiveTextModifier.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/InteractiveTextModifier.kt
@@ -1,0 +1,36 @@
+package com.thebluealliance.android.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+
+/**
+ * Makes this element clickable with [padding] *inside* the tap target, clipped to [shape].
+ *
+ * Prefer this over hand-rolling `clip` + `clickable` + `padding`: the order of those three
+ * modifiers is easy to get wrong, and both wrong orders produce the same class of bug.
+ *
+ * - `padding(...).clickable(...)` puts the padding **outside** the tap target, so the ripple and
+ *   pointer-hover highlight hug the text glyphs instead of filling the padded area, and the
+ *   touch target is smaller than it looks.
+ * - `clickable(...).padding(...)` without a preceding `clip(...)` draws a hard-cornered highlight
+ *   that ignores the theme's rounded corners.
+ *
+ * Only `clip(shape).clickable(onClick).padding(padding)` gives a highlight that both fills the
+ * padded target and follows [shape]. Composing them here means call sites cannot get it wrong.
+ *
+ * Note that [padding] is applied last, so it insets this element's *content* — chain any sizing
+ * modifiers (`weight`, `fillMaxWidth`, ...) before this one, exactly as with the raw chain.
+ */
+fun Modifier.paddedClickable(
+    shape: Shape,
+    padding: PaddingValues,
+    onClick: () -> Unit,
+): Modifier =
+    this
+        .clip(shape)
+        .clickable(onClick = onClick)
+        .padding(padding)

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -43,6 +42,7 @@ import com.thebluealliance.android.domain.model.EventAdvancementPoints
 import com.thebluealliance.android.domain.model.Team
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
+import com.thebluealliance.android.ui.components.paddedClickable
 import com.thebluealliance.android.ui.theme.TBAMotionTokens
 import com.thebluealliance.android.util.teamNumber
 
@@ -148,9 +148,10 @@ private fun AdvancementPointsItem(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clip(MaterialTheme.shapes.small)
-                            .clickable { onTeamClick(points.teamKey) }
-                            .padding(vertical = 2.dp),
+                            .paddedClickable(
+                                shape = MaterialTheme.shapes.small,
+                                padding = PaddingValues(vertical = 2.dp),
+                            ) { onTeamClick(points.teamKey) },
                 )
                 if (teamName != null) {
                     Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
@@ -1,6 +1,5 @@
 package com.thebluealliance.android.ui.events.detail.tabs
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -18,13 +17,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.domain.model.Alliance
 import com.thebluealliance.android.domain.model.displayTitle
 import com.thebluealliance.android.domain.model.playoffSummary
 import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.LoadingBox
+import com.thebluealliance.android.ui.components.paddedClickable
 import com.thebluealliance.android.util.teamNumber
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -121,10 +120,10 @@ private fun AllianceSlot(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier =
-            Modifier
-                .clip(MaterialTheme.shapes.small)
-                .clickable { onTeamClick(teamKey) }
-                .padding(horizontal = 8.dp, vertical = 4.dp),
+            Modifier.paddedClickable(
+                shape = MaterialTheme.shapes.small,
+                padding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+            ) { onTeamClick(teamKey) },
     ) {
         Text(
             text = label,

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
@@ -29,7 +30,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -55,6 +55,7 @@ import com.thebluealliance.android.ui.components.MediaGridRow
 import com.thebluealliance.android.ui.components.RpDots
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.mediaUrl
+import com.thebluealliance.android.ui.components.paddedClickable
 import com.thebluealliance.android.util.teamNumber
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -412,10 +413,10 @@ private fun AllianceTeams(
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.error,
                     modifier =
-                        Modifier
-                            .clip(MaterialTheme.shapes.small)
-                            .clickable { onTeamClick(key) }
-                            .padding(horizontal = 12.dp, vertical = 4.dp),
+                        Modifier.paddedClickable(
+                            shape = MaterialTheme.shapes.small,
+                            padding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+                        ) { onTeamClick(key) },
                 )
             }
         }
@@ -438,10 +439,10 @@ private fun AllianceTeams(
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.primary,
                     modifier =
-                        Modifier
-                            .clip(MaterialTheme.shapes.small)
-                            .clickable { onTeamClick(key) }
-                            .padding(horizontal = 12.dp, vertical = 4.dp),
+                        Modifier.paddedClickable(
+                            shape = MaterialTheme.shapes.small,
+                            padding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+                        ) { onTeamClick(key) },
                 )
             }
         }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
@@ -3,6 +3,7 @@ package com.thebluealliance.android.ui.more
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -28,11 +29,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.thebluealliance.android.BuildConfig
 import com.thebluealliance.android.ui.components.TBATopAppBar
+import com.thebluealliance.android.ui.components.paddedClickable
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -90,10 +91,11 @@ fun MoreScreen(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary,
                     modifier =
-                        Modifier
-                            .clip(MaterialTheme.shapes.small)
-                            .clickable(onClick = onNavigateToAbout)
-                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                        Modifier.paddedClickable(
+                            shape = MaterialTheme.shapes.small,
+                            padding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                            onClick = onNavigateToAbout,
+                        ),
                 )
                 Text(
                     text = "·",
@@ -106,10 +108,11 @@ fun MoreScreen(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary,
                     modifier =
-                        Modifier
-                            .clip(MaterialTheme.shapes.small)
-                            .clickable(onClick = onNavigateToThanks)
-                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                        Modifier.paddedClickable(
+                            shape = MaterialTheme.shapes.small,
+                            padding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                            onClick = onNavigateToThanks,
+                        ),
                 )
             }
 

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -32,7 +33,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -43,6 +43,7 @@ import com.thebluealliance.android.ui.common.EmptyBox
 import com.thebluealliance.android.ui.common.StateContent
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.TopBarYearPicker
+import com.thebluealliance.android.ui.components.paddedClickable
 import com.thebluealliance.android.util.teamNumber
 import kotlinx.coroutines.flow.Flow
 
@@ -221,10 +222,10 @@ private fun RegionalRankingRow(
                     modifier =
                         Modifier
                             .weight(0.15f)
-                            .clip(MaterialTheme.shapes.small)
-                            .clickable {
-                                onNavigateToEvent(sortedEvents[0].eventKey)
-                            }.padding(vertical = 6.dp),
+                            .paddedClickable(
+                                shape = MaterialTheme.shapes.small,
+                                padding = PaddingValues(vertical = 6.dp),
+                            ) { onNavigateToEvent(sortedEvents[0].eventKey) },
                 )
             } else {
                 Text(
@@ -241,10 +242,10 @@ private fun RegionalRankingRow(
                     modifier =
                         Modifier
                             .weight(0.15f)
-                            .clip(MaterialTheme.shapes.small)
-                            .clickable {
-                                onNavigateToEvent(sortedEvents[1].eventKey)
-                            }.padding(vertical = 6.dp),
+                            .paddedClickable(
+                                shape = MaterialTheme.shapes.small,
+                                padding = PaddingValues(vertical = 6.dp),
+                            ) { onNavigateToEvent(sortedEvents[1].eventKey) },
                 )
             } else {
                 Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -63,6 +62,7 @@ import com.thebluealliance.android.ui.components.TBATab
 import com.thebluealliance.android.ui.components.TBATabRow
 import com.thebluealliance.android.ui.components.TBATopAppBar
 import com.thebluealliance.android.ui.components.TeamRow
+import com.thebluealliance.android.ui.components.paddedClickable
 import com.thebluealliance.android.ui.events.detail.EventDetailTab
 import com.thebluealliance.android.ui.events.detail.tabs.advancementBreakdownRows
 import com.thebluealliance.android.util.openUrl
@@ -114,10 +114,14 @@ fun TeamEventDetailScreen(
                                     text = "${team.number}",
                                     maxLines = 1,
                                     modifier =
-                                        Modifier
-                                            .clip(MaterialTheme.shapes.small)
-                                            .clickable { onNavigateToTeam(team.key) }
-                                            .padding(horizontal = 6.dp, vertical = 4.dp),
+                                        Modifier.paddedClickable(
+                                            shape = MaterialTheme.shapes.small,
+                                            padding =
+                                                PaddingValues(
+                                                    horizontal = 6.dp,
+                                                    vertical = 4.dp,
+                                                ),
+                                        ) { onNavigateToTeam(team.key) },
                                     style = MaterialTheme.typography.titleLarge,
                                 )
                                 Text(
@@ -132,13 +136,19 @@ fun TeamEventDetailScreen(
                                     modifier =
                                         Modifier
                                             .weight(1f)
-                                            .clip(MaterialTheme.shapes.small)
-                                            .clickable {
+                                            .paddedClickable(
+                                                shape = MaterialTheme.shapes.small,
+                                                padding =
+                                                    PaddingValues(
+                                                        horizontal = 6.dp,
+                                                        vertical = 4.dp,
+                                                    ),
+                                            ) {
                                                 onNavigateToEvent(
                                                     event.key,
                                                     EventDetailTab.INFO,
                                                 )
-                                            }.padding(horizontal = 6.dp, vertical = 4.dp),
+                                            },
                                     style = MaterialTheme.typography.titleLarge,
                                 )
                             }
@@ -601,12 +611,14 @@ private fun StatsTab(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .clip(MaterialTheme.shapes.small)
-                        .clickable {
+                        .paddedClickable(
+                            shape = MaterialTheme.shapes.small,
+                            padding = PaddingValues(vertical = 4.dp),
+                        ) {
                             context.openUrl(
                                 "https://www.thebluealliance.com/opr",
                             )
-                        }.padding(vertical = 4.dp),
+                        },
             )
         }
 


### PR DESCRIPTION
## Why

From @bherbst's review on #1526:

> Could also consider extracting this combination of modifies to an extension function (or a new Modifier implementation) for reusability since quite a few changes are doing the same thing now

The hover-state fix wave (#1521, #1522, #1523, #1526, #1527) converged on one idiom for interactive text:

```kotlin
Modifier
    .clip(shape)
    .clickable(onClick)
    .padding(...)
```

Order is the entire point of that chain, and both wrong orders produce the same defect:

- `padding(...).clickable(...)` puts the padding **outside** the tap target, so the ripple and pointer-hover highlight hug the glyphs and the touch target is smaller than it looks. That was the bug in most of the fixes above.
- `clickable(...).padding(...)` without a preceding `clip(...)` draws a hard-cornered highlight that ignores the theme's rounded corners.

Hand-rolling the chain at every call site means every new interactive `Text` is a fresh chance to reintroduce the bug.

## What

New `app/src/main/kotlin/com/thebluealliance/android/ui/components/InteractiveTextModifier.kt`:

```kotlin
fun Modifier.paddedClickable(
    shape: Shape,
    padding: PaddingValues,
    onClick: () -> Unit,
): Modifier =
    this
        .clip(shape)
        .clickable(onClick = onClick)
        .padding(padding)
```

The three pieces are composed internally, so call sites cannot order them wrong. KDoc spells out both failure modes.

Design notes:

- **Plain function, not `composed {}` / `Modifier.Node`.** There is no state or composition-local to capture — it is a pure `Modifier.then` chain, so the cheapest correct form is the right one.
- **`shape` is a required parameter, not a `MaterialTheme.shapes.small` default.** A theme default would force the factory to be `@Composable`, which `ComposableModifierFactory` discourages. Every call site already had `MaterialTheme.shapes.small` written out, so nothing is lost.
- **`PaddingValues` rather than `horizontal`/`vertical` `Dp`s**, so the remaining `start`/`top`/`end`/`bottom` call sites elsewhere in the app can migrate later without an overload.
- No `enabled` parameter — nothing migrated here needs one; it can be added when a call site does.

## Sites migrated (9)

| File | Element |
| --- | --- |
| `MoreScreen.kt` ×2 | About / Thanks footer links |
| `EventAdvancementTab.kt` | team-number tap target in a points row |
| `EventAlliancesTab.kt` | alliance pick team pills |
| `MatchDetailScreen.kt` ×2 | red/blue alliance team numbers |
| `RegionalAdvancementScreen.kt` ×2 | event-points cells |
| `TeamEventDetailScreen.kt` ×3 | `27 @ Buckeye` split title links, "Learn more about OPR" |

## Deliberately not migrated

- **Files with open PRs in flight** — `EventInfoTab.kt` (#1522, #1525) and `EventInsightsTab.kt` / `EventRankingsTab.kt` (#1527). Those land the idiom in code this PR would conflict with; they migrate in a follow-up once merged.
- **Full-width rows that use `clickable(...).padding(...)` with no `clip`** — `ThanksScreen`, `MoreItem`, `DistrictItem`, `DistrictDetailScreen`, `MyTBAScreen` ×2, `TeamEventDetailScreen`'s `StatRow`, `MatchDetailScreen`'s event-name row, `EventAdvancementTab`'s expander row, `RegionalAdvancementScreen`'s outer row. Their ordering is already correct; routing them through `paddedClickable` would require inventing a `RectangleShape` argument (noise) or silently rounding their highlight (a visual change). Whether those edge-to-edge rows *should* get a shape is a separate UX question.
- **Sites that only partially match** — `SectionHeader.kt`, `MediaGrid.kt`, `TeamDetailScreen.kt`'s avatar toggle, `EventAwardsTab.kt`. They have no interior padding (or a conditional `clickable`), so the helper does not fit.

## Proof: visual no-op

Both builds installed to the same emulator (`sdk_gphone16k_arm64`, API 36), driven through the same scripted navigation, against the same local backend data. Screenshots diffed with PIL/numpy, status bar (top 80px, clock/battery) cropped. **No masking beyond that crop** — the diff is exactly zero everywhere.

| Screen | Differing pixels | Total compared | Max channel delta |
| --- | --- | --- | --- |
| More (About / Thanks) | 0 | 2,505,600 | 0 |
| Event → Alliances | 0 | 2,505,600 | 0 |
| Event → District Points | 0 | 2,505,600 | 0 |
| Match detail | 0 | 2,505,600 | 0 |
| Team @ Event summary | 0 | 2,505,600 | 0 |

Sanity check that the two runs really used different binaries: installed `base.apk` md5 `3a2dfff…` (after) vs `608a5cd…` (before/`origin/main`).

Two migrated call sites are not covered by a screenshot because the local dev backend has no data for them: `RegionalAdvancementScreen` (`/regional_advancement` returns 404) and `TeamEventDetailScreen`'s "Learn more about OPR" link (no OPR stats). Both are byte-for-byte the same modifier chain as the covered sites.

## Verification

- `:app:assembleDebug` ✅
- `:app:testDebugUnitTest` ✅
- `:app:lintDebug` ✅ (zero new findings)
- `:app:ktlintCheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- screenshots:start -->
## Screenshots

| | Before | After |
|---|---|---|
| **More — About / Thanks links** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/refactor-padded-clickable-modifier/1531_more_before-efd1c2ff.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/refactor-padded-clickable-modifier/1531_more_after-626226fa.png" width="300"> |
| **Event → Alliances** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/refactor-padded-clickable-modifier/1531_event_alliances_before-b1e385b3.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/refactor-padded-clickable-modifier/1531_event_alliances_after-3d3b9dda.png" width="300"> |
| **Event → District Points** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/refactor-padded-clickable-modifier/1531_event_advancement_before-84f8a9ea.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/refactor-padded-clickable-modifier/1531_event_advancement_after-d134364c.png" width="300"> |
| **Match detail — team links** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/refactor-padded-clickable-modifier/1531_match_detail_before-f14ab0c9.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/refactor-padded-clickable-modifier/1531_match_detail_after-c54c6cd6.png" width="300"> |
| **Team @ Event — split title links** | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/refactor-padded-clickable-modifier/1531_teamevent_summary_before-6c002b54.png" width="300"> | <img src="https://raw.githubusercontent.com/the-blue-alliance/the-blue-alliance-android/screenshot-assets/shots/refactor-padded-clickable-modifier/1531_teamevent_summary_after-00aee842.png" width="300"> |
<!-- screenshots:end -->