### PR TITLE
refactor: paddedClickable takes horizontal/vertical Dp, not PaddingValues

### DIFF
--- a/app/src/main/kotlin/com/thebluealliance/android/ui/components/InteractiveTextModifier.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/components/InteractiveTextModifier.kt
@@ -1,14 +1,16 @@
 package com.thebluealliance.android.ui.components
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
 /**
- * Makes this element clickable with [padding] *inside* the tap target, clipped to [shape].
+ * Makes this element clickable with symmetric [horizontal]/[vertical] padding *inside* the tap
+ * target, clipped to [shape].
  *
  * Prefer this over hand-rolling `clip` + `clickable` + `padding`: the order of those three
  * modifiers is easy to get wrong, and both wrong orders produce the same class of bug.
@@ -19,18 +21,22 @@ import androidx.compose.ui.graphics.Shape
  * - `clickable(...).padding(...)` without a preceding `clip(...)` draws a hard-cornered highlight
  *   that ignores the theme's rounded corners.
  *
- * Only `clip(shape).clickable(onClick).padding(padding)` gives a highlight that both fills the
- * padded target and follows [shape]. Composing them here means call sites cannot get it wrong.
+ * Only `clip(shape).clickable(onClick).padding(...)` gives a highlight that both fills the padded
+ * target and follows [shape]. Composing them here means call sites cannot get it wrong.
  *
- * Note that [padding] is applied last, so it insets this element's *content* — chain any sizing
+ * Note that the padding is applied last, so it insets this element's *content* — chain any sizing
  * modifiers (`weight`, `fillMaxWidth`, ...) before this one, exactly as with the raw chain.
+ *
+ * This convenience form covers symmetric horizontal/vertical padding, which every current call
+ * site uses. If a per-edge (start/top/end/bottom) site appears, add a `PaddingValues` overload.
  */
 fun Modifier.paddedClickable(
     shape: Shape,
-    padding: PaddingValues,
+    horizontal: Dp = 0.dp,
+    vertical: Dp = 0.dp,
     onClick: () -> Unit,
 ): Modifier =
     this
         .clip(shape)
         .clickable(onClick = onClick)
-        .padding(padding)
+        .padding(horizontal = horizontal, vertical = vertical)

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAdvancementTab.kt
@@ -148,10 +148,9 @@ private fun AdvancementPointsItem(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .paddedClickable(
-                                shape = MaterialTheme.shapes.small,
-                                padding = PaddingValues(vertical = 2.dp),
-                            ) { onTeamClick(points.teamKey) },
+                            .paddedClickable(MaterialTheme.shapes.small, vertical = 2.dp) {
+                                onTeamClick(points.teamKey)
+                            },
                 )
                 if (teamName != null) {
                     Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/events/detail/tabs/EventAlliancesTab.kt
@@ -121,8 +121,9 @@ private fun AllianceSlot(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier =
             Modifier.paddedClickable(
-                shape = MaterialTheme.shapes.small,
-                padding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                MaterialTheme.shapes.small,
+                horizontal = 8.dp,
+                vertical = 4.dp,
             ) { onTeamClick(teamKey) },
     ) {
         Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/matches/MatchDetailScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
@@ -414,8 +413,9 @@ private fun AllianceTeams(
                     color = MaterialTheme.colorScheme.error,
                     modifier =
                         Modifier.paddedClickable(
-                            shape = MaterialTheme.shapes.small,
-                            padding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+                            MaterialTheme.shapes.small,
+                            horizontal = 12.dp,
+                            vertical = 4.dp,
                         ) { onTeamClick(key) },
                 )
             }
@@ -440,8 +440,9 @@ private fun AllianceTeams(
                     color = MaterialTheme.colorScheme.primary,
                     modifier =
                         Modifier.paddedClickable(
-                            shape = MaterialTheme.shapes.small,
-                            padding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+                            MaterialTheme.shapes.small,
+                            horizontal = 12.dp,
+                            vertical = 4.dp,
                         ) { onTeamClick(key) },
                 )
             }

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/more/MoreScreen.kt
@@ -3,7 +3,6 @@ package com.thebluealliance.android.ui.more
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -92,8 +91,9 @@ fun MoreScreen(
                     color = MaterialTheme.colorScheme.primary,
                     modifier =
                         Modifier.paddedClickable(
-                            shape = MaterialTheme.shapes.small,
-                            padding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                            MaterialTheme.shapes.small,
+                            horizontal = 8.dp,
+                            vertical = 4.dp,
                             onClick = onNavigateToAbout,
                         ),
                 )
@@ -109,8 +109,9 @@ fun MoreScreen(
                     color = MaterialTheme.colorScheme.primary,
                     modifier =
                         Modifier.paddedClickable(
-                            shape = MaterialTheme.shapes.small,
-                            padding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                            MaterialTheme.shapes.small,
+                            horizontal = 8.dp,
+                            vertical = 4.dp,
                             onClick = onNavigateToThanks,
                         ),
                 )

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/regional/RegionalAdvancementScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -222,10 +221,9 @@ private fun RegionalRankingRow(
                     modifier =
                         Modifier
                             .weight(0.15f)
-                            .paddedClickable(
-                                shape = MaterialTheme.shapes.small,
-                                padding = PaddingValues(vertical = 6.dp),
-                            ) { onNavigateToEvent(sortedEvents[0].eventKey) },
+                            .paddedClickable(MaterialTheme.shapes.small, vertical = 6.dp) {
+                                onNavigateToEvent(sortedEvents[0].eventKey)
+                            },
                 )
             } else {
                 Text(
@@ -242,10 +240,9 @@ private fun RegionalRankingRow(
                     modifier =
                         Modifier
                             .weight(0.15f)
-                            .paddedClickable(
-                                shape = MaterialTheme.shapes.small,
-                                padding = PaddingValues(vertical = 6.dp),
-                            ) { onNavigateToEvent(sortedEvents[1].eventKey) },
+                            .paddedClickable(MaterialTheme.shapes.small, vertical = 6.dp) {
+                                onNavigateToEvent(sortedEvents[1].eventKey)
+                            },
                 )
             } else {
                 Text(

--- a/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
+++ b/app/src/main/kotlin/com/thebluealliance/android/ui/teamevent/TeamEventDetailScreen.kt
@@ -115,12 +115,9 @@ fun TeamEventDetailScreen(
                                     maxLines = 1,
                                     modifier =
                                         Modifier.paddedClickable(
-                                            shape = MaterialTheme.shapes.small,
-                                            padding =
-                                                PaddingValues(
-                                                    horizontal = 6.dp,
-                                                    vertical = 4.dp,
-                                                ),
+                                            MaterialTheme.shapes.small,
+                                            horizontal = 6.dp,
+                                            vertical = 4.dp,
                                         ) { onNavigateToTeam(team.key) },
                                     style = MaterialTheme.typography.titleLarge,
                                 )
@@ -137,18 +134,10 @@ fun TeamEventDetailScreen(
                                         Modifier
                                             .weight(1f)
                                             .paddedClickable(
-                                                shape = MaterialTheme.shapes.small,
-                                                padding =
-                                                    PaddingValues(
-                                                        horizontal = 6.dp,
-                                                        vertical = 4.dp,
-                                                    ),
-                                            ) {
-                                                onNavigateToEvent(
-                                                    event.key,
-                                                    EventDetailTab.INFO,
-                                                )
-                                            },
+                                                MaterialTheme.shapes.small,
+                                                horizontal = 6.dp,
+                                                vertical = 4.dp,
+                                            ) { onNavigateToEvent(event.key, EventDetailTab.INFO) },
                                     style = MaterialTheme.typography.titleLarge,
                                 )
                             }
@@ -611,10 +600,7 @@ private fun StatsTab(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .paddedClickable(
-                            shape = MaterialTheme.shapes.small,
-                            padding = PaddingValues(vertical = 4.dp),
-                        ) {
+                        .paddedClickable(MaterialTheme.shapes.small, vertical = 4.dp) {
                             context.openUrl(
                                 "https://www.thebluealliance.com/opr",
                             )


### PR DESCRIPTION
## Summary

Follow-up to #1531 (already merged). That PR extracted `Modifier.paddedClickable` to guarantee the `clip → clickable → padding` ordering, but its `PaddingValues` parameter left each call site as long as the raw chain it replaced — a correctness/ordering guarantee, but not the call-site simplification it was meant to be.

This changes the signature to convenience `horizontal`/`vertical` `Dp` params (both default `0.dp`), which is what every current interactive-text site actually needs:

```kotlin
fun Modifier.paddedClickable(
    shape: Shape,
    horizontal: Dp = 0.dp,
    vertical: Dp = 0.dp,
    onClick: () -> Unit,
): Modifier =
    this
        .clip(shape)
        .clickable(onClick = onClick)
        .padding(horizontal = horizontal, vertical = vertical)
```

The KDoc explaining the ordering-bug rationale (why `clip` precedes `clickable` precedes `padding` by construction) is kept.

## Call site: before → after

```kotlin
// before (PaddingValues form, merged in #1531) — 4 lines
Modifier.paddedClickable(
    shape = MaterialTheme.shapes.small,
    padding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
) { onTeamClick(key) }

// after (Dp form) — drops the nested PaddingValues(...) argument
Modifier.paddedClickable(
    MaterialTheme.shapes.small,
    horizontal = 12.dp,
    vertical = 4.dp,
) { onTeamClick(key) }
```

Vertical-only sites collapse to a single-expression call:

```kotlin
Modifier.paddedClickable(MaterialTheme.shapes.small, vertical = 6.dp) { onNavigateToEvent(key) }
```

**Net −9 lines** across the eleven migrated sites, and the `PaddingValues` import drops from three screens (MatchDetailScreen, MoreScreen, RegionalAdvancementScreen). Sites still wrap where `MaterialTheme.shapes.small` + two named padding args + the 100-col ktlint limit don't fit one line — that's expected and still shorter than or equal to the raw chain.

## Migration plan / skipped sites

- Migrates the eleven sites already on the helper from #1531 (MoreScreen ×2, EventAdvancementTab, EventAlliancesTab, MatchDetailScreen ×2, RegionalAdvancementScreen ×2, TeamEventDetailScreen ×3).
- No `PaddingValues` overload is added now — no current site needs per-edge (`start`/`top`/`end`/`bottom`) padding (YAGNI). One can be added the day such a site appears.
- Sites landed after #1531 (EventInfoTab from #1522, EventInsightsTab / EventRankingsTab from #1527) are out of scope here and can adopt the helper in a separate pass.

## Visual no-op

`PaddingValues(horizontal = h, vertical = v)` fed to `.padding(PaddingValues)` produces the exact same insets as `.padding(horizontal = h, vertical = v)`, so the emitted modifier chain — `clip(shape).clickable(onClick).padding(horizontal, vertical)` — is byte-for-byte the runtime chain the merged version already produced. Rendering is therefore pixel-identical, and #1531's before/after pixel-diff evidence still holds unchanged.

I re-rendered one screen (More → About / Thanks links) on the phone emulator to confirm the links still render with correct padding and rounded hover/ripple shape. The rest is asserted from the byte-identical chain above rather than re-shot.

## Verification

- `:app:assembleDebug` ✅
- `:app:testDebugUnitTest` ✅
- `:app:lintDebug` ✅ (no new findings)
- `:app:ktlintCheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
